### PR TITLE
fix(pilot): banner steps stack vertically when narrow; clearer step 2

### DIFF
--- a/src/components/pilot/PilotTradeLabIntroBanner.tsx
+++ b/src/components/pilot/PilotTradeLabIntroBanner.tsx
@@ -127,21 +127,29 @@ export function PilotTradeLabIntroBanner({ userId, orgId }: PilotTradeLabIntroBa
           <Sparkles className="h-4 w-4" />
           <span className="text-[12px] uppercase tracking-wider">Get started</span>
         </div>
-        <div className="flex items-start gap-x-4 text-gray-700 dark:text-gray-300 min-w-0 flex-wrap">
+        {/*
+          Stack steps vertically on narrow screens (mobile/laptop side-panel
+          widths) and lay them out horizontally on wider screens. The
+          previous `flex-wrap` approach put steps in the wrong visual order
+          when the row ran out of space — pilot tester saw step 3 appear
+          below step 1 instead of below step 2. The inter-step arrows are
+          decorative; we hide them in the stacked layout.
+        */}
+        <div className="flex flex-col md:flex-row md:items-start gap-y-2 md:gap-x-4 text-gray-700 dark:text-gray-300 min-w-0">
           <Step
             n={1}
             title="Review and add the recommendation"
             hint="Check the box on the recommendation card on the left to import it into the holdings table."
             done={step1}
           />
-          <ArrowRight className="h-3.5 w-3.5 text-amber-400 dark:text-amber-500 shrink-0 mt-[3px]" />
+          <ArrowRight className="hidden md:block h-3.5 w-3.5 text-amber-400 dark:text-amber-500 shrink-0 mt-[3px]" />
           <Step
             n={2}
-            title="Adjust sizing and select the trade"
-            hint="Tweak Sim Wt if needed, then check the box on the trade row in the holdings table."
+            title="Pick your trade"
+            hint="Check the box on the trade row in the table below."
             done={step2}
           />
-          <ArrowRight className="h-3.5 w-3.5 text-amber-400 dark:text-amber-500 shrink-0 mt-[3px]" />
+          <ArrowRight className="hidden md:block h-3.5 w-3.5 text-amber-400 dark:text-amber-500 shrink-0 mt-[3px]" />
           <Step
             n={3}
             title="Execute"

--- a/src/pages/TradeQueuePage.tsx
+++ b/src/pages/TradeQueuePage.tsx
@@ -1607,21 +1607,28 @@ export function TradeQueuePage() {
               <Sparkles className="h-4 w-4" />
               <span className="text-[12px] uppercase tracking-wider">Get started</span>
             </div>
-            <div className="flex items-start gap-x-4 text-gray-700 dark:text-gray-300 min-w-0 flex-wrap">
+            {/*
+              Stack steps vertically on narrow screens, horizontal on wider
+              ones. flex-wrap (the previous approach) produced confusing
+              orderings when steps overflowed — pilot tester saw step 3
+              wrap to a new row below step 1 instead of below step 2. Same
+              fix is applied in PilotTradeLabIntroBanner.
+            */}
+            <div className="flex flex-col md:flex-row md:items-start gap-y-2 md:gap-x-4 text-gray-700 dark:text-gray-300 min-w-0">
               <PilotPipelineStep
                 n={1}
                 title="Drag ideas through the pipeline"
                 hint="Click and drag ideas left to right through stages as they mature."
                 done={pilotStep1Done}
               />
-              <ArrowRight className="h-3.5 w-3.5 text-amber-400 dark:text-amber-500 shrink-0 mt-[3px]" />
+              <ArrowRight className="hidden md:block h-3.5 w-3.5 text-amber-400 dark:text-amber-500 shrink-0 mt-[3px]" />
               <PilotPipelineStep
                 n={2}
                 title="Open the Decision Inbox"
                 hint="The bottom drawer is where recommendations wait for your decision — click it."
                 done={pilotStep2Done}
               />
-              <ArrowRight className="h-3.5 w-3.5 text-amber-400 dark:text-amber-500 shrink-0 mt-[3px]" />
+              <ArrowRight className="hidden md:block h-3.5 w-3.5 text-amber-400 dark:text-amber-500 shrink-0 mt-[3px]" />
               <PilotPipelineStep
                 n={3}
                 title="Open Trade Lab"


### PR DESCRIPTION
Pilot tester reported the Idea Pipeline get-started banner showed step 3 wrapping below step 1 instead of below step 2 at certain window widths. Cause: flex-wrap puts whatever fits on row 1 and overflows the rest, which doesn't guarantee a useful reading order.

Switch both pilot banners (Idea Pipeline + Trade Lab) to flex-col on narrow and flex-row on >=md, hiding the inter-step arrows in the stacked layout. Reading order is now always 1 → 2 → 3.

Also rewords Trade Lab step 2:
  before: title "Adjust sizing and select the trade"
          hint  "Tweak Sim Wt if needed, then check the box on the
                 trade row in the holdings table."
  after:  title "Pick your trade"
          hint  "Check the box on the trade row in the table below."

The previous wording bundled an optional action (sizing) with the required one and used jargon ("holdings table"). The pilot reading just needs to know "check the row to confirm."

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
