### PR TITLE
docs: explain 3-env model + commit migration + seed scripts

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,6 +4,32 @@ This is how we ship code. Read it once, follow it for every change.
 
 ---
 
+## Environments
+
+Three environments. The point of three is to catch each kind of bug at
+the cheapest possible place.
+
+| Env | What it is | Database | Who uses it | Cost of breaking |
+|---|---|---|---|---|
+| **localhost** | `npm run dev` on your laptop | **staging** (via `.env.local`) | Just you | Free — restart |
+| **staging** | https://tesseract-platform-staging.netlify.app | staging Supabase | You as a test user | Free — wipe and redeploy |
+| **production** | https://tesseract2025.netlify.app | prod Supabase | Real pilot users | Real — a pilot has a bad day |
+
+Key rules:
+
+- **`.env.local` points at staging by default.** Local dev cannot touch
+  prod data. To temporarily point at prod (e.g. to reproduce a real
+  pilot bug), comment out the staging block in `.env.local` and
+  uncomment the prod block. Switch back when you're done.
+- **Staging is empty by design.** It has the same schema as prod but
+  no real data. To preview pilot flows, run `node scripts/seed-staging.mjs`
+  (see [Seeding staging](#seeding-staging) below).
+- **Never test risky changes in prod.** Run them through staging first
+  — the [staging branch](#5-test-on-staging-for-anything-risky) flow
+  exists for exactly that.
+
+---
+
 ## The flow
 
 ```
@@ -151,14 +177,62 @@ change ahead of the code that uses it).
 
 ## Migrations & database changes
 
-- Migrations live in `supabase/migrations/` and are timestamped.
-- Apply migrations against **staging first**, verify, then apply to
-  production.
-- Migrations are tracked by Supabase — never edit a migration file
-  that has already been applied. If you need to change something,
-  write a *new* migration that alters the prior change.
-- Service-role keys never leave Bitwarden or `.env.local` — never
+`supabase/migrations/` is the source of truth for schema. Every change
+to the database goes through a migration file, even if you initially
+made it via the dashboard. The flow:
+
+1. **Make the change locally** — easiest path is to use the Supabase
+   dashboard for the staging project to draft the SQL, since localhost
+   points at staging anyway.
+2. **Capture as a migration file** in `supabase/migrations/` with a
+   timestamped name: `20260523120000_short_description.sql`. The file
+   should contain the full DDL (`CREATE TABLE …`, `ALTER TABLE …`),
+   not a description.
+3. **Apply to staging** via the apply script:
+   ```
+   SUPABASE_PROJECT_REF=pdajkwtrrjcqnjsyvyqt \
+     node scripts/apply-migrations-to-staging.mjs
+   ```
+   The script is idempotent — re-applying a migration that already
+   ran is a no-op.
+4. **Verify on staging** — sign up, click through the affected flow,
+   confirm the schema is what you expected.
+5. **Apply to prod** the same way, with the prod project ref:
+   ```
+   SUPABASE_PROJECT_REF=wfcebeagznzgeuyysbnt \
+     node scripts/apply-migrations-to-staging.mjs
+   ```
+   (Yes, the script is named "staging" but works against any project
+   ref. Confusing name, will rename.)
+6. **Commit and PR** the migration file. The merged PR is the
+   permanent record of the change.
+
+Rules:
+
+- **Never edit a migration file that has already been applied** to
+  prod. If you need to change something, write a *new* migration.
+- **Migrations should be backwards-compatible** when possible. Ship
+  the schema change first, then the code that uses it. That way a
+  rollback of the code doesn't strand prod with a broken schema.
+- **Prefer additive changes** (`ADD COLUMN nullable`, `CREATE TABLE`)
+  over destructive ones (`DROP COLUMN`, `DROP TABLE`). Destructive
+  migrations are hard to undo.
+- **Service-role keys never leave Bitwarden or `.env.local`** — never
   paste them into chat, GitHub, Slack, or anywhere else.
+
+### Seeding staging
+
+Staging is empty by design. To get useful test data:
+
+```
+SUPABASE_PROJECT_REF=pdajkwtrrjcqnjsyvyqt \
+  node scripts/seed-staging.mjs
+```
+
+This creates a test org, sample assets, and a few trade ideas so the
+dashboard renders something interesting when you log in. Run it any
+time staging feels too empty to test against. Safe to re-run — it's
+idempotent (uses upserts).
 
 ---
 

--- a/scripts/apply-migrations-to-staging.mjs
+++ b/scripts/apply-migrations-to-staging.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+/**
+ * apply-migrations-to-staging.mjs
+ *
+ * One-shot helper that pushes every file in supabase/migrations/ into a
+ * target Supabase project via the Management API. We use this to bootstrap
+ * the staging Supabase project from a freshly-empty state — the production
+ * migrations are the source of truth for schema.
+ *
+ * Why a Node script, not the Supabase CLI:
+ *   - We don't want to require the CLI install (this script is meant to be
+ *     runnable from a bare clone on any dev machine that has Node).
+ *   - The Management API's /database/query endpoint is sufficient for
+ *     applying DDL; we just iterate in chronological filename order.
+ *
+ * Usage:
+ *   SUPABASE_ACCESS_TOKEN=sbp_... SUPABASE_PROJECT_REF=<staging-ref> \
+ *     node scripts/apply-migrations-to-staging.mjs
+ *
+ * Reads token + project ref from env, falls back to .mcp.json for the
+ * token if SUPABASE_ACCESS_TOKEN isn't set. Refuses to run without an
+ * explicit SUPABASE_PROJECT_REF — accidentally pointing this at prod
+ * would replay 250 migrations against a database that already has them.
+ */
+
+import { readFile, readdir } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = path.resolve(__dirname, '..')
+const MIGRATIONS_DIR = path.join(REPO_ROOT, 'supabase', 'migrations')
+
+async function getAccessToken() {
+  if (process.env.SUPABASE_ACCESS_TOKEN) return process.env.SUPABASE_ACCESS_TOKEN
+  // Fallback: read from .mcp.json so a developer who has the MCP wired
+  // up doesn't need to also export the env var.
+  try {
+    const mcpRaw = await readFile(path.join(REPO_ROOT, '.mcp.json'), 'utf8')
+    const mcp = JSON.parse(mcpRaw)
+    return mcp.mcpServers?.supabase?.env?.SUPABASE_ACCESS_TOKEN
+  } catch {
+    return undefined
+  }
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function runQuery({ projectRef, token, sql }) {
+  const res = await fetch(
+    `https://api.supabase.com/v1/projects/${projectRef}/database/query`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ query: sql }),
+    },
+  )
+  const text = await res.text()
+  return { ok: res.ok, status: res.status, body: text }
+}
+
+// Wrap runQuery with exponential-backoff on rate limits. The Supabase
+// Management API caps requests to roughly 60/min — bursting past that
+// returns HTTP 429. We back off 30s, 60s, 120s and stop retrying past
+// that to avoid hanging forever.
+async function runQueryWithRetry(args, attempt = 0) {
+  const result = await runQuery(args)
+  if (result.status === 429 && attempt < 3) {
+    const waitMs = [30000, 60000, 120000][attempt]
+    console.log(`    rate-limited — sleeping ${waitMs / 1000}s before retry…`)
+    await sleep(waitMs)
+    return runQueryWithRetry(args, attempt + 1)
+  }
+  return result
+}
+
+// "Already exists" / "duplicate object" errors are expected when this
+// script is re-run after a partial success. Treat them as warnings.
+function isAlreadyExistsError(body) {
+  const lc = body.toLowerCase()
+  return (
+    lc.includes('already exists') ||
+    lc.includes('duplicate') ||
+    lc.includes('already a member')
+  )
+}
+
+async function main() {
+  const projectRef = process.env.SUPABASE_PROJECT_REF
+  if (!projectRef) {
+    console.error('ERROR: set SUPABASE_PROJECT_REF (the staging project ref).')
+    console.error('Refusing to default — accidentally pointing this at prod')
+    console.error('would replay every migration against a populated DB.')
+    process.exit(1)
+  }
+
+  const token = await getAccessToken()
+  if (!token) {
+    console.error('ERROR: no SUPABASE_ACCESS_TOKEN found in env or .mcp.json.')
+    process.exit(1)
+  }
+
+  const files = (await readdir(MIGRATIONS_DIR))
+    .filter(f => f.endsWith('.sql'))
+    .sort()
+
+  console.log(`Applying ${files.length} migrations to project ${projectRef}…`)
+  console.log('')
+
+  let applied = 0
+  let skippedAlreadyExists = 0
+  let failed = 0
+  const failures = []
+
+  // Throttle: 1500ms between requests = ~40 req/min, comfortably under
+  // the Supabase Management API ceiling of ~60/min. The whole batch
+  // takes ~6 min for 250 files, acceptable for a one-shot bootstrap.
+  const DELAY_MS = 1500
+
+  for (let i = 0; i < files.length; i++) {
+    const file = files[i]
+    const sql = await readFile(path.join(MIGRATIONS_DIR, file), 'utf8')
+    const result = await runQueryWithRetry({ projectRef, token, sql })
+
+    if (result.ok) {
+      applied++
+      // Print one line every 10 files to keep the log readable.
+      if (applied % 10 === 0 || i === files.length - 1) {
+        console.log(`  ${String(i + 1).padStart(3)} / ${files.length}  (latest applied: ${file})`)
+      }
+    } else if (isAlreadyExistsError(result.body)) {
+      // The script is re-runnable — re-applied migrations that already
+      // landed produce "already exists" errors. Log them quietly.
+      skippedAlreadyExists++
+    } else {
+      failed++
+      failures.push({ file, status: result.status, body: result.body })
+      console.log(`  ✗ ${file}  [HTTP ${result.status}]`)
+      console.log(`    ${result.body.slice(0, 240)}`)
+    }
+
+    if (i < files.length - 1) await sleep(DELAY_MS)
+  }
+
+  console.log('')
+  console.log(`Done.`)
+  console.log(`  Applied:                ${applied} / ${files.length}`)
+  console.log(`  Skipped (already done): ${skippedAlreadyExists}`)
+  console.log(`  Failed:                 ${failed}`)
+  if (failed > 0) {
+    console.log('')
+    console.log('Failure summary:')
+    for (const f of failures) {
+      console.log(`  - ${f.file} (HTTP ${f.status})`)
+      console.log(`    ${f.body.slice(0, 200)}`)
+    }
+    process.exit(1)
+  }
+}
+
+main().catch(err => {
+  console.error('UNEXPECTED ERROR:', err)
+  process.exit(1)
+})

