### PR TITLE
chore: wire Sentry for error tracking + session replay

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,16 @@
 VITE_SUPABASE_URL=https://your-project-ref.supabase.co
 VITE_SUPABASE_ANON_KEY=your-anon-or-publishable-key
 
+# ─── Sentry error tracking (optional) ────────────────────────────────────
+# Sentry only initializes when VITE_SENTRY_DSN is set, so local dev stays
+# quiet by default. Production and staging set these in Netlify's
+# Environment Variables dashboard. The DSN is safe to expose in the
+# client bundle (Sentry uses domain allow-lists for security).
+VITE_SENTRY_DSN=
+# Logical environment name reported to Sentry — typically "production" or
+# "staging". Falls back to Vite's MODE if unset.
+VITE_SENTRY_ENVIRONMENT=
+
 # ─── Financial data providers (optional) ─────────────────────────────────
 # Used by src/lib/financial-data/ for prices, fundamentals, and history.
 # The app falls back to free providers when these are absent — set them

--- a/README.md
+++ b/README.md
@@ -84,8 +84,9 @@ reach pilots in production. See
 - **Hosting**: Netlify (frontend), Supabase (backend)
 - **CI**: GitHub Actions (`.github/workflows/ci.yml`)
 - **Testing**: Vitest, Testing Library, Playwright (Storybook visual tests)
-- **Observability**: planned — see open items in
-  [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
+- **Observability**: Sentry (error tracking + session replay), gated by
+  `VITE_SENTRY_DSN` so local dev stays quiet. Product analytics still
+  planned — see open items in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -141,9 +141,10 @@ See [docs/CONTRIBUTING.md](CONTRIBUTING.md) for the full PR + deploy flow.
 
 These are known gaps. Listing them so the absence isn't a surprise.
 
-- **No production error tracking** (Sentry / PostHog). Planned when
-  pilot count crosses ~25. Currently, prod bugs are surfaced via direct
-  pilot communication.
+- **No product analytics** (PostHog / Mixpanel). Errors *are* tracked
+  in Sentry (`src/main.tsx`), but we don't yet collect funnel/feature
+  usage. The Ops portal's pilot funnel covers the most important
+  conversion path.
 - **No bundle-size budget**. Some pages are large (Simulation, Org
   page). To be sliced + lazy-loaded as part of the file-breakup
   refactor.

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^3.3.2",
+        "@sentry/react": "^10.53.1",
         "@supabase/supabase-js": "^2.39.0",
         "@tanstack/react-query": "^5.17.0",
         "@tanstack/react-virtual": "^3.13.12",
@@ -1957,6 +1958,97 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sentry-internal/browser-utils": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/browser-utils/-/browser-utils-10.53.1.tgz",
+      "integrity": "sha512-X4d6y8sBMjmNhcDW4eMBU3ASsNIMz8dqaFkhyIMN/dkYr/yZKnbRZPaVuVUGvHKjnlficPpIH0/HK9KBjrYxPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.53.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/feedback": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.53.1.tgz",
+      "integrity": "sha512-vVpTI/aEYN5d9IgZeYJWMqVaN0+iFgidSrYNAsZTh1US5sJUzF/wrl+68KdpmCtFROrN3jiAn1oPSwL5CKvEJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/core": "10.53.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay/-/replay-10.53.1.tgz",
+      "integrity": "sha512-wZNzTBYkgGUPWMuUQv7L64+OJmoCnz7GQNiTrTFK6EVAjJXFBCSsPp/nhif0bLhbk8+0g4xz633uOhpXuQbFdw==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.53.1",
+        "@sentry/core": "10.53.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry-internal/replay-canvas": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/replay-canvas/-/replay-canvas-10.53.1.tgz",
+      "integrity": "sha512-aueLaf/2prExwA76BGU5/bOXCKWqtt6jQXWA6WJQNrmKpPEtZJB4ypnpsou0McXQCF8tur2Y8U0TEkwQP13yJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/replay": "10.53.1",
+        "@sentry/core": "10.53.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/browser": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.53.1.tgz",
+      "integrity": "sha512-zXF373hzUOGzUOrqd8xb1U3LQi5uYC3mwv+z5OMKUUinQlu30tTWBs7ypy6YTchtix9QlYaHWlayUF8vBZ5UjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry-internal/browser-utils": "10.53.1",
+        "@sentry-internal/feedback": "10.53.1",
+        "@sentry-internal/replay": "10.53.1",
+        "@sentry-internal/replay-canvas": "10.53.1",
+        "@sentry/core": "10.53.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.53.1.tgz",
+      "integrity": "sha512-XG4ezlkyuAPjBC5+9kXC94rXXuqYTw9NRhfaDHssbTFaGnqBR8vQX2UUgZfY7ucbeelRDGfBu1sywoU+mB04uA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@sentry/react": {
+      "version": "10.53.1",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.53.1.tgz",
+      "integrity": "sha512-lrwNq5T/zW84l60894TpKHPcvFuc1I/Hnohecc0TfYVpIcYYuw2orCHoU4v4wgkFaJUpegVetbgdOphViyLVjA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/browser": "10.53.1",
+        "@sentry/core": "10.53.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.14.0 || 17.x || 18.x || 19.x"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^3.3.2",
+    "@sentry/react": "^10.53.1",
     "@supabase/supabase-js": "^2.39.0",
     "@tanstack/react-query": "^5.17.0",
     "@tanstack/react-virtual": "^3.13.12",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,32 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import * as Sentry from '@sentry/react'
 import './index.css'
 import App from './App.tsx'
+
+// Sentry — must initialize before render so it can catch React errors.
+// We only init when a DSN is present, so local dev never reports out.
+// VITE_SENTRY_DSN + VITE_SENTRY_ENVIRONMENT are set per-context in
+// Netlify (production vs branch-deploy/staging).
+const SENTRY_DSN = import.meta.env.VITE_SENTRY_DSN
+if (SENTRY_DSN) {
+  Sentry.init({
+    dsn: SENTRY_DSN,
+    environment:
+      import.meta.env.VITE_SENTRY_ENVIRONMENT || import.meta.env.MODE,
+    integrations: [
+      Sentry.browserTracingIntegration(),
+      Sentry.replayIntegration(),
+    ],
+    // Performance tracing — 10% in prod, 100% elsewhere (cheap on pilots).
+    tracesSampleRate: import.meta.env.MODE === 'production' ? 0.1 : 1.0,
+    // Session Replay — never record happy sessions (would burn quota fast);
+    // always record sessions that hit an error, so bug reports are
+    // accompanied by a recording of what the user actually did.
+    replaysSessionSampleRate: 0,
+    replaysOnErrorSampleRate: 1.0,
+  })
+}
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
DSN-gated init in main.tsx so local dev stays quiet. Per-context env vars (VITE_SENTRY_DSN, VITE_SENTRY_ENVIRONMENT) set in Netlify for production and staging. Session replay records only error sessions to keep quota usage low.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
