### PR TITLE
chore: extend CSP to allow Sentry endpoints + worker blob

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,10 +7,11 @@
     <meta http-equiv="Content-Security-Policy"
           content="default-src 'self';
                    script-src 'self';
+                   worker-src 'self' blob:;
                    style-src 'self' 'unsafe-inline';
                    img-src 'self' data: https: blob:;
                    font-src 'self' data:;
-                   connect-src 'self' https://*.supabase.co wss://*.supabase.co https://www.alphavantage.co https://api.anthropic.com https://api.openai.com https://generativelanguage.googleapis.com https://api.perplexity.ai;
+                   connect-src 'self' https://*.supabase.co wss://*.supabase.co https://www.alphavantage.co https://api.anthropic.com https://api.openai.com https://generativelanguage.googleapis.com https://api.perplexity.ai https://*.sentry.io https://*.ingest.sentry.io https://*.ingest.us.sentry.io;
                    frame-ancestors 'none';" />
     <meta http-equiv="X-Content-Type-Options" content="nosniff" />
     <meta http-equiv="X-Frame-Options" content="DENY" />


### PR DESCRIPTION
Sentry's transport was being blocked by the connect-src directive, and Replay's web-worker (created from a blob: URL) was being blocked by script-src acting as worker-src fallback.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
