### PR TITLE
fix(pilot): kill cold-load hitch by hydrating pilot state from localS…

### DIFF
--- a/src/hooks/usePilotMode.ts
+++ b/src/hooks/usePilotMode.ts
@@ -111,10 +111,28 @@ export function usePilotMode(): PilotModeState {
   // unlock into every subsequent pilot org they land in — defeating the
   // "locked until you complete a trade here" UX. Requiring at least one
   // committed trade in the current org gates unlocks per-org.
+  //
+  // Cached in localStorage per-(user, org) for synchronous hydration.
+  // The access useMemo below ANDs this with hasUnlockedTradeBook —
+  // both have to be true for Trade Book to render unlocked, so caching
+  // pilot_progress alone wasn't enough to kill the cold-load locked
+  // preview flash. Now both come back synchronously on first paint.
+  const cachedHasCommittedTrade = useMemo<boolean | null>(() => {
+    if (!user?.id || !currentOrgId) return null
+    try {
+      const raw = localStorage.getItem(`has_committed_trade_${user.id}_${currentOrgId}`)
+      return raw === '1' ? true : raw === '0' ? false : null
+    } catch {
+      return null
+    }
+  }, [user?.id, currentOrgId])
+
   const { data: hasCommittedTradeInOrg } = useQuery({
     queryKey: ['org-has-accepted-trade', currentOrgId, user?.id],
     enabled: !!currentOrgId && !!user?.id,
     staleTime: 60_000,
+    initialData: cachedHasCommittedTrade ?? undefined,
+    initialDataUpdatedAt: 0,
     queryFn: async () => {
       // accepted_trades is scoped through portfolio_id (no direct org_id
       // column), so we use an embedded filter on portfolios.organization_id.
@@ -129,6 +147,23 @@ export function usePilotMode(): PilotModeState {
       return (data?.length ?? 0) > 0
     }
   })
+
+  // Mirror the cached pilot_progress write — store '1' / '0' so the
+  // tri-state read above can distinguish "never cached" (null) from
+  // "cached false" (0). Without that distinction, a first-time user
+  // would have the cache evaluated as `false` and we'd miss the case
+  // where the cache simply doesn't exist yet.
+  useEffect(() => {
+    if (!user?.id || !currentOrgId || typeof hasCommittedTradeInOrg !== 'boolean') return
+    try {
+      localStorage.setItem(
+        `has_committed_trade_${user.id}_${currentOrgId}`,
+        hasCommittedTradeInOrg ? '1' : '0'
+      )
+    } catch {
+      /* ignore */
+    }
+  }, [user?.id, currentOrgId, hasCommittedTradeInOrg])
 
   const isPilot = !!orgFlags?.pilotMode
 

--- a/src/hooks/usePilotProgress.ts
+++ b/src/hooks/usePilotProgress.ts
@@ -85,10 +85,37 @@ export function usePilotProgress() {
   const { currentOrgId } = useOrganization()
   const queryClient = useQueryClient()
 
+  // Synchronous cache of the user's pilot_progress JSONB. Without this,
+  // a hard refresh leaves `hasUnlockedTradeBook` / `hasUnlockedOutcomes`
+  // undefined for the ~100-300ms it takes the query to resolve. During
+  // that window the System Loop computes its active stage from the
+  // missing data — so a user who's actually on Review briefly sees the
+  // strip highlight Decide, and the Trade Book tab briefly renders the
+  // locked preview before swapping to the unlocked page. Hydrating
+  // from localStorage on the first render closes the gap.
+  const cachedProgress = useMemo<PilotProgress | null>(() => {
+    if (!user?.id) return null
+    try {
+      const raw = localStorage.getItem(`pilot_progress_${user.id}`)
+      if (!raw) return null
+      const parsed = JSON.parse(raw)
+      return (typeof parsed === 'object' && parsed !== null) ? (parsed as PilotProgress) : null
+    } catch {
+      return null
+    }
+  }, [user?.id])
+
   const query = useQuery({
     queryKey: ['pilot-progress', user?.id],
     enabled: !!user?.id,
     staleTime: 60_000,
+    // initialData hydrates the first render synchronously from the
+    // localStorage snapshot. `initialDataUpdatedAt: 0` marks it as
+    // already stale so React Query still fires a background refetch
+    // on mount to reconcile with the server — but the UI doesn't flash
+    // through "undefined → real" during that fetch.
+    initialData: cachedProgress ?? undefined,
+    initialDataUpdatedAt: 0,
     queryFn: async (): Promise<PilotProgress> => {
       const { data, error } = await supabase
         .from('users')
@@ -101,6 +128,19 @@ export function usePilotProgress() {
   })
 
   const progress: PilotProgress = query.data ?? {}
+
+  // Persist the freshest progress JSONB to localStorage so the next
+  // hard refresh hydrates with the same state instead of waiting on
+  // the network round-trip. Keyed per-user; the JSONB itself already
+  // encodes the per-org stage keys, so no extra org dimension needed.
+  useEffect(() => {
+    if (!user?.id || !query.data) return
+    try {
+      localStorage.setItem(`pilot_progress_${user.id}`, JSON.stringify(query.data))
+    } catch {
+      /* ignore */
+    }
+  }, [user?.id, query.data])
 
   const markStage = useMutation({
     mutationFn: async (stage: PilotStage) => {


### PR DESCRIPTION
…torage

Hard refresh was showing visible state-snap because the two queries that drive pilot unlock gates (`pilot_progress` and `org-has-accepted-trade`) start as undefined for the first ~100-300ms while React Query fetches. During that window:

- The System Loop computed its active stage off the missing data, so a user actually on Review would briefly see the strip highlight Decide before snapping back to Review once the queries resolved.
- The Trade Book tab's access decision evaluated to 'preview' (both unlock conditions were falsy), so the locked PilotTradeBookPreview flashed for a beat before swapping to the unlocked TradeBookPage.

Both are now hydrated synchronously from localStorage on first render, mirroring the existing `was_pilot_<userId>` and
`pilot_graduated_<userId>_<orgId>` cache pattern:

- `usePilotProgress` caches the user's `pilot_progress` JSONB per-user. `initialData` + `initialDataUpdatedAt: 0` populates the query synchronously while still firing a background refetch on mount to reconcile with the server.

- `usePilotMode` caches `hasCommittedTradeInOrg` per-(user, org) as a tri-state '1' / '0' / null so a first-time user (no cache) is distinguishable from a cached `false`. Same `initialData` pattern.

Both write to localStorage in a useEffect on every successful query result, so the cache stays current as the user progresses through the loop.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
