### PR TITLE
fix: scope every user picker to current-org members via useOrgMembers

### DIFF
--- a/src/components/communication/DirectMessaging.tsx
+++ b/src/components/communication/DirectMessaging.tsx
@@ -11,6 +11,7 @@ import { clsx } from 'clsx'
 import { UniversalSmartInput, SmartInputRenderer, type SmartInputMetadata } from '../smart-input'
 import type { UniversalSmartInputRef } from '../smart-input'
 import { useEntityOrgResolver } from '../../hooks/useEntityOrgResolver'
+import { useOrgMembers } from '../../hooks/useOrgMembers'
 import { OrgSwitchBanner } from '../common/OrgSwitchBanner'
 
 interface DirectMessagingProps {
@@ -310,20 +311,12 @@ export function DirectMessaging({ isOpen, onClose }: DirectMessagingProps) {
     refetchInterval: 2000, // Real-time updates
   })
 
-  // Fetch all users for creating conversations
-  const { data: allUsers } = useQuery({
-    queryKey: ['all-users-messaging'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('users')
-        .select('id, email, first_name, last_name')
-        .neq('id', user?.id)
-        .order('first_name', { ascending: true })
-
-      if (error) throw error
-      return data || []
-    },
+  // Fetch users in the current org for creating conversations. Scoped
+  // via useOrgMembers — explicit org filter, not just RLS — so the
+  // picker shows only org-mates even for platform admins.
+  const { data: allUsers = [] } = useOrgMembers({
     enabled: showNewConversation || showGroupCreation,
+    excludeUserId: user?.id,
   })
 
   // Auto-scroll to bottom when new messages arrive (but not on initial load)
@@ -578,19 +571,11 @@ export function DirectMessaging({ isOpen, onClose }: DirectMessagingProps) {
     },
   })
 
