### PR TITLE
fix(pilot): use render-time cache fallback, not React Query initialData

### DIFF
--- a/src/components/pilot/PilotActionDashboard.tsx
+++ b/src/components/pilot/PilotActionDashboard.tsx
@@ -474,11 +474,25 @@ export function PilotActionDashboard({
   })
 
   // While the pipeline query is still loading after a hard refresh,
-  // prefer the cached state so the visuals don't flicker. Once the
-  // real data arrives, swap in liveStepDone and persist it for the
-  // next refresh.
+  // prefer the cached state for stages whose inputs are still loading
+  // (capture / develop / analyze depend on pipelineItems / userCaptured
+  // / pilot_scenario_status, which aren't cached at the hook level).
+  //
+  // decide and review come from `usePilotProgress.hasUnlockedTradeBook`
+  // / `hasUnlockedOutcomes`, which ARE cached synchronously in
+  // localStorage at the hook level. Always use the live values for
+  // those two — the dashboard's own `cachedStepDone` is only updated
+  // when the dashboard is mounted with resolved queries, so a user who
+  // unlocks Decide or Review on another page (Trade Lab, Trade Book,
+  // Outcomes) before returning to the dashboard would otherwise see
+  // the System Loop highlight a stale earlier stage on the next hard
+  // refresh, then snap forward once the queries land.
   const stepDone: Record<StageKey, boolean> = pipelineLoading && cachedStepDone