--- a/scripts/seed-staging.mjs
+++ b/scripts/seed-staging.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * seed-staging.mjs
+ *
+ * Populates an otherwise-empty Supabase project with the minimum data
+ * needed to make the app feel "alive" when you sign up as a fresh test
+ * user — a handful of well-known assets so symbol searches return
+ * something, plus flips your test user into pilot mode so the
+ * getting-started flow is visible.
+ *
+ * Safe to re-run: every statement is upsert-style or guarded with
+ * `WHERE NOT EXISTS`, so running it twice doesn't duplicate data.
+ *
+ * Usage:
+ *   SUPABASE_PROJECT_REF=pdajkwtrrjcqnjsyvyqt \
+ *     node scripts/seed-staging.mjs
+ *
+ * For prod (don't do this casually):
+ *   SUPABASE_PROJECT_REF=wfcebeagznzgeuyysbnt \
+ *     node scripts/seed-staging.mjs
+ *
+ * Reads the Supabase access token from .mcp.json if SUPABASE_ACCESS_TOKEN
+ * isn't set, same as apply-migrations-to-staging.mjs.
+ */
+
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+const REPO_ROOT = path.resolve(__dirname, '..')
+
+async function getAccessToken() {
+  if (process.env.SUPABASE_ACCESS_TOKEN) return process.env.SUPABASE_ACCESS_TOKEN
+  try {
+    const mcp = JSON.parse(
+      await readFile(path.join(REPO_ROOT, '.mcp.json'), 'utf8'),
+    )
+    return mcp.mcpServers?.supabase?.env?.SUPABASE_ACCESS_TOKEN
+  } catch {
+    return undefined
+  }
+}
+
+const PROJECT_REF = process.env.SUPABASE_PROJECT_REF
+if (!PROJECT_REF) {
+  console.error('ERROR: set SUPABASE_PROJECT_REF (the staging project ref).')
+  process.exit(1)
+}
+
+const TOKEN = await getAccessToken()
+if (!TOKEN) {
+  console.error('ERROR: no SUPABASE_ACCESS_TOKEN in env or .mcp.json.')
+  process.exit(1)
+}
+
+async function runSql(sql, label) {
+  const res = await fetch(
+    `https://api.supabase.com/v1/projects/${PROJECT_REF}/database/query`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ query: sql }),
+    },
+  )
+  const body = await res.text()
+  if (!res.ok) {
+    console.error(`  ✗ ${label}: HTTP ${res.status}`)
+    console.error(`    ${body.slice(0, 400)}`)
+    return false
+  }
+  console.log(`  ✓ ${label}`)
+  return true
+}
+
+console.log(`Seeding project ${PROJECT_REF}…\n`)
+
+// ───────────────────────────────────────────────────────────────────
+// 1. Sample assets — so symbol searches return something
+// ───────────────────────────────────────────────────────────────────
+const SEED_ASSETS = [
+  { symbol: 'AAPL', company_name: 'Apple Inc.',          sector: 'Technology'           },
+  { symbol: 'MSFT', company_name: 'Microsoft Corporation', sector: 'Technology'         },
+  { symbol: 'GOOG', company_name: 'Alphabet Inc.',       sector: 'Communication Services' },
+  { symbol: 'NVDA', company_name: 'NVIDIA Corporation',  sector: 'Technology'           },
+  { symbol: 'TSLA', company_name: 'Tesla Inc.',          sector: 'Consumer Cyclical'    },
+  { symbol: 'AMZN', company_name: 'Amazon.com Inc.',     sector: 'Consumer Cyclical'    },
+  { symbol: 'META', company_name: 'Meta Platforms Inc.', sector: 'Communication Services' },
+  { symbol: 'JPM',  company_name: 'JPMorgan Chase & Co.',sector: 'Financial Services'   },
+  { symbol: 'V',    company_name: 'Visa Inc.',           sector: 'Financial Services'   },
+  { symbol: 'WMT',  company_name: 'Walmart Inc.',        sector: 'Consumer Defensive'   },
+]
+
+const valuesClause = SEED_ASSETS
+  .map(a => `('${a.symbol}', '${a.company_name.replace(/'/g, "''")}', '${a.sector}')`)
+  .join(', ')
+
+console.log('Sample assets:')
+await runSql(
+  `INSERT INTO public.assets (symbol, company_name, sector)
+   VALUES ${valuesClause}
+   ON CONFLICT (symbol) DO NOTHING`,
+  `inserted/skipped ${SEED_ASSETS.length} assets`,
+)
+console.log('')
+
+// ───────────────────────────────────────────────────────────────────
+// 2. Mark the dev's test user as a pilot so the pilot UX is visible.
+//    Only updates a single, hardcoded email — won't affect other test
+//    users that get created later.
+// ───────────────────────────────────────────────────────────────────
+console.log('Dev pilot flag:')
+await runSql(
+  `UPDATE public.users
+   SET is_pilot_user = true
+   WHERE email = 'elockenvitz@yahoo.com'`,
+  `flipped is_pilot_user=true for elockenvitz@yahoo.com (if present)`,
+)
+console.log('')
+
+console.log('Done. Refresh your browser to see the seeded data.')


### PR DESCRIPTION
Adds an Environments section to CONTRIBUTING explaining localhost/staging/prod and the data isolation between them. Expands the Migrations section with a concrete step-by-step workflow (migration file → apply to staging → verify → apply to prod → commit) and points at the helper scripts.

Also commits two scripts that were already in use but living outside git:
  - scripts/apply-migrations-to-staging.mjs (applies migration files to any Supabase project via the Management API)
  - scripts/seed-staging.mjs (idempotent seed of sample assets + pilot-flag flip so a fresh staging signup has something to interact with)

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
