### PR TITLE
docs: first three ADRs (RLS, per-org pilot keys, accepted_trades)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ scripts/
 docs/
   ARCHITECTURE.md
   CONTRIBUTING.md
+  adr/                         Architecture Decision Records — why things are the way they are
   archive/                     Historical planning / refactoring notes
 ```
 
@@ -128,7 +129,9 @@ docs/
 
 - **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** — system overview,
   multi-tenancy model, data flow
-- **[docs/CONTRIBUTING.md](docs/CONTRIBUTING.md)** — branch / PR / review flow
+- **[docs/CONTRIBUTING.md](docs/CONTRIBUTING.md)** — environments, branch / PR / review flow, migrations
+- **[docs/adr/](docs/adr/)** — Architecture Decision Records explaining
+  load-bearing choices (RLS, pilot keys, trade-commit canonicalization)
 - **[docs/archive/](docs/archive/)** — historical refactoring and feature plans
 
 ---

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -153,9 +153,11 @@ These are known gaps. Listing them so the absence isn't a surprise.
 - **Storybook visual-regression tests don't run in CI**. They need
   Playwright + Chromium in the runner. Will be added as a separate
   workflow when more stories exist (we have ~3 today).
-- **ADRs (architecture decision records)**. Planned next sprint —
-  one-page docs for the load-bearing choices (Supabase RLS, per-org
-  pilot keys, decision engine design, etc.).
+- **ADRs are partial.** [docs/adr/](adr/) has the first three
+  load-bearing decisions (RLS multi-tenancy, per-org pilot keys,
+  `accepted_trades` as canonical commit record). More to come for
+  the decision engine, AI / BYOK design, snapshot-based sharing,
+  and others.
 
 ---
 

--- a/docs/adr/001-multi-tenancy-via-postgres-rls.md
+++ b/docs/adr/001-multi-tenancy-via-postgres-rls.md
@@ -1,0 +1,92 @@
+# ADR-001 — Multi-tenancy via Postgres RLS
+
+**Status**: Accepted — 2025-01
+**Last reviewed**: 2026-05
+
+## Context
+
+Tesseract is a B2B platform: each customer is an "organization" with
+its own users, portfolios, trade ideas, notes, decisions, etc. A
+single Tesseract deployment serves many orgs at once. Critical
+invariant: **no org's data can ever leak into another org's view**.
+
+We had two reasonable ways to enforce that boundary:
+
+- **Application-level filtering** — every query in the React/TS
+  client adds `.eq('organization_id', currentOrgId)`. If a developer
+  forgets to add the filter, data leaks.
+- **Database-level enforcement** — Postgres row-level security (RLS)
+  policies, evaluated on every read/write, that resolve the caller's
+  active org from their JWT and refuse to return rows from other
+  orgs.
+
+## Decision
+
+**Postgres RLS, enforced on every domain table.**
+
+Every domain table carries an `organization_id` column (or is in the
+"global" exempt list — `assets`, `currencies`, etc.) and has at
+least one RLS policy gating reads and writes on the caller's
+active-org membership.
+
+Three helper functions are used everywhere so the policies stay
+short:
+
+- `auth.uid()` — current user
+- `is_active_org_admin_of_current_org()` — admin check
+- `portfolio_in_current_org(p_id)` — portfolio scoping
+- `user_is_portfolio_member(p_id)` — collaboration scoping
+
+A custom linter (`scripts/tenant-boundary-lint.mjs`) verifies the
+invariants programmatically: every non-exempt table has RLS on,
+every org-scoped table has `organization_id NOT NULL`, every such
+table has at least one policy. A second linter
+(`scripts/frontend-tenant-lint.mjs`) scans React/TS code for
+`supabase.from(...)` calls that lack an org filter on org-scoped
+tables.
+
+## Consequences
+
+**Good:**
+
+- A frontend developer can't accidentally leak data across orgs even
+  if they forget to filter — Postgres refuses the rows.
+- The same protection applies to direct API access (anyone with an
+  anon key and a JWT only sees their org's data).
+- Auditors and security reviewers can verify the invariant by
+  reading SQL policies, not by trusting that every code path got
+  the filter right.
+- New devs don't have to memorize "always filter by org" — the
+  database does it.
+
+**Bad:**
+
+- Every query goes through RLS, which has a non-trivial planning
+  cost. Mitigated by aggressive use of indexes on `(organization_id,
+  ...)` and by hot-path queries that batch.
+- Policies are SQL, not TypeScript. Bugs in policies are harder to
+  unit-test than bugs in app code.
+- Some queries that should be cheap (e.g. "all assets the user can
+  see") have to evaluate policy expressions per row. Not a problem
+  yet but worth watching.
+
+## Alternatives considered
+
+- **App-layer filtering only.** Rejected: one missed `.eq('organization_id', …)`
+  in one PR ships a cross-tenant data leak that's invisible until a
+  customer reports it. The blast radius of a forgotten filter is
+  enormous and there's no mechanical safeguard.
+- **One Postgres schema per org.** Rejected: scaling to hundreds of
+  orgs with hundreds of tables each becomes a migration nightmare.
+  Also requires routing queries to the right schema, which is its own
+  source of bugs.
+- **One Postgres database per org.** Rejected: same problem as
+  per-schema, plus much higher infrastructure cost. Not justified
+  until a single customer needs hard data residency guarantees we
+  can't meet with RLS.
+
+## Related
+
+- `docs/ARCHITECTURE.md` § Multi-tenancy model
+- `scripts/tenant-boundary-lint.mjs`
+- `scripts/frontend-tenant-lint.mjs`

--- a/docs/adr/002-pilot-progress-keyed-per-organization.md
+++ b/docs/adr/002-pilot-progress-keyed-per-organization.md
@@ -1,0 +1,102 @@
+# ADR-002 — Pilot progress keyed per organization
+
+**Status**: Accepted — 2026-05
+**Last reviewed**: 2026-05
+
+## Context
+
+When a new pilot org is onboarded, its admin walks through a
+guided three-stage flow:
+
+1. Capture a first idea
+2. Build it through Idea Pipeline → Trade Lab → Trade Book
+3. See the result in Outcomes
+
+The frontend gates UI on three milestone timestamps that mark when
+each stage was first reached:
+
+- `trade_book_unlocked_at`
+- `outcomes_unlocked_at`
+- `graduated_at`
+
+Originally these were stored on `users.pilot_progress` as
+**user-level keys** — one timestamp per user, regardless of which
+org they were currently in. That worked when every pilot user
+belonged to exactly one org.
+
+Two scenarios broke that assumption:
+
+1. **Multi-org analysts.** Someone helping onboard several pilot
+   clients ended up in N orgs. The first time they completed Trade
+   Lab in Org A, their `trade_book_unlocked_at` got set globally.
+   When they later opened Org B as a fresh pilot, the banner
+   immediately showed Trade Book as "unlocked" — even though Org B
+   had never done anything. The flow was broken because the
+   timestamp was attached to the *user*, not the *engagement*.
+2. **Resets.** When a pilot wanted to restart the flow (testing,
+   demo prep), we needed to clear progress for *that org only*,
+   not wipe the user's history across every other org they belong
+   to.
+
+## Decision
+
+**Store pilot progress as per-org keys in the same JSONB column.**
+
+Keys are now suffixed with the org ID:
+
+```
+trade_book_unlocked_at_<orgId>
+outcomes_unlocked_at_<orgId>
+graduated_at_<orgId>
+```
+
+The `usePilotProgress` hook reads and writes only the suffixed
+keys; legacy unsuffixed keys are **deliberately not read** — old
+state from before this change must be wiped via the Ops Pilot Panel
+"Reset Progress" button.
+
+Telemetry events (`pilot_telemetry_events`) carry the same
+`organization_id` so all funnel analytics can be sliced per-org.
+
+## Consequences
+
+**Good:**
+
+- Multi-org users see fresh onboarding flows in each new org they're
+  added to.
+- Resets are surgical — Ops can wipe a specific pilot's progress
+  without affecting any other org the same user belongs to.
+- Funnel analytics in OpsMetricsPage and OpsClientDetailPage are
+  accurate per-org instead of being polluted by cross-org carry-over.
+
+**Bad:**
+
+- Keys are not type-safe — they're string-templated at the call
+  site. Wrong org ID = silent wrong-key write. Mitigated by the
+  centralized `tradeBookUnlockedKey(orgId)` helpers.
+- Stale state from before the migration can sit in JSONB indefinitely
+  if the user never hits "Reset Progress". Not a correctness issue
+  because the legacy keys are never *read*, but it's clutter.
+- `pilot_progress` JSONB keeps growing as a user is added to more
+  orgs. Realistic cap is "a few dozen" — not a problem in practice.
+
+## Alternatives considered
+
+- **A separate `pilot_org_progress` table** keyed on
+  `(user_id, organization_id)`. More normalized, type-safe per-row.
+  Rejected for now because the JSONB approach was a one-line schema
+  change with no downtime; a normalized table would have required
+  a backfill migration plus refactoring every read site.
+- **Move progress to the `organizations` table.** Wrong: progress is
+  per *user* per *org* (e.g. an analyst could be onboarding several
+  team members in parallel, each at different stages). Org-level
+  storage loses the user dimension.
+- **Compute progress on the fly from `pilot_telemetry_events`.**
+  Tempting but slow on every render. The materialized timestamps
+  are cheap to read and update.
+
+## Related
+
+- `src/hooks/usePilotProgress.ts`
+- `src/lib/pilot/pilot-telemetry.ts`
+- ADR-001 (multi-tenancy / org scoping)

--- a/docs/adr/003-accepted-trades-is-the-canonical-commit-record.md
+++ b/docs/adr/003-accepted-trades-is-the-canonical-commit-record.md
@@ -1,0 +1,108 @@
+# ADR-003 — `accepted_trades` is the canonical commit record
+
+**Status**: Accepted — 2026-03
+**Last reviewed**: 2026-05
+
+## Context
+
+Tesseract's domain model has many objects that look "trade-shaped":
+
+- **Trade ideas** — research proposals, not yet decisions
+- **Recommendations** — formal proposals to a PM
+- **Trade Lab variants** — what-if sizing scenarios
+- **Trade Sheets** — bundles of proposed trades for review
+- **Trade Batches** — grouped commitments with optional approval
+- **Decision requests** — "PM please decide on this"
+- **Accepted trades** — actual committed trade decisions
+
+Earlier in the product's life, several of these objects acted as
+"committed trade" representations depending on which surface the
+user came from. A trade accepted via the Decision Inbox would
+update one table; the same trade pushed from Trade Lab would update
+a different one. The "what is a committed trade" question had
+multiple correct answers depending on context.
+
+That ambiguity caused real bugs:
+
+- Trade Book showed counts that didn't match the Decision History
+  (different sources for "did this trade happen").
+- Outcomes attribution missed trades because some commit paths
+  didn't fire the same triggers.
+- Reconciliation logic had to walk multiple object types to
+  reconstruct "what trades has this org executed."
+
+## Decision
+
+**`accepted_trades` is the single source of truth for committed
+trades. No other object represents a committed trade.**
+
+This is enforced as a load-bearing invariant:
+
+- Every commit path — Decision Inbox accept, Trade Lab execute,
+  Trade Batch approval, ops admin override — writes to
+  `accepted_trades` (and only `accepted_trades` as the commit
+  record).
+- `decision_requests.accepted_trade_id` is the FK from a decision
+  back to the trade it produced.
+- `trade_batches.id` is the FK on `accepted_trades` linking grouped
+  commits.
+- **Trade Plans** (an earlier abstraction) are removed from the UI.
+  Their DB tables remain for historical data but are dead code.
+- **Trade Sheets** are now snapshot-only artifacts — they record
+  what was proposed at a moment in time but have no commit side
+  effects. They don't resolve decisions.
+
+The `accepted_trades.source` enum (`decision_inbox` |
+`trade_lab_execute` | `trade_batch` | `manual_admin` | ...) records
+*how* the trade was committed, so reconciliation can still slice by
+origin without inferring it from other tables.
+
+## Consequences
+
+**Good:**
+
+- Every read of "what trades happened" goes through one table.
+  Counts match. Reconciliation is one query.
+- Outcomes attribution is correct by construction — every committed
+  trade has the same triggers fire.
+- Adding a new commit path (e.g. a future API integration) means
+  "write to `accepted_trades` with the right source enum" — no
+  parallel record-keeping to maintain.
+- Auditors and downstream analytics can trust a single table as
+  ground truth.
+
+**Bad:**
+
+- `accepted_trades` is now load-bearing — schema changes need to
+  consider all the surfaces writing to it. Mitigated by a single
+  `accepted-trade-service.ts` that all commit paths go through.
+- The dead Trade Plans tables still exist in the schema. We chose
+  not to drop them for safety reasons (historical data, plus
+  irreversibility of `DROP TABLE`). They're flagged in the schema
+  as deprecated.
+- `trade_batches.source_type` was a lossy rollup of per-trade
+  sources and **should not be read in UI** — per-trade
+  `accepted_trades.source` is canonical. This trap caught us once
+  and is now documented inline.
+
+## Alternatives considered
+
+- **Trade Plans as the canonical commit record.** This was the
+  earlier model. Failed because some commit paths (e.g. ad-hoc
+  inbox accepts) didn't naturally fit a "plan" shape and ended up
+  writing to other tables anyway.
+- **A polymorphic "committed_object" join.** Considered briefly.
+  Rejected because the polymorphism would push the ambiguity into
+  queries rather than removing it — every read would have to
+  resolve which underlying table the row points to.
+- **Drop the dead Trade Plans tables now.** Rejected because (a)
+  historical data has reporting value, and (b) dropping a table is
+  irreversible. They're cheaper to leave in place than to remove
+  prematurely.
+
+## Related
+
+- `src/lib/services/accepted-trade-service.ts`
+- `src/pages/TradeBookPage.tsx`
+- Memory notes: `project_trade_flow_architecture.md`,
+  `project_trade_book.md`, `project_trade_book_source_truth.md`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,42 @@
+# Architecture Decision Records
+
+Short, dated records of load-bearing architectural decisions. The
+point is to capture **why** something is the way it is — so future
+contributors (or future-you) don't undo a decision out of "this
+seems weird, let me clean it up."
+
+These are not how-tos. For "how does X work," read the code or
+`docs/ARCHITECTURE.md`. For "why is X like this," read here.
+
+## Index
+
+| # | Title | Status |
+|---|---|---|
+| [001](001-multi-tenancy-via-postgres-rls.md) | Multi-tenancy via Postgres RLS | Accepted |
+| [002](002-pilot-progress-keyed-per-organization.md) | Pilot progress keyed per organization | Accepted |
+| [003](003-accepted-trades-is-the-canonical-commit-record.md) | `accepted_trades` is the canonical commit record | Accepted |
+
+## Adding a new ADR
+
+1. Pick the next number (`004`, `005`, …) — numbers never get reused
+   even if an ADR is later marked Superseded.
+2. Copy the structure of an existing ADR. The shape is:
+   **Status**, **Context**, **Decision**, **Consequences**,
+   **Alternatives considered**.
+3. Keep it to ~1 page. The summary should fit in someone's head; if
+   you need more, the *code* is the long form.
+4. Update this index.
+
+## When to write one
+
+Write an ADR when a decision is:
+
+- **Hard to reverse** — schema choices, multi-tenancy model, auth
+  topology, the data flow for a core domain concept.
+- **Counterintuitive** — anywhere a future reader might look at the
+  code and say "this is weird, I'll change it" without realizing
+  what would break.
+- **Load-bearing** — if undoing it would cascade to many places.
+
+Skip ADRs for ergonomics, formatting, tooling choices, or anything
+small enough that the diff is self-explanatory.


### PR DESCRIPTION
Captures the why behind three load-bearing architectural decisions so future contributors don't undo them out of misunderstanding:

  001 — Multi-tenancy via Postgres RLS (vs. app-layer filtering or
        per-tenant schemas)
  002 — Pilot progress keyed per-org (vs. user-level keys that
        broke multi-org analysts and surgical resets)
  003 — accepted_trades is the canonical commit record (vs. earlier
        Trade Plans ambiguity that caused count mismatches)

Each ADR is ~1 page following the standard Context / Decision / Consequences / Alternatives shape. Adds an index + contribution guide for future ADRs.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
