### PR TITLE
fix(pilot): stop Trade Book tab flickering between locked/unlocked af…

### DIFF
--- a/src/components/pilot/PilotTradeBookPreview.tsx
+++ b/src/components/pilot/PilotTradeBookPreview.tsx
@@ -2,16 +2,58 @@
  * PilotTradeBookPreview — read-only teaser rendered when a pilot user opens
  * the Trade Book tab. Shows what the real surface will do once enabled,
  * without exposing the operational workflow.
+ *
+ * Self-heal: if the user lands here having already committed a trade in
+ * this org, they've earned Trade Book — mark trade_book_unlocked so the
+ * next render swaps in the real surface. Catches the case where the
+ * event-based unlock from SimulationPage's `pilot-tradelab:executed`
+ * listener missed (e.g., SimulationPage unmounted mid-dispatch on the
+ * post-execute navigation). Mirrors the same pattern used by
+ * PilotOutcomesPreview.
+ *
+ * This replaces the older unbounded self-heal that lived in
+ * usePilotMode — that one fired on every render where the conditions
+ * matched, which combined with usePilotProgress's invalidateQueries to
+ * create a visible flicker between locked and unlocked right after
+ * execute. Living inside the preview means the heal can only fire
+ * while the locked preview is mounted; the moment access flips to
+ * 'full', the preview unmounts and the heal stops, so no oscillation.
  */
 
+import { useEffect } from 'react'
 import { BookOpen, CheckCircle2, Sparkles, ArrowRight, Lock } from 'lucide-react'
 import { Button } from '../ui/Button'
