### PR TITLE
hotfix: mention picker must not crash when rendered outside OrgProvider

### DIFF
--- a/src/components/ui/MentionInput.tsx
+++ b/src/components/ui/MentionInput.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../../lib/supabase'
-import { useOrganization } from '../../contexts/OrganizationContext'
+import { useOrganizationOptional } from '../../contexts/OrganizationContext'
 import { AtSign, Hash, X } from 'lucide-react'
 
 interface User {
@@ -43,7 +43,13 @@ export function MentionInput({ value, onChange, placeholder, className, disabled
   const [mentions, setMentions] = useState<string[]>([])
   const [references, setReferences] = useState<Array<{ type: string; id: string; text: string }>>([])
   const textareaRef = useRef<HTMLTextAreaElement>(null)
-  const { currentOrgId } = useOrganization()
+  // Optional context: this component is also rendered in places that
+  // sit outside the OrganizationProvider tree (portal-rendered modals,
+  // overlays). Falling back to null currentOrgId disables the user
+  // suggestion query — that's the correct behavior when we don't know
+  // which org's members to surface.
+  const orgCtx = useOrganizationOptional()
+  const currentOrgId = orgCtx?.currentOrgId ?? null
 
   // Fetch users for @mentions, scoped to the current org's active members
   // only. We don't rely on RLS alone here — platform admins legitimately

--- a/src/contexts/OrganizationContext.tsx
+++ b/src/contexts/OrganizationContext.tsx
@@ -236,3 +236,14 @@ export function useOrganization() {
   }
   return context
 }
+
+/**
+ * Like `useOrganization` but returns null when no provider is in scope
+ * instead of throwing. Use this from components that can legitimately
+ * render outside the org provider tree (modals via portal, capture
+ * overlays, login screens with mention pickers, etc.) — they should
+ * degrade gracefully rather than crash.
+ */
+export function useOrganizationOptional() {
+  return useContext(OrganizationContext) ?? null
+}

--- a/src/hooks/useEntitySearch.ts
+++ b/src/hooks/useEntitySearch.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../lib/supabase'
-import { useOrganization } from '../contexts/OrganizationContext'
+import { useOrganizationOptional } from '../contexts/OrganizationContext'
 
 export type EntityType = 'user' | 'asset' | 'theme' | 'portfolio' | 'note' | 'workflow' | 'list' | 'trade_idea' | 'project' | 'trade' | 'trade_sheet' | 'meeting'
 
@@ -29,7 +29,12 @@ export function useEntitySearch({
   limit = 5,
   enabled = true
 }: UseEntitySearchOptions) {
-  const { currentOrgId } = useOrganization()
+  // Optional context: this hook is also called from components rendered
+  // outside the OrganizationProvider tree (capture overlay, portal modals).
+  // Without an org we can't scope user searches; the user branch below
+  // gates on `currentOrgId` and returns empty results in that case.
+  const orgCtx = useOrganizationOptional()
+  const currentOrgId = orgCtx?.currentOrgId ?? null
   const { data: results = [], isLoading, error } = useQuery({
     queryKey: ['entity-search', query, types.join(','), limit, currentOrgId],
     queryFn: async () => {


### PR DESCRIPTION
PR #21 added useOrganization() to MentionInput + useEntitySearch to scope user suggestions to the current org. But useOrganization throws when called outside the provider, and both components render in contexts that legitimately sit outside the provider tree (portal modals, capture overlays). The result: any time one of those callsites mounted, the page crashed (Sentry TESSERACT-7).

Adds useOrganizationOptional() that returns null instead of throwing, and switches both callsites to use it. Without an org context, the user suggestion query is disabled (returns empty) — which is the correct behavior: we don't know which org's members to surface.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
