### PR TITLE
fix: self-heal trade_book_unlocked + report pilot_progress write fail…

### DIFF
--- a/src/hooks/usePilotMode.ts
+++ b/src/hooks/usePilotMode.ts
@@ -62,7 +62,7 @@ export interface PilotModeState {
 export function usePilotMode(): PilotModeState {
   const { user } = useAuth()
   const { currentOrgId } = useOrganization()
-  const { hasUnlockedTradeBook, hasUnlockedOutcomes, hasGraduated, cachedHasGraduated, isLoading: progressLoading } = usePilotProgress()
+  const { hasUnlockedTradeBook, hasUnlockedOutcomes, hasGraduated, cachedHasGraduated, isLoading: progressLoading, mark: markPilotStage } = usePilotProgress()
 
   // Cached hint from the previous session: was this user a pilot? Read
   // synchronously on mount so we can answer "is this a pilot session?"
@@ -131,6 +131,30 @@ export function usePilotMode(): PilotModeState {
   })
 
   const isPilot = !!orgFlags?.pilotMode
+
+  // Self-heal trade_book_unlocked. The event-based unlock fires from
+  // SimulationPage's listener on `pilot-tradelab:executed`, but if that
+  // listener missed (race condition, mutation errored silently, page
+  // navigated away mid-mutation), the user can land in a stuck state
+  // where they've committed a trade but Trade Book is still locked.
+  // Both `hasCommittedTradeInOrg` and `hasUnlockedTradeBook` are
+  // required to unlock; the existence of an accepted_trade is proof
+  // enough that execute happened, so we can safely backfill the flag.
+  // The mutation is idempotent so re-runs are no-ops.
+  //
+  // Note: outcomes_unlocked is NOT self-healed — that one represents
+  // intent ("user navigated to Outcomes"), not just trade activity.
+  useEffect(() => {
+    if (
+      isPilot &&
+      !progressLoading &&
+      !orgLoading &&
+      hasCommittedTradeInOrg &&
+      !hasUnlockedTradeBook
+    ) {
+      markPilotStage('trade_book_unlocked')
+    }
+  }, [isPilot, progressLoading, orgLoading, hasCommittedTradeInOrg, hasUnlockedTradeBook, markPilotStage])
   const access = useMemo(() => {
     // Once the user has graduated, all pilot gating drops away —
     // they get the same access as a non-pilot user even though the

--- a/src/hooks/usePilotProgress.ts
+++ b/src/hooks/usePilotProgress.ts
@@ -29,6 +29,7 @@
 
 import { useCallback, useEffect, useMemo } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import * as Sentry from '@sentry/react'
 import { supabase } from '../lib/supabase'
 import { useAuth } from './useAuth'
 import { useOrganization } from '../contexts/OrganizationContext'
@@ -156,11 +157,23 @@ export function usePilotProgress() {
       queryClient.setQueryData(['pilot-progress', user.id], optimistic)
       return { previous }
     },
-    onError: (_error, _stage, context) => {
+    onError: (error, stage, context) => {
       // Roll back the optimistic flip if the DB write fails.
       if (context?.previous !== undefined && user?.id) {
         queryClient.setQueryData(['pilot-progress', user.id], context.previous)
       }
+      // Surface the failure to Sentry — Daniel hit a case where his
+      // accepted_trade landed but trade_book_unlocked never marked,
+      // and we had no record of *why* (silent rollback). Future
+      // failures land in Sentry tagged with the stage + org so we can
+      // tell whether it was a network blip, RLS rejection, or a real
+      // mutation bug.
+      Sentry.withScope((scope) => {
+        scope.setTag('pilot_stage', stage)
+        scope.setTag('organization_id', currentOrgId ?? 'none')
+        scope.setContext('pilot_progress', { stage, currentOrgId, userId: user?.id })
+        Sentry.captureException(error)
+      })
     },
     onSuccess: (result) => {
       if (result?.nextProgress) {


### PR DESCRIPTION
…ures

Pilot user Daniel executed a trade in Trade Lab, but Trade Book stayed locked because pilot_progress.trade_book_unlocked_at_<orgId> was never written. The event-based unlock listener exists (SimulationPage:376) but appears to have missed for him — silent failure, no Sentry trail.

Two changes:

  1. usePilotMode self-heal: when a pilot has committed ≥1 trade in the current org but the trade_book_unlocked flag is still false, mark it now. The accepted_trade row is itself proof that execute happened, so backfilling the flag is safe. The mutation is idempotent so re-runs are no-ops. (We do NOT self-heal outcomes_unlocked — that one represents user intent, not trade activity.)

  2. usePilotProgress markStage onError now reports to Sentry with stage + org tags + user context, so the next silent failure gives us a trace instead of just rolling back the optimistic flip.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
