### PR TITLE
fix(pilot): self-heal outcomes_unlocked when preview is rendered afte…

### DIFF
--- a/src/components/pilot/PilotOutcomesPreview.tsx
+++ b/src/components/pilot/PilotOutcomesPreview.tsx
@@ -1,16 +1,50 @@
 /**
  * PilotOutcomesPreview — read-only teaser rendered when a pilot user opens
  * the Outcomes tab. Shows what the real surface will do once enabled.
+ *
+ * Self-heal: if the user lands here having already completed Trade Book
+ * (committed a trade + Trade Book unlocked), they've earned Outcomes —
+ * mark outcomes_unlocked so the next render swaps in the real surface.
+ * Catches the case where the event-based unlock from Trade Book's
+ * "Open Outcomes" button missed silently (pilot tester hit this).
  */
 
+import { useEffect } from 'react'
 import { Target, CheckCircle2, Sparkles, ArrowRight, Lock } from 'lucide-react'
 import { Button } from '../ui/Button'
+import { usePilotMode } from '../../hooks/usePilotMode'
+import { usePilotProgress } from '../../hooks/usePilotProgress'
 
 interface PilotOutcomesPreviewProps {
   onGoToTradeLab?: () => void
 }
 
 export function PilotOutcomesPreview({ onGoToTradeLab }: PilotOutcomesPreviewProps) {
+  const pilotMode = usePilotMode()
+  const { hasUnlockedTradeBook, hasUnlockedOutcomes, mark } = usePilotProgress()
+
+  useEffect(() => {
+    // If we're rendering this preview but the user has already
+    // completed everything required to unlock Outcomes, mark it
+    // now. The mutation is idempotent so re-firing is a no-op.
+    if (
+      !pilotMode.isLoading &&
+      pilotMode.isPilot &&
+      pilotMode.hasCommittedTradeInOrg &&
+      hasUnlockedTradeBook &&
+      !hasUnlockedOutcomes
+    ) {
+      mark('outcomes_unlocked')
+    }
+  }, [
+    pilotMode.isLoading,
+    pilotMode.isPilot,
+    pilotMode.hasCommittedTradeInOrg,
+    hasUnlockedTradeBook,
+    hasUnlockedOutcomes,
+    mark,
+  ])
+
   return (
     <div className="p-8 max-w-4xl mx-auto space-y-6">
       <div>


### PR DESCRIPTION
…r trade book

Pilot tester completed all Trade Book getting-started items, clicked through to Outcomes, but landed on the locked preview instead of the real surface. Same shape as the earlier trade_book_unlocked silent-miss: the event-based handler in TradeBookPage:248 didn't fire (or its mutation errored silently), and pilot_progress never got the outcomes_unlocked_at_<orgId> key.

Fix: in PilotOutcomesPreview, when we detect we're being rendered to a user who has all the prerequisites met (committed a trade, trade book unlocked), mark outcomes_unlocked. The user expressed intent by navigating here; if the event-based path missed, this catches them on the same click.

This is the analogous fix to fix/self-heal-trade-book-unlock — intentionally scoped to the preview component (not usePilotMode) so the unlock requires the user to actively land on Outcomes, preserving the sequential "must navigate to Outcomes" semantics.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
