### PR TITLE
fix: scope user-picker queries to current-org members

### DIFF
--- a/src/components/ui/MentionInput.tsx
+++ b/src/components/ui/MentionInput.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../../lib/supabase'
+import { useOrganization } from '../../contexts/OrganizationContext'
 import { AtSign, Hash, X } from 'lucide-react'
 
 interface User {
@@ -42,19 +43,34 @@ export function MentionInput({ value, onChange, placeholder, className, disabled
   const [mentions, setMentions] = useState<string[]>([])
   const [references, setReferences] = useState<Array<{ type: string; id: string; text: string }>>([])
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const { currentOrgId } = useOrganization()
 
-  // Fetch users for @mentions
+  // Fetch users for @mentions, scoped to the current org's active members
+  // only. We don't rely on RLS alone here — platform admins legitimately
+  // *can* read all users (for ops dashboards) but the mention dropdown
+  // should never show anyone outside the current org regardless of role.
+  // Defense in depth: explicit org scope at the query level.
   const { data: users } = useQuery({
-    queryKey: ['users'],
+    queryKey: ['mention-users', currentOrgId],
     queryFn: async () => {
+      if (!currentOrgId) return []
+      const { data: members, error: memErr } = await supabase
+        .from('organization_memberships')
+        .select('user_id')
+        .eq('organization_id', currentOrgId)
+        .eq('status', 'active')
+      if (memErr) throw memErr
+      const userIds = (members ?? []).map((m: any) => m.user_id).filter(Boolean)
+      if (userIds.length === 0) return []
       const { data, error } = await supabase
         .from('users')
         .select('id, email, first_name, last_name')
+        .in('id', userIds)
         .order('email')
       if (error) throw error
       return data as User[]
     },
-    enabled: suggestionType === 'mention'
+    enabled: suggestionType === 'mention' && !!currentOrgId,
   })
 
   // Fetch assets for #hashtags

--- a/src/hooks/useEntitySearch.ts
+++ b/src/hooks/useEntitySearch.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../lib/supabase'
+import { useOrganization } from '../contexts/OrganizationContext'
 
 export type EntityType = 'user' | 'asset' | 'theme' | 'portfolio' | 'note' | 'workflow' | 'list' | 'trade_idea' | 'project' | 'trade' | 'trade_sheet' | 'meeting'
 
@@ -28,21 +29,35 @@ export function useEntitySearch({
   limit = 5,
   enabled = true
 }: UseEntitySearchOptions) {
+  const { currentOrgId } = useOrganization()
   const { data: results = [], isLoading, error } = useQuery({
-    queryKey: ['entity-search', query, types.join(','), limit],
+    queryKey: ['entity-search', query, types.join(','), limit, currentOrgId],
     queryFn: async () => {
       const searchResults: EntitySearchResult[] = []
       const searchPromises: Promise<void>[] = []
 
-      // Search users
-      if (types.includes('user')) {
+      // Search users — scoped to current-org members only. Platform
+      // admins legitimately have read access to all users (for ops
+      // dashboards), but any user-facing picker should only surface
+      // members of the org the caller is currently working in.
+      // Defense in depth: explicit scope at the query level, not just RLS.
+      if (types.includes('user') && currentOrgId) {
         searchPromises.push(
           (async () => {
+            const { data: members } = await supabase
+              .from('organization_memberships')
+              .select('user_id')
+              .eq('organization_id', currentOrgId)
+              .eq('status', 'active')
+
+            const memberIds = (members ?? []).map((m: any) => m.user_id).filter(Boolean)
+            if (memberIds.length === 0) return
+
             let usersQuery = supabase
               .from('users')
               .select('id, email, first_name, last_name')
+              .in('id', memberIds)
 
-            // If query is provided, filter by it; otherwise return all users
             if (query.trim()) {
               usersQuery = usersQuery.or(`email.ilike.%${query}%,first_name.ilike.%${query}%,last_name.ilike.%${query}%`)
             }


### PR DESCRIPTION
Pilot user (member of two orgs + platform admin for testing) saw users from a different pilot org in their @-mention dropdown. RLS was doing the right thing — platform admins legitimately can read all users — but the mention dropdown never should, regardless of the caller's permissions.

Switch both user-picker entry points (MentionInput, useEntitySearch) to query through organization_memberships filtered by currentOrgId, so the dropdown shows org members and only org members. Defense in depth: the database still has RLS, but we no longer rely on it for UI scoping.

The remaining ~20 places that call .from('users') without explicit org scope still need an audit; tracking separately.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
