### PR TITLE
fix(pilot): mark Get-Started step 1 done when auto-select fires

### DIFF
--- a/src/pages/SimulationPage.tsx
+++ b/src/pages/SimulationPage.tsx
@@ -3661,6 +3661,15 @@ export function SimulationPage({ simulationId: propSimulationId, tabId, onClose,
     } else {
       handleAddAsset(scenarioIdea)
     }
+
+    // Mark step 1 of the Get Started banner ("Review and add the
+    // recommendation") as done — the auto-select above did exactly
+    // what the user would have done by clicking the checkbox, so the
+    // banner should reflect reality. Without this, the user lands
+    // with the checkbox already visually checked but the banner still
+    // asking them to "Check the box on the recommendation card",
+    // which is confusing.
+    try { window.dispatchEvent(new CustomEvent('pilot-tradelab:rec-reviewed')) } catch { /* ignore */ }
   }, [
     pilotMode.effectiveIsPilot,
     user?.id,


### PR DESCRIPTION
Pilot users have the seeded recommendation auto-added to their simulation on first Trade Lab open (SimulationPage:3578). The checkbox visually flips to checked, but the Get-Started banner's step 1 ("Review and add the recommendation — Check the box on the recommendation card...") was NOT being ticked, so the banner asked the user to do something already done.

Pilot tester Daniel hit the confused state: the box was checked, the banner said to check it, and eventually the localStorage flag got set somehow (probably from a curiosity click), so on the next session step 1 appeared "already complete without clicking."

Fix: dispatch pilot-tradelab:rec-reviewed at the end of the auto-select effect. Now the banner reflects reality from first paint — step 1 ticked off, only steps 2 and 3 left to do.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