-  // Fetch users for add-member picker (reuse allUsers query but also enable when adding)
-  const { data: addMemberUsers } = useQuery({
-    queryKey: ['all-users-messaging'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('users')
-        .select('id, email, first_name, last_name')
-        .neq('id', user?.id)
-        .order('first_name', { ascending: true })
-      if (error) throw error
-      return data || []
-    },
+  // Fetch users for add-member picker, scoped to current org (same hook
+  // as the new-conversation picker — see comment above).
+  const { data: addMemberUsers = [] } = useOrgMembers({
     enabled: showAddMember,
+    excludeUserId: user?.id,
   })
 
   const handleSendMessage = () => {

--- a/src/components/feed/ShareToUserModal.tsx
+++ b/src/components/feed/ShareToUserModal.tsx
@@ -3,6 +3,7 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { X, Search, Send, Check, User, Loader2 } from 'lucide-react'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
+import { useOrgMembers } from '../../hooks/useOrgMembers'
 import { clsx } from 'clsx'
 import type { ScoredFeedItem } from '../../hooks/ideas/types'
 
@@ -30,20 +31,12 @@ export function ShareToUserModal({ isOpen, onClose, item }: ShareToUserModalProp
     }
   }, [isOpen])
 
-  // Fetch all users
-  const { data: allUsers, isLoading: usersLoading } = useQuery({
-    queryKey: ['all-users-share'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('users')
-        .select('id, email, first_name, last_name')
-        .neq('id', user?.id)
-        .order('first_name', { ascending: true })
-
-      if (error) throw error
-      return data || []
-    },
-    enabled: isOpen
+  // Fetch users in the current org. Scoped via useOrgMembers — explicit
+  // org filter, not just RLS — so the share dialog shows only org-mates
+  // even for platform admins.
+  const { data: allUsers = [], isLoading: usersLoading } = useOrgMembers({
+    enabled: isOpen,
+    excludeUserId: user?.id,
   })
 
   // Filter users based on search

--- a/src/components/portfolios/AddTeamMemberModal.tsx
+++ b/src/components/portfolios/AddTeamMemberModal.tsx
@@ -9,6 +9,7 @@ import { Select } from '../ui/Select'
 import { SearchableSelect } from '../ui/SearchableSelect'
 import { ROLE_OPTIONS, getFocusOptionsForRole } from '../../lib/roles-config'
 import { useOrganization } from '../../contexts/OrganizationContext'
+import { useOrgMembers } from '../../hooks/useOrgMembers'
 import { logOrgActivity } from '../../lib/org-activity-log'
 
 interface AddTeamMemberModalProps {
@@ -74,18 +75,12 @@ export function AddTeamMemberModal({
     return 'Unknown User'
   }
 
-  const { data: allUsers, isLoading: usersLoading } = useQuery<UserOption[]>({
-    queryKey: ['all-users'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('users')
-        .select('id, email, first_name, last_name')
-        .order('first_name', { ascending: true })
-      if (error) throw error
-      return data || []
-    },
+  // Scope the user picker to current-org members. The team-add modal
+  // is for adding org-mates to a portfolio team, so cross-org users
+  // would never be valid candidates anyway. Explicit scope via
+  // useOrgMembers — defense in depth, not RLS-only.
+  const { data: allUsers = [], isLoading: usersLoading } = useOrgMembers({
     enabled: isOpen,
-    staleTime: 0,
   })
 
   const { data: existingTeamMembers, isLoading: existingTeamLoading } = useQuery<

--- a/src/components/portfolios/NewPortfolioModal.tsx
+++ b/src/components/portfolios/NewPortfolioModal.tsx
@@ -19,6 +19,7 @@ import {
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 import { useOrganization } from '../../contexts/OrganizationContext'
+import { useOrgMembers } from '../../hooks/useOrgMembers'
 import { logOrgActivity } from '../../lib/org-activity-log'
 import { Button } from '../ui/Button'
 import { Select } from '../ui/Select'
@@ -106,19 +107,10 @@ export function NewPortfolioModal({ isOpen, onClose, onCreated }: NewPortfolioMo
     enabled: isOpen && !!currentOrgId,
   })
 
-  // Fetch all users for step 3 (same pattern as AddTeamMemberModal)
-  const { data: orgUsers = [], isLoading: usersLoading } = useQuery({
-    queryKey: ['all-users'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('users')
-        .select('id, email, first_name, last_name')
-        .order('first_name', { ascending: true })
-      if (error) throw error
-      return data || []
-    },
+  // Step 3 user picker: scoped to current-org members via useOrgMembers.
+  // Explicit scope, not RLS-only.
+  const { data: orgUsers = [], isLoading: usersLoading } = useOrgMembers({
     enabled: isOpen,
-    staleTime: 0,
   })
 
   // Duplicate name check

--- a/src/components/projects/CreateProjectModal.tsx
+++ b/src/components/projects/CreateProjectModal.tsx
@@ -3,6 +3,7 @@ import { X, Plus, Search, Users, Building2, ChevronDown, ChevronRight, Check } f
 import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
+import { useOrgMembers } from '../../hooks/useOrgMembers'
 import { Button } from '../ui/Button'
 import { Input } from '../ui/Input'
 import { Select } from '../ui/Select'
@@ -89,17 +90,7 @@ export function CreateProjectModal({ isOpen, onClose, onSuccess, initialContext 
   }, [orgDropdownOpen])
 
   // Fetch all users
-  const { data: users } = useQuery({
-    queryKey: ['users'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('users')
-        .select('id, email, first_name, last_name')
-        .order('email')
-      if (error) throw error
-      return data as User[]
-    }
-  })
+  const { data: users } = useOrgMembers()
 
   // Fetch org groups with parent info and settings (portfolio nodes have settings.portfolio_id)
   const { data: orgGroups } = useQuery({

--- a/src/components/projects/CreateTeamModal.tsx
+++ b/src/components/projects/CreateTeamModal.tsx
@@ -3,6 +3,7 @@ import { X, Search, Users, Building2, ChevronDown, ChevronRight, Check, Filter, 
 import { useMutation, useQueryClient, useQuery } from '@tanstack/react-query'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
+import { useOrgMembers } from '../../hooks/useOrgMembers'
 import { Button } from '../ui/Button'
 import { Input } from '../ui/Input'
 import { clsx } from 'clsx'
@@ -46,25 +47,18 @@ export function CreateTeamModal({ isOpen, onClose, editingTeam }: CreateTeamModa
   const [viewingUserOrgs, setViewingUserOrgs] = useState<string | null>(null)
   const popoverRef = useRef<HTMLDivElement>(null)
 
-  // Fetch all users
-  const { data: allUsers } = useQuery({
-    queryKey: ['users-list'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('users')
-        .select('id, first_name, last_name, email')
-        .eq('is_active', true)
-        .order('first_name')
-
-      if (error) throw error
-      return (data || []).map(u => ({
+  // Fetch all users (org-scoped, active members only)
+  const { data: orgMembers = [] } = useOrgMembers()
+  const allUsers = useMemo(
+    () =>
+      orgMembers.map(u => ({
         ...u,
         full_name: u.first_name && u.last_name
           ? `${u.first_name} ${u.last_name}`.trim()
           : u.first_name || u.last_name || null
-      }))
-    }
-  })
+      })),
+    [orgMembers]
+  )
 
   // Fetch all org nodes
   const { data: rawOrgNodes } = useQuery({

--- a/src/components/rich-text-editor/TaskModal.tsx
+++ b/src/components/rich-text-editor/TaskModal.tsx
@@ -3,6 +3,7 @@ import { X, Calendar, Clock, User, Flag, Bell, AlignLeft } from 'lucide-react'
 import { clsx } from 'clsx'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
+import { useOrgMembers } from '../../hooks/useOrgMembers'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 
 export interface TaskData {
@@ -65,19 +66,8 @@ export function TaskModal({
     initialData?.priority || 'medium'
   )
 
-  // Fetch users for assignment dropdown
-  const { data: users = [] } = useQuery({
-    queryKey: ['users-for-assignment'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('users')
-        .select('id, first_name, last_name, email')
-        .order('first_name')
-      if (error) throw error
-      return data || []
-    },
-    staleTime: 5 * 60 * 1000
-  })
+  // Fetch users for assignment dropdown (org-scoped)
+  const { data: users = [] } = useOrgMembers()
 
   // Create task mutation
   const createTaskMutation = useMutation({

--- a/src/components/rich-text-editor/extensions/InlineTaskExtension.tsx
+++ b/src/components/rich-text-editor/extensions/InlineTaskExtension.tsx
@@ -5,6 +5,7 @@ import { Calendar, Clock, Flag, User, Bell, X, Check, ChevronDown, ChevronUp, Re
 import { clsx } from 'clsx'
 import { supabase } from '../../../lib/supabase'
 import { useAuth } from '../../../hooks/useAuth'
+import { useOrgMembers } from '../../../hooks/useOrgMembers'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 
 const PRIORITY_OPTIONS = [
@@ -126,19 +127,8 @@ function InlineTaskView({ node, updateAttributes, deleteNode, selected }: Inline
     setShowQuickDueMenu(false)
   }
 
-  // Fetch users for assignment
-  const { data: users = [] } = useQuery({
-    queryKey: ['users-for-task-assignment'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('users')
-        .select('id, first_name, last_name, email')
-        .order('first_name')
-      if (error) throw error
-      return data || []
-    },
-    staleTime: 5 * 60 * 1000
-  })
+  // Fetch users for assignment (org-scoped)
+  const { data: users = [] } = useOrgMembers()
 
   // Get assigned user name
   const assignedUser = users.find(u => u.id === node.attrs.assignedTo)

--- a/src/components/table/AssetTableView.tsx
+++ b/src/components/table/AssetTableView.tsx
@@ -23,6 +23,7 @@ import {
 import { PriorityBadge } from '../ui/PriorityBadge'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
+import { useOrgMembers } from '../../hooks/useOrgMembers'
 import { Card } from '../ui/Card'
 import { Button } from '../ui/Button'
 import { Badge } from '../ui/Badge'
@@ -660,18 +661,8 @@ export function AssetTableView({
   } | null>(null)
   const [prioritySourceSearch, setPrioritySourceSearch] = useState('')
 
-  // Fetch team members for priority column picker
-  const { data: teamMembers = [] } = useQuery({
-    queryKey: ['team-members'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('users')
-        .select('id, email, first_name, last_name')
-        .order('first_name')
-      if (error) throw error
-      return data || []
-    }
-  })
+  // Fetch team members for priority column picker (org-scoped)
+  const { data: teamMembers = [] } = useOrgMembers()
 
   // Get unique user IDs from columns that have priority source set to 'user'
   const specificPriorityUserIds = useMemo(() => {

--- a/src/hooks/useOrgMembers.ts
+++ b/src/hooks/useOrgMembers.ts
@@ -1,0 +1,67 @@
+/**
+ * useOrgMembers — shared hook for user-pickers (share dialogs, team
+ * member modals, task assignment, DMs, etc.).
+ *
+ * Returns the active members of the caller's current org with the
+ * fields a picker needs (id, email, first_name, last_name). Scopes
+ * explicitly via `organization_memberships` rather than relying on
+ * RLS — a platform admin can legitimately *read* all users (for ops
+ * dashboards), but a picker should always show org members only,
+ * regardless of the caller's permissions. Defense in depth.
+ *
+ * Use `useOrganizationOptional` so the hook can be safely called from
+ * components rendered outside the OrganizationProvider tree (portal
+ * modals, capture overlay). Without an org context, returns an empty
+ * list — which is the correct behavior: we don't know which org's
+ * members to surface.
+ */
+
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../lib/supabase'
+import { useOrganizationOptional } from '../contexts/OrganizationContext'
+
+export interface OrgMember {
+  id: string
+  email: string | null
+  first_name: string | null
+  last_name: string | null
+}
+
+interface UseOrgMembersOptions {
+  /** Don't run the query when false. Default: true. */
+  enabled?: boolean
+  /** Filter out a specific user id from the result (e.g. the current
+   *  user, in "share with someone else" pickers). */
+  excludeUserId?: string | null | undefined
+}
+
+export function useOrgMembers({ enabled = true, excludeUserId }: UseOrgMembersOptions = {}) {
+  const orgCtx = useOrganizationOptional()
+  const currentOrgId = orgCtx?.currentOrgId ?? null
+
+  return useQuery({
+    queryKey: ['org-members', currentOrgId, excludeUserId ?? null],
+    enabled: enabled && !!currentOrgId,
+    queryFn: async (): Promise<OrgMember[]> => {
+      if (!currentOrgId) return []
+      const { data: memberships, error: memErr } = await supabase
+        .from('organization_memberships')
+        .select('user_id')
+        .eq('organization_id', currentOrgId)
+        .eq('status', 'active')
+      if (memErr) throw memErr
+      let userIds = (memberships ?? [])
+        .map((m: any) => m.user_id)
+        .filter((id: string | null): id is string => !!id)
+      if (excludeUserId) userIds = userIds.filter(id => id !== excludeUserId)
+      if (userIds.length === 0) return []
+      const { data, error } = await supabase
+        .from('users')
+        .select('id, email, first_name, last_name')
+        .in('id', userIds)
+        .order('first_name', { ascending: true })
+      if (error) throw error
+      return (data ?? []) as OrgMember[]
+    },
+  })
+}


### PR DESCRIPTION
Follow-up to fix/mention-scope-to-current-org. That PR fixed the @-mention dropdown's cross-org leak; this PR applies the same defense-in-depth pattern to every other user picker in the app, so a future Daniel-shaped pilot tester (member of multiple orgs and/or a platform admin for testing) doesn't see cross-org users in any UI dropdown.

Pattern: a new useOrgMembers hook (src/hooks/useOrgMembers.ts) queries organization_memberships filtered by currentOrgId, then loads users from those IDs. All user pickers now call this hook instead of .from('users') directly. RLS is still the outer safety net; the hook adds the inner scoping that should have been there.

Fixed user pickers (9 sites):
  - DirectMessaging (new conversation + add member)
  - ShareToUserModal (feed share dialog)
  - AddTeamMemberModal (portfolio team)
  - NewPortfolioModal (initial access step)
  - CreateProjectModal
  - CreateTeamModal
  - TaskModal + InlineTaskExtension (task assignment)
  - AssetTableView (priority column team picker)

Other .from('users') call sites (11) were triaged as safe: they look up specific users by known IDs (mention authors, log records, etc.) rather than displaying a picker, so RLS is sufficient.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
