### PR TITLE
fix: auto-reload on stale chunk load after a deploy

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -28,6 +28,27 @@ if (SENTRY_DSN) {
   })
 }
 
+// Stale-chunk recovery. When we ship a new deploy, dynamically-imported
+// chunks get new content hashes (`SimulationPage-abc.js` → `SimulationPage-xyz.js`).
+// Any tab that was open before the deploy still references the old
+// hashed paths and crashes when it tries to navigate into a route
+// whose chunk has been replaced — Daniel hit this on Trade Lab open.
+// Vite emits `vite:preloadError` for exactly this case; the standard
+// fix is to reload the page, which fetches fresh HTML referencing the
+// current chunk hashes. The `sessionStorage` flag guards against an
+// infinite reload loop if the failure is something other than staleness.
+window.addEventListener('vite:preloadError', (event) => {
+  const reloadFlag = 'tesseract:preload-error-reloaded'
+  if (sessionStorage.getItem(reloadFlag)) {
+    // We already reloaded once this session and still hit it — let
+    // the error bubble so Sentry / the user notices something real.
+    return
+  }
+  sessionStorage.setItem(reloadFlag, '1')
+  event.preventDefault()
+  window.location.reload()
+})
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />


### PR DESCRIPTION
When we ship a new build, dynamically-imported chunks get new content hashes. Any tab open from before the deploy still references the old hashed paths and crashes with "Failed to fetch dynamically imported module" the next time it navigates into a route whose chunk was replaced (Sentry TESSERACT-6, what Daniel hit on Trade Lab open).

Listen for Vite's `vite:preloadError` and reload the page once per session. The reload fetches fresh HTML which references the current chunk filenames, and the user lands on the page they meant to visit instead of an error. A sessionStorage guard prevents an infinite reload loop if the error is actually something other than staleness.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