-    ? cachedStepDone
+    ? {
+        ...cachedStepDone,
+        decide: liveStepDone.decide,
+        review: liveStepDone.review,
+      }
     : liveStepDone
 
   useEffect(() => {

--- a/src/hooks/usePilotMode.ts
+++ b/src/hooks/usePilotMode.ts
@@ -112,11 +112,12 @@ export function usePilotMode(): PilotModeState {
   // "locked until you complete a trade here" UX. Requiring at least one
   // committed trade in the current org gates unlocks per-org.
   //
-  // Cached in localStorage per-(user, org) for synchronous hydration.
-  // The access useMemo below ANDs this with hasUnlockedTradeBook —
+  // Cached in localStorage per-(user, org) for synchronous render-time
+  // fallback. The access useMemo below ANDs this with hasUnlockedTradeBook —
   // both have to be true for Trade Book to render unlocked, so caching
   // pilot_progress alone wasn't enough to kill the cold-load locked
-  // preview flash. Now both come back synchronously on first paint.
+  // preview flash. Tri-state ('1' / '0' / null) so first-time users
+  // (no cache) are distinguishable from a cached `false`.
   const cachedHasCommittedTrade = useMemo<boolean | null>(() => {
     if (!user?.id || !currentOrgId) return null
     try {
@@ -127,12 +128,10 @@ export function usePilotMode(): PilotModeState {
     }
   }, [user?.id, currentOrgId])
 
-  const { data: hasCommittedTradeInOrg } = useQuery({
+  const { data: hasCommittedTradeInOrgQuery } = useQuery({
     queryKey: ['org-has-accepted-trade', currentOrgId, user?.id],
     enabled: !!currentOrgId && !!user?.id,
     staleTime: 60_000,
-    initialData: cachedHasCommittedTrade ?? undefined,
-    initialDataUpdatedAt: 0,
     queryFn: async () => {
       // accepted_trades is scoped through portfolio_id (no direct org_id
       // column), so we use an embedded filter on portfolios.organization_id.
@@ -148,22 +147,30 @@ export function usePilotMode(): PilotModeState {
     }
   })
 
-  // Mirror the cached pilot_progress write — store '1' / '0' so the
-  // tri-state read above can distinguish "never cached" (null) from
-  // "cached false" (0). Without that distinction, a first-time user
-  // would have the cache evaluated as `false` and we'd miss the case
-  // where the cache simply doesn't exist yet.
+  // Effective value: real query result if we have one, otherwise the
+  // localStorage cache. Same render-time fallback pattern as
+  // `usePilotProgress.cachedProgress`. Avoids the cold-load window
+  // where `hasCommittedTradeInOrgQuery` is undefined → access drops
+  // to 'preview' → Trade Book tab flashes the locked teaser.
+  const hasCommittedTradeInOrg =
+    typeof hasCommittedTradeInOrgQuery === 'boolean'
+      ? hasCommittedTradeInOrgQuery
+      : (cachedHasCommittedTrade ?? false)
+
+  // Persist on each successful refetch so the next cold load starts
+  // from the right value. Only write when the query has actually
+  // resolved (boolean), not when we're showing the cached fallback.
   useEffect(() => {
-    if (!user?.id || !currentOrgId || typeof hasCommittedTradeInOrg !== 'boolean') return
+    if (!user?.id || !currentOrgId || typeof hasCommittedTradeInOrgQuery !== 'boolean') return
     try {
       localStorage.setItem(
         `has_committed_trade_${user.id}_${currentOrgId}`,
-        hasCommittedTradeInOrg ? '1' : '0'
+        hasCommittedTradeInOrgQuery ? '1' : '0'
       )
     } catch {
       /* ignore */
     }
-  }, [user?.id, currentOrgId, hasCommittedTradeInOrg])
+  }, [user?.id, currentOrgId, hasCommittedTradeInOrgQuery])
 
   const isPilot = !!orgFlags?.pilotMode
 

--- a/src/hooks/usePilotProgress.ts
+++ b/src/hooks/usePilotProgress.ts
@@ -85,14 +85,18 @@ export function usePilotProgress() {
   const { currentOrgId } = useOrganization()
   const queryClient = useQueryClient()
 
-  // Synchronous cache of the user's pilot_progress JSONB. Without this,
-  // a hard refresh leaves `hasUnlockedTradeBook` / `hasUnlockedOutcomes`
-  // undefined for the ~100-300ms it takes the query to resolve. During
-  // that window the System Loop computes its active stage from the
-  // missing data — so a user who's actually on Review briefly sees the
-  // strip highlight Decide, and the Trade Book tab briefly renders the
-  // locked preview before swapping to the unlocked page. Hydrating
-  // from localStorage on the first render closes the gap.
+  // Synchronous cache of the user's pilot_progress JSONB, mirroring the
+  // `cachedHasGraduated` pattern below. Used as a render-time fallback
+  // when the query hasn't resolved (or for the brief window before
+  // user.id is even available to the query). Without this, a hard
+  // refresh leaves `hasUnlockedTradeBook` / `hasUnlockedOutcomes`
+  // undefined → falsy for the ~100-300ms it takes the query to
+  // resolve; during that window the System Loop highlights the wrong
+  // active stage and the Trade Book tab briefly renders the locked
+  // preview. Render-time fallback (not React Query `initialData`) is
+  // used because the latter is captured at first useQuery call time
+  // and doesn't reliably re-apply when user.id transitions from null
+  // to set on the second render.
   const cachedProgress = useMemo<PilotProgress | null>(() => {
     if (!user?.id) return null
     try {
@@ -109,13 +113,6 @@ export function usePilotProgress() {
     queryKey: ['pilot-progress', user?.id],
     enabled: !!user?.id,
     staleTime: 60_000,
-    // initialData hydrates the first render synchronously from the
-    // localStorage snapshot. `initialDataUpdatedAt: 0` marks it as
-    // already stale so React Query still fires a background refetch
-    // on mount to reconcile with the server — but the UI doesn't flash
-    // through "undefined → real" during that fetch.
-    initialData: cachedProgress ?? undefined,
-    initialDataUpdatedAt: 0,
     queryFn: async (): Promise<PilotProgress> => {
       const { data, error } = await supabase
         .from('users')
@@ -127,7 +124,12 @@ export function usePilotProgress() {
     },
   })
 
-  const progress: PilotProgress = query.data ?? {}
+  // Effective progress: real query data when we have it, otherwise the
+  // localStorage cache. `query.data` is the server's view, `cachedProgress`
+  // is the previous session's snapshot. Falling back to the cache means
+  // every derived flag below (hasUnlockedTradeBook, hasUnlockedOutcomes,
+  // hasGraduated) returns the right value from the first paint.
+  const progress: PilotProgress = query.data ?? cachedProgress ?? {}
 
   // Persist the freshest progress JSONB to localStorage so the next
   // hard refresh hydrates with the same state instead of waiting on


### PR DESCRIPTION
The previous commit on this branch cached pilot_progress and hasCommittedTradeInOrg via React Query's `initialData` + `initialDataUpdatedAt: 0`, but the user still saw the same cold-load hitch: System Loop highlighting Decide before snapping to Review, and Trade Book flashing the locked preview.

Root cause: `initialData` is captured at the first useQuery call and doesn't reliably re-apply when `user.id` transitions from null on the very first render to populated on the second. The repo's existing `cachedHasGraduated` pattern doesn't use initialData for this reason — it falls back to the localStorage cache AT RENDER TIME wherever the derived value is computed.

This commit follows that proven pattern:

- `usePilotProgress` now computes `progress = query.data ?? cachedProgress ?? {}`. Every derived flag (hasUnlockedTradeBook, hasUnlockedOutcomes, hasGraduated) reads from `progress`, so they return the correct value from the first paint regardless of how React Query schedules its first fetch.

- `usePilotMode` renames the raw query data to `hasCommittedTradeInOrgQuery` and computes the effective value as `hasCommittedTradeInOrgQuery ?? cachedHasCommittedTrade ?? false`. Same render-time fallback shape.

- `PilotActionDashboard` no longer let the dashboard's own `cachedStepDone` shadow the now-reliable hook-cached values for decide/review. The cache is still used for capture/develop/analyze (whose inputs aren't cached yet), but decide and review always come from `liveStepDone`.

Persisted writes to localStorage are unchanged — they still fire only when the real query resolves, so a stale cache from the fallback doesn't get re-written as if it were the truth.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