+import { usePilotMode } from '../../hooks/usePilotMode'
+import { usePilotProgress } from '../../hooks/usePilotProgress'
 
 interface PilotTradeBookPreviewProps {
   onGoToTradeLab?: () => void
 }
 
 export function PilotTradeBookPreview({ onGoToTradeLab }: PilotTradeBookPreviewProps) {
+  const pilotMode = usePilotMode()
+  const { hasUnlockedTradeBook, mark } = usePilotProgress()
+
+  useEffect(() => {
+    // If we're rendering this preview but the user has already
+    // committed a trade in this org, mark trade_book_unlocked now.
+    // The mutation is idempotent so re-firing is a no-op.
+    if (
+      !pilotMode.isLoading &&
+      pilotMode.isPilot &&
+      pilotMode.hasCommittedTradeInOrg &&
+      !hasUnlockedTradeBook
+    ) {
+      mark('trade_book_unlocked')
+    }
+  }, [
+    pilotMode.isLoading,
+    pilotMode.isPilot,
+    pilotMode.hasCommittedTradeInOrg,
+    hasUnlockedTradeBook,
+    mark,
+  ])
+
   return (
     <div className="p-8 max-w-4xl mx-auto space-y-6">
       {/* Header */}

--- a/src/hooks/usePilotMode.ts
+++ b/src/hooks/usePilotMode.ts
@@ -62,7 +62,7 @@ export interface PilotModeState {
 export function usePilotMode(): PilotModeState {
   const { user } = useAuth()
   const { currentOrgId } = useOrganization()
-  const { hasUnlockedTradeBook, hasUnlockedOutcomes, hasGraduated, cachedHasGraduated, isLoading: progressLoading, mark: markPilotStage } = usePilotProgress()
+  const { hasUnlockedTradeBook, hasUnlockedOutcomes, hasGraduated, cachedHasGraduated, isLoading: progressLoading } = usePilotProgress()
 
   // Cached hint from the previous session: was this user a pilot? Read
   // synchronously on mount so we can answer "is this a pilot session?"
@@ -132,29 +132,13 @@ export function usePilotMode(): PilotModeState {
 
   const isPilot = !!orgFlags?.pilotMode
 
-  // Self-heal trade_book_unlocked. The event-based unlock fires from
-  // SimulationPage's listener on `pilot-tradelab:executed`, but if that
-  // listener missed (race condition, mutation errored silently, page
-  // navigated away mid-mutation), the user can land in a stuck state
-  // where they've committed a trade but Trade Book is still locked.
-  // Both `hasCommittedTradeInOrg` and `hasUnlockedTradeBook` are
-  // required to unlock; the existence of an accepted_trade is proof
-  // enough that execute happened, so we can safely backfill the flag.
-  // The mutation is idempotent so re-runs are no-ops.
-  //
-  // Note: outcomes_unlocked is NOT self-healed — that one represents
-  // intent ("user navigated to Outcomes"), not just trade activity.
-  useEffect(() => {
-    if (
-      isPilot &&
-      !progressLoading &&
-      !orgLoading &&
-      hasCommittedTradeInOrg &&
-      !hasUnlockedTradeBook
-    ) {
-      markPilotStage('trade_book_unlocked')
-    }
-  }, [isPilot, progressLoading, orgLoading, hasCommittedTradeInOrg, hasUnlockedTradeBook, markPilotStage])
+  // (The trade_book_unlocked self-heal previously lived here as an
+  // unbounded useEffect. It now lives inside PilotTradeBookPreview so
+  // it can only fire while the locked preview is mounted — the moment
+  // access flips to 'full', the preview unmounts and the heal stops,
+  // which prevents the visible flicker we were seeing right after
+  // execute when this effect re-fired against the brief stale-cache
+  // window created by usePilotProgress's invalidateQueries call.)
   const access = useMemo(() => {
     // Once the user has graduated, all pilot gating drops away —
     // they get the same access as a non-pilot user even though the

--- a/src/hooks/usePilotProgress.ts
+++ b/src/hooks/usePilotProgress.ts
@@ -190,8 +190,17 @@ export function usePilotProgress() {
           organizationId: currentOrgId,
         })
       }
-      // Force usePilotMode to re-resolve access
-      queryClient.invalidateQueries({ queryKey: ['pilot-progress', user?.id] })
+      // No invalidate here. The setQueryData above already writes the
+      // authoritative server response into the cache, so a refetch
+      // would just round-trip the same data. The invalidate that used
+      // to live here forced a refetch that briefly contradicted the
+      // just-applied optimistic flip, and the resulting state churn
+      // re-fired the trade_book_unlocked self-heal effect — producing
+      // the visible locked⇄unlocked flicker on the Trade Book tab
+      // right after execute. The self-heal now lives inside the
+      // preview components (PilotTradeBookPreview /
+      // PilotOutcomesPreview) so it can't fire after access has
+      // already flipped to 'full'.
     },
   })
 


### PR DESCRIPTION
…ter execute

Three coordinated changes that close the race causing the visible flicker between PilotTradeBookPreview (locked) and TradeBookPage (unlocked) right after a trade is executed.

Root cause: two independent unlock paths fighting.

  (1) Event-based: SimulationPage dispatches `pilot-tradelab:executed`
      → listener calls usePilotProgress.mark('trade_book_unlocked')
      → optimistic onMutate flips the cache → access becomes 'full'.

  (2) usePilotProgress.markStage.onSuccess then immediately called
      `queryClient.invalidateQueries(['pilot-progress'])`, forcing a
      refetch even though the same onSuccess had just written the
      authoritative server response via setQueryData.

  (3) The unbounded useEffect in usePilotMode watched
      `hasCommittedTradeInOrg && !hasUnlockedTradeBook` and re-fired
      markPilotStage every time the cache briefly looked stale during
      the refetch window from (2). Each re-fire produced another
      render cycle through locked → unlocked.

The Outcomes flow doesn't flicker because commit 34606f5 moved its self-heal into PilotOutcomesPreview — fires only while the locked preview is mounted, stops the moment access flips to 'full'. Trade Book never got the same treatment.

Changes:

- PilotTradeBookPreview now self-heals trade_book_unlocked the same way PilotOutcomesPreview self-heals outcomes_unlocked. The heal can't loop because the preview unmounts the moment it succeeds.

- The unbounded useEffect in usePilotMode is gone — its job is now done by the preview-component heal. `markPilotStage` is no longer destructured from usePilotProgress here.

- The invalidateQueries call in usePilotProgress.markStage.onSuccess is gone. `setQueryData(result.nextProgress)` is already the authoritative server response; the refetch round-trip just opened the race window.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
