### PR TITLE
chore: attribute Sentry events to the signed-in user + org

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
+import * as Sentry from '@sentry/react'
 import type { User, Session } from '@supabase/supabase-js'
 import { supabase } from '../lib/supabase'
 import { routeOrgByEmail, autoAcceptPendingInvites, titleCase } from '../lib/org-domain-routing'
@@ -216,6 +217,23 @@ export function useAuth() {
       window.removeEventListener('org-switched', handleOrgSwitched)
     }
   }, [])
+
+  // Mirror the React user into Sentry's user context so every captured
+  // event is attributed to a specific pilot. Cleared on sign-out so a
+  // shared browser doesn't leak the previous user into the next session.
+  useEffect(() => {
+    if (user) {
+      Sentry.setUser({
+        id: user.id,
+        email: user.email ?? undefined,
+      })
+      const orgId = (user as any).current_organization_id
+      Sentry.setTag('organization_id', orgId ?? 'none')
+    } else {
+      Sentry.setUser(null)
+      Sentry.setTag('organization_id', undefined)
+    }
+  }, [user])
 
   const signIn = async (email: string, password: string) => {
     const { data, error } = await supabase.auth.signInWithPassword({


### PR DESCRIPTION
Mirrors React user state into Sentry.setUser so each captured error shows which pilot hit it, with organization_id as a tag for filtering in the Sentry dashboard. Cleared on sign-out so a shared browser doesn't leak context.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
