### PR TITLE
chore: forward ErrorBoundary catches to Sentry with React component s…

### DIFF
--- a/src/components/common/ErrorBoundary.tsx
+++ b/src/components/common/ErrorBoundary.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { Component, ErrorInfo, ReactNode } from 'react'
+import * as Sentry from '@sentry/react'
 import { AlertCircle, RefreshCw, Home } from 'lucide-react'
 import { Button } from '../ui/Button'
 
@@ -48,8 +49,13 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
       errorInfo,
     })
 
-    // TODO: Send to error reporting service (e.g., Sentry)
-    // logErrorToService(error, errorInfo)
+    // Report to Sentry with React's component stack attached so we can
+    // see which component crashed (not just the JS stack). No-op when
+    // Sentry isn't initialized (local dev without a DSN).
+    Sentry.withScope((scope) => {
+      scope.setContext('react', { componentStack: errorInfo.componentStack })
+      Sentry.captureException(error)
+    })
   }
 
   handleReset = () => {


### PR DESCRIPTION
…tack

The boundary already catches render errors and renders a fallback; this fills in the TODO to also report them to Sentry, with React's componentStack attached so we can pinpoint the failing component. Sentry.captureException is a no-op when no DSN is configured (local dev), so this is safe outside of production.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
