### PR TITLE
fix(pilot): hold neutral render while unlock state is unresolved

### DIFF
--- a/src/components/pilot/PilotActionDashboard.tsx
+++ b/src/components/pilot/PilotActionDashboard.tsx
@@ -150,7 +150,7 @@ export function PilotActionDashboard({
   onOpenOutcomes,
 }: PilotActionDashboardProps) {
   const { user } = useAuth()
-  const { currentOrg } = useOrganization()
+  const { currentOrg, currentOrgId } = useOrganization()
   const queryClient = useQueryClient()
   const { scenario, state, acceptedTrade, committedAt, hasReview } = usePilotScenarioStatus()
   const { hasUnlockedTradeBook, hasUnlockedOutcomes, hasReadyProgress } = usePilotProgress()
@@ -454,7 +454,17 @@ export function PilotActionDashboard({
   // v4 — bumped after thoughts with no org context were strictly
   // excluded from Capture display + signal. Old caches could still
   // hold a stale capture=true from the previous, lossier filter.
-  const stepCacheKey = `pilot_loop_steps_v4_${user?.id || 'anon'}_${currentOrg?.id || 'no-org'}`
+  //
+  // Note: we key off `currentOrgId` (synchronously derived from
+  // `user.current_organization_id` in OrganizationContext) rather
+  // than `currentOrg?.id` (which is the userOrgs-query lookup and
+  // is null on the very first render until that query resolves).
+  // The earlier version used the async value, so the useState init
+  // below baked `no-org` into the key on first paint, loaded an
+  // all-false cache, and got locked there — which is what the user
+  // observed as the System Loop briefly highlighting step 1 before
+  // the queries landed.
+  const stepCacheKey = `pilot_loop_steps_v4_${user?.id || 'anon'}_${currentOrgId || 'no-org'}`
   const [cachedStepDone, setCachedStepDone] = useState<Record<StageKey, boolean> | null>(() => {
     try {
       const raw = localStorage.getItem(stepCacheKey)

--- a/src/components/pilot/PilotActionDashboard.tsx
+++ b/src/components/pilot/PilotActionDashboard.tsx
@@ -624,28 +624,45 @@ export function PilotActionDashboard({
             Bold description + colored CTA + stage-specific
             attention items. Stays inside the same visual block as
             the loop header so the dashboard reads as one focused
-            surface, not a stack of panels. */}
-        <StagePanel
-          stage={openStage}
-          cta={ctaForStage(openStage.key)}
-          state={state}
-          scenario={scenario}
-          acceptedTrade={acceptedTrade}
-          committedAt={committedAt}
-          hasReview={hasReview}
-          pipelineItems={pipelineItems || []}
-          pipelineLoading={pipelineLoading}
-          recorded={recordedDecisions ?? null}
-          userCaptured={userCaptured ?? null}
-          userIdeasFromPipeline={userIdeasFromPipeline}
-          onOpenTradeLab={() => onOpenTradeLab(scenarioContext)}
-          onOpenIdeaPipeline={onOpenIdeaPipeline}
-          onOpenTradeBook={onOpenTradeBook}
-          onOpenOutcomes={onOpenOutcomes}
-          onCapture={openCapture}
-          hasUnlockedTradeBook={hasUnlockedTradeBook}
-          hasUnlockedOutcomes={hasUnlockedOutcomes}
-        />
+            surface, not a stack of panels.
+
+            While `hasReadyProgress` is false (cold-load window: no
+            cache and queries still pending) the `openKey` driving
+            this panel is computed from undefined unlock flags, so it
+            defaults to the first incomplete stage — which during
+            loading is whichever stage we haven't proven complete yet,
+            i.e. NOT the user's actual stage. Rendering the real panel
+            here would flash that wrong stage's content. A min-height
+            placeholder preserves layout without showing wrong data;
+            once readiness flips, the real panel takes over. */}
+        {hasReadyProgress ? (
+          <StagePanel
+            stage={openStage}
+            cta={ctaForStage(openStage.key)}
+            state={state}
+            scenario={scenario}
+            acceptedTrade={acceptedTrade}
+            committedAt={committedAt}
+            hasReview={hasReview}
+            pipelineItems={pipelineItems || []}
+            pipelineLoading={pipelineLoading}
+            recorded={recordedDecisions ?? null}
+            userCaptured={userCaptured ?? null}
+            userIdeasFromPipeline={userIdeasFromPipeline}
+            onOpenTradeLab={() => onOpenTradeLab(scenarioContext)}
+            onOpenIdeaPipeline={onOpenIdeaPipeline}
+            onOpenTradeBook={onOpenTradeBook}
+            onOpenOutcomes={onOpenOutcomes}
+            onCapture={openCapture}
+            hasUnlockedTradeBook={hasUnlockedTradeBook}
+            hasUnlockedOutcomes={hasUnlockedOutcomes}
+          />
+        ) : (
+          <section
+            className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm min-h-[320px]"
+            aria-busy="true"
+          />
+        )}
       </div>
     </div>
   )

--- a/src/components/pilot/PilotActionDashboard.tsx
+++ b/src/components/pilot/PilotActionDashboard.tsx
@@ -526,6 +526,25 @@ export function PilotActionDashboard({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pipelineLoading, liveStepDone.capture, liveStepDone.develop, liveStepDone.decide, liveStepDone.review, liveStepDone.analyze, stepCacheKey])
 
+  // TEMP DEBUG — pair with the [pilot-debug] log in usePilotProgress.
+  // Shows what stepDone/activeKey/openKey resolve to on each render
+  // so we can spot which input is producing the wrong stage.
+  if (typeof window !== 'undefined') {
+    // eslint-disable-next-line no-console
+    console.log('[pilot-debug] dashboard render', {
+      pipelineLoading,
+      hasReadyProgress,
+      stepCacheKey,
+      cachedStepDone,
+      liveStepDone,
+      stepDone,
+      hasUserIdea,
+      hasMovedIdea,
+      hasUnlockedTradeBook,
+      hasUnlockedOutcomes,
+    })
+  }
+
   // First incomplete step is the active one. The pilot lands on
   // Capture by default — if NOTHING is done yet, that's where the
   // pulse lives. (Previously we jumped to Decide for new pilots,
@@ -543,6 +562,17 @@ export function PilotActionDashboard({
   // Open stage = whatever the user clicked (defaults to active).
   const [openKey, setOpenKey] = useState<StageKey>(activeKey)
   const openStage = STAGES.find(s => s.key === openKey) ?? STAGES[0]
+
+  // TEMP DEBUG — log the derived active/open keys so we can confirm
+  // what's actually driving the visible stage highlight.
+  if (typeof window !== 'undefined') {
+    // eslint-disable-next-line no-console
+    console.log('[pilot-debug] dashboard keys', {
+      activeKey,
+      openKey,
+      openStageLabel: openStage.label,
+    })
+  }
 
   // Auto-advance: only fire on the *actual* transition from undone
   // → done for whichever stage is currently open. Track the previous

--- a/src/components/pilot/PilotActionDashboard.tsx
+++ b/src/components/pilot/PilotActionDashboard.tsx
@@ -484,25 +484,37 @@ export function PilotActionDashboard({
   })
 
   // While the pipeline query is still loading after a hard refresh,
-  // prefer the cached state for stages whose inputs are still loading
-  // (capture / develop / analyze depend on pipelineItems / userCaptured
-  // / pilot_scenario_status, which aren't cached at the hook level).
+  // build stepDone from whichever signals we actually have
+  // synchronously.
   //
-  // decide and review come from `usePilotProgress.hasUnlockedTradeBook`
-  // / `hasUnlockedOutcomes`, which ARE cached synchronously in
-  // localStorage at the hook level. Always use the live values for
-  // those two — the dashboard's own `cachedStepDone` is only updated
-  // when the dashboard is mounted with resolved queries, so a user who
-  // unlocks Decide or Review on another page (Trade Lab, Trade Book,
-  // Outcomes) before returning to the dashboard would otherwise see
-  // the System Loop highlight a stale earlier stage on the next hard
-  // refresh, then snap forward once the queries land.
-  const stepDone: Record<StageKey, boolean> = pipelineLoading && cachedStepDone
-    ? {
-        ...cachedStepDone,
-        decide: liveStepDone.decide,
-        review: liveStepDone.review,
-      }
+  // decide / review come from usePilotProgress which now hydrates
+  // from user.pilot_progress in the auth cache, so they're always
+  // correct from frame one.
+  //
+  // capture / develop normally come from pipelineItems / userCaptured,
+  // which ARE async. If we have a cachedStepDone snapshot from a
+  // prior dashboard mount, use those values. If we don't, derive
+  // them by IMPLICATION from the unlock flags: a user can only
+  // unlock decide (trade book) by completing capture + develop +
+  // executing a trade, so if decide is unlocked those earlier
+  // stages must be complete too. Same for review implying capture
+  // / develop / decide. This keeps the loop on the correct active
+  // stage even when no prior dashboard cache exists, instead of
+  // briefly highlighting capture/develop as incomplete.
+  const stepDone: Record<StageKey, boolean> = pipelineLoading
+    ? (cachedStepDone
+        ? {
+            ...cachedStepDone,
+            decide: liveStepDone.decide,
+            review: liveStepDone.review,
+          }
+        : {
+            capture: liveStepDone.capture || liveStepDone.decide || liveStepDone.review,
+            develop: liveStepDone.develop || liveStepDone.decide || liveStepDone.review,
+            decide:  liveStepDone.decide,
+            review:  liveStepDone.review,
+            analyze: liveStepDone.analyze,
+          })
     : liveStepDone
 
   useEffect(() => {

--- a/src/components/pilot/PilotActionDashboard.tsx
+++ b/src/components/pilot/PilotActionDashboard.tsx
@@ -153,7 +153,7 @@ export function PilotActionDashboard({
   const { currentOrg } = useOrganization()
   const queryClient = useQueryClient()
   const { scenario, state, acceptedTrade, committedAt, hasReview } = usePilotScenarioStatus()
-  const { hasUnlockedTradeBook, hasUnlockedOutcomes } = usePilotProgress()
+  const { hasUnlockedTradeBook, hasUnlockedOutcomes, hasReadyProgress } = usePilotProgress()
 
   // Listen for cross-component refresh signals (e.g., user submitted a
   // trade idea in the right-hand capture sidebar). Without this, the
@@ -609,6 +609,15 @@ export function PilotActionDashboard({
           activeKey={activeKey}
           openKey={openKey}
           onSelect={setOpenKey}
+          // While the unlock-flag queries haven't resolved AND we have
+          // no localStorage cache to fall back on, the computed
+          // activeKey can briefly point at a stage the user is actually
+          // past (e.g. Decide instead of Review on hard refresh,
+          // because hasUnlockedTradeBook reads as false until the
+          // query lands). Pass `loading` so the strip renders neutral
+          // — no active pulse, no checkmarks — for that brief window
+          // and snaps to the correct state once the data arrives.
+          loading={!hasReadyProgress}
         />
 
         {/* ── Selected-stage panel ───────────────────────────────
@@ -650,12 +659,16 @@ function SystemLoopCard({
   activeKey,
   openKey,
   onSelect,
+  loading = false,
 }: {
   stages: StageMeta[]
   stepDone: Record<StageKey, boolean>
   activeKey: StageKey
   openKey: StageKey
   onSelect: (key: StageKey) => void
+  /** Render neutral cards (no active pulse, no checkmarks) while the
+   *  unlock-flag data isn't trustworthy yet — see PilotActionDashboard. */
+  loading?: boolean
 }) {
   return (
     <section className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 shadow-sm overflow-hidden">
@@ -678,9 +691,13 @@ function SystemLoopCard({
         <div className="grid grid-cols-5 gap-1.5 items-stretch">
           {stages.map((s, i) => {
             const Icon = s.icon
-            const done = stepDone[s.key]
-            const isActive = s.key === activeKey && !done
-            const isOpen = s.key === openKey
+            // During the cold-load window, force every stage to render
+            // as the neutral "not done / not active" variant so the
+            // user doesn't see the wrong stage briefly pulsed before
+            // the queries land and snap the strip forward.
+            const done = loading ? false : stepDone[s.key]
+            const isActive = !loading && s.key === activeKey && !done
+            const isOpen = !loading && s.key === openKey
             // Visual state precedence: open > active (pulse) > done > neutral.
             // Note: every state keeps `border` at 1px width — the active
             // state uses `ring-2` (which paints outside the border box,

--- a/src/components/pilot/PilotActionDashboard.tsx
+++ b/src/components/pilot/PilotActionDashboard.tsx
@@ -33,6 +33,7 @@ import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
 import { useOrganization } from '../../contexts/OrganizationContext'
 import { usePilotProgress } from '../../hooks/usePilotProgress'
+import { usePilotMode } from '../../hooks/usePilotMode'
 import { usePilotScenarioStatus, type PilotScenarioState } from '../../hooks/usePilotScenarioStatus'
 
 interface PilotActionDashboardProps {
@@ -154,6 +155,16 @@ export function PilotActionDashboard({
   const queryClient = useQueryClient()
   const { scenario, state, acceptedTrade, committedAt, hasReview } = usePilotScenarioStatus()
   const { hasUnlockedTradeBook, hasUnlockedOutcomes, hasReadyProgress } = usePilotProgress()
+  // `hasCommittedTradeInOrg` comes from a separate accepted_trades
+  // query AND is cached in localStorage synchronously. We use it as an
+  // immediate fallback for `hasUnlockedTradeBook` in the System Loop
+  // below — a user who's committed a trade in this org HAS earned the
+  // decide stage even when `pilot_progress.trade_book_unlocked_at_<orgId>`
+  // is briefly missing (the self-heal in usePilotMode writes it, but
+  // not before the first paint). Without this, the loop briefly
+  // highlights decide as the active (incomplete) stage on every
+  // cold load before the heal lands.
+  const { hasCommittedTradeInOrg } = usePilotMode()
 
   // Listen for cross-component refresh signals (e.g., user submitted a
   // trade idea in the right-hand capture sidebar). Without this, the
@@ -440,7 +451,15 @@ export function PilotActionDashboard({
   const liveStepDone: Record<StageKey, boolean> = {
     capture: hasUserIdea,
     develop: hasMovedIdea,
-    decide:  hasUnlockedTradeBook,
+    // Either a marked pilot_progress flag OR a real committed trade
+    // in this org is sufficient evidence that decide is complete. The
+    // committed-trade signal is cached synchronously and available on
+    // first paint, while the per-org pilot_progress key sometimes lags
+    // behind reality and gets re-written by the self-heal in
+    // usePilotMode. Reading both means the loop reflects the truth
+    // immediately on cold load instead of flickering through decide
+    // first while waiting for the heal.
+    decide:  hasUnlockedTradeBook || hasCommittedTradeInOrg,
     review:  hasUnlockedOutcomes,
     analyze: completed && hasReview,
   }

--- a/src/components/pilot/PilotActionDashboard.tsx
+++ b/src/components/pilot/PilotActionDashboard.tsx
@@ -526,25 +526,6 @@ export function PilotActionDashboard({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pipelineLoading, liveStepDone.capture, liveStepDone.develop, liveStepDone.decide, liveStepDone.review, liveStepDone.analyze, stepCacheKey])
 
-  // TEMP DEBUG — pair with the [pilot-debug] log in usePilotProgress.
-  // Shows what stepDone/activeKey/openKey resolve to on each render
-  // so we can spot which input is producing the wrong stage.
-  if (typeof window !== 'undefined') {
-    // eslint-disable-next-line no-console
-    console.log('[pilot-debug] dashboard render', {
-      pipelineLoading,
-      hasReadyProgress,
-      stepCacheKey,
-      cachedStepDone,
-      liveStepDone,
-      stepDone,
-      hasUserIdea,
-      hasMovedIdea,
-      hasUnlockedTradeBook,
-      hasUnlockedOutcomes,
-    })
-  }
-
   // First incomplete step is the active one. The pilot lands on
   // Capture by default — if NOTHING is done yet, that's where the
   // pulse lives. (Previously we jumped to Decide for new pilots,
@@ -562,17 +543,6 @@ export function PilotActionDashboard({
   // Open stage = whatever the user clicked (defaults to active).
   const [openKey, setOpenKey] = useState<StageKey>(activeKey)
   const openStage = STAGES.find(s => s.key === openKey) ?? STAGES[0]
-
-  // TEMP DEBUG — log the derived active/open keys so we can confirm
-  // what's actually driving the visible stage highlight.
-  if (typeof window !== 'undefined') {
-    // eslint-disable-next-line no-console
-    console.log('[pilot-debug] dashboard keys', {
-      activeKey,
-      openKey,
-      openStageLabel: openStage.label,
-    })
-  }
 
   // Auto-advance: only fire on the *actual* transition from undone
   // → done for whichever stage is currently open. Track the previous

--- a/src/hooks/usePilotMode.ts
+++ b/src/hooks/usePilotMode.ts
@@ -245,7 +245,9 @@ export function usePilotMode(): PilotModeState {
   // wrong-state preview (Trade Book locked) or wrong-stage strip
   // (Decide instead of Review).
   const accessIsReady =
-    hasReadyProgress && (typeof hasCommittedTradeInOrgQuery === 'boolean' || cachedHasCommittedTrade != null)
+    hasReadyProgress
+    && !!currentOrgId
+    && (typeof hasCommittedTradeInOrgQuery === 'boolean' || cachedHasCommittedTrade != null)
 
   return {
     isPilot,

--- a/src/hooks/usePilotMode.ts
+++ b/src/hooks/usePilotMode.ts
@@ -36,6 +36,14 @@ export interface PilotModeState {
    *  `effectiveIsPilot=true` and `effectiveIsPilot=false` are best-guesses
    *  with no information backing them. */
   isInitialResolve: boolean
+  /** True once the per-feature access decision is trustworthy on this
+   *  paint. False during the cold-load window where the unlock queries
+   *  haven't returned AND we have no localStorage cache to fall back on.
+   *  Pilot-aware surfaces (Trade Book / Outcomes preview gating, System
+   *  Loop active stage) should hold a neutral render until this flips
+   *  true; otherwise they flash the wrong gate state for ~200ms before
+   *  snapping to the right one. */
+  accessIsReady: boolean
   /** Best-effort "is pilot" that falls back to a cached hint from the
    *  previous session while the real query is still loading. Use this for
    *  UI gates that must stay stable across a cold refresh (e.g. hiding the
@@ -62,7 +70,7 @@ export interface PilotModeState {
 export function usePilotMode(): PilotModeState {
   const { user } = useAuth()
   const { currentOrgId } = useOrganization()
-  const { hasUnlockedTradeBook, hasUnlockedOutcomes, hasGraduated, cachedHasGraduated, isLoading: progressLoading } = usePilotProgress()
+  const { hasUnlockedTradeBook, hasUnlockedOutcomes, hasGraduated, cachedHasGraduated, isLoading: progressLoading, hasReadyProgress } = usePilotProgress()
 
   // Cached hint from the previous session: was this user a pilot? Read
   // synchronously on mount so we can answer "is this a pilot session?"
@@ -228,10 +236,23 @@ export function usePilotMode(): PilotModeState {
 
   const isInitialResolve = isLoading && !hasCachedPilotHint && !cachedHasGraduated
 
+  // True when the access decision is trustworthy on first paint —
+  // either both unlock signals have actually resolved (we have real
+  // server data) or the localStorage cache fallback has both pieces
+  // (we know what to render without waiting). False during the
+  // cold-load window where queries are pending AND we have no cache,
+  // which is when callers should hold rendering rather than flash a
+  // wrong-state preview (Trade Book locked) or wrong-stage strip
+  // (Decide instead of Review).
+  const accessIsReady =
+    hasReadyProgress && (typeof hasCommittedTradeInOrgQuery === 'boolean' || cachedHasCommittedTrade != null)
+
   return {
     isPilot,
     isLoading,
     isInitialResolve,
+    /** See comment on `accessIsReady` above. */
+    accessIsReady,
     effectiveIsPilot,
     hasCommittedTradeInOrg: !!hasCommittedTradeInOrg,
     /** Once true, the user has finished the pilot loop and the app

--- a/src/hooks/usePilotMode.ts
+++ b/src/hooks/usePilotMode.ts
@@ -10,7 +10,7 @@
  * override at organizations.settings.pilot_access.
  */
 
-import { useEffect, useMemo } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../lib/supabase'
 import { useAuth } from './useAuth'
@@ -70,7 +70,7 @@ export interface PilotModeState {
 export function usePilotMode(): PilotModeState {
   const { user } = useAuth()
   const { currentOrgId } = useOrganization()
-  const { hasUnlockedTradeBook, hasUnlockedOutcomes, hasGraduated, cachedHasGraduated, isLoading: progressLoading, hasReadyProgress } = usePilotProgress()
+  const { hasUnlockedTradeBook, hasUnlockedOutcomes, hasGraduated, cachedHasGraduated, isLoading: progressLoading, hasReadyProgress, mark: markPilotStage } = usePilotProgress()
 
   // Cached hint from the previous session: was this user a pilot? Read
   // synchronously on mount so we can answer "is this a pilot session?"
@@ -182,13 +182,43 @@ export function usePilotMode(): PilotModeState {
 
   const isPilot = !!orgFlags?.pilotMode
 
-  // (The trade_book_unlocked self-heal previously lived here as an
-  // unbounded useEffect. It now lives inside PilotTradeBookPreview so
-  // it can only fire while the locked preview is mounted — the moment
-  // access flips to 'full', the preview unmounts and the heal stops,
-  // which prevents the visible flicker we were seeing right after
-  // execute when this effect re-fired against the brief stale-cache
-  // window created by usePilotProgress's invalidateQueries call.)
+  // Self-heal trade_book_unlocked at the hook level so the dashboard
+  // (and any other pilot surface that isn't the locked Trade Book
+  // preview) recovers when `pilot_progress.trade_book_unlocked_at_<orgId>`
+  // is missing for the current org despite the user having committed
+  // a trade in it. Symptom we saw repeatedly: the System Loop stayed
+  // stuck on Decide because hasUnlockedTradeBook resolved false, and
+  // only flipped to the correct stage after the user opened the Trade
+  // Book tab (whose own self-heal in PilotTradeBookPreview wrote the
+  // missing per-org key). With the heal here too, the dashboard
+  // recovers on its own.
+  //
+  // Bounded by a ref so we mark at most once per session — the
+  // mark mutation is idempotent server-side, but firing it on every
+  // matching render still produces unnecessary cache churn. The
+  // earlier flicker that drove us to remove this effect was caused
+  // by usePilotProgress.markStage.onSuccess re-invalidating the
+  // query right after writing it; that invalidate is now gone (see
+  // commit history on usePilotProgress), so the heal can live here
+  // safely again.
+  const tradeBookHealFiredRef = useRef(false)
+  useEffect(() => {
+    if (tradeBookHealFiredRef.current) return
+    if (!isPilot || progressLoading || orgLoading) return
+    if (!hasReadyProgress) return
+    if (!hasCommittedTradeInOrg) return
+    if (hasUnlockedTradeBook) return
+    tradeBookHealFiredRef.current = true
+    markPilotStage('trade_book_unlocked')
+  }, [
+    isPilot,
+    progressLoading,
+    orgLoading,
+    hasReadyProgress,
+    hasCommittedTradeInOrg,
+    hasUnlockedTradeBook,
+    markPilotStage,
+  ])
   const access = useMemo(() => {
     // Once the user has graduated, all pilot gating drops away —
     // they get the same access as a non-pilot user even though the

--- a/src/hooks/usePilotProgress.ts
+++ b/src/hooks/usePilotProgress.ts
@@ -110,14 +110,18 @@ export function usePilotProgress() {
     },
   })
 
-  // Effective progress: real query data when we have it, otherwise
-  // the synchronous snapshot from the auth cache. `query.data` is
-  // the server's view; `userPilotProgress` is the snapshot taken
-  // at last useAuth refetch. Falling back to it means every derived
-  // flag below (hasUnlockedTradeBook, hasUnlockedOutcomes,
-  // hasGraduated) returns the right value from the very first paint
-  // for any authenticated user — no separate cache write needed.
-  const progress: PilotProgress = query.data ?? userPilotProgress ?? {}
+  // Effective progress: merge the auth cache snapshot UNDER the live
+  // query result, so the query takes precedence per-key but anything
+  // it's missing falls back to the cache. We deliberately spread
+  // rather than `query.data ?? userPilotProgress`, because the
+  // queryFn returns `{}` on any error/RLS hiccup — and `{}` is
+  // truthy, which would shadow the auth-cache value entirely and
+  // drop us back into the same flicker. Spreading means even a
+  // briefly-empty query response doesn't wipe known unlock flags.
+  const progress: PilotProgress = {
+    ...(userPilotProgress ?? {}),
+    ...(query.data ?? {}),
+  }
 
   const markStage = useMutation({
     mutationFn: async (stage: PilotStage) => {

--- a/src/hooks/usePilotProgress.ts
+++ b/src/hooks/usePilotProgress.ts
@@ -123,31 +123,6 @@ export function usePilotProgress() {
     ...(query.data ?? {}),
   }
 
-  // TEMP DEBUG — diagnosing the cold-load stage flicker. Logs each
-  // render of usePilotProgress so we can see whether user.pilot_progress
-  // is actually present on first paint, what currentOrgId resolves to,
-  // and whether the per-org unlock lookup actually finds its key.
-  // Remove after the bug is understood.
-  if (typeof window !== 'undefined') {
-    const tbKey = `trade_book_unlocked_at_${currentOrgId || 'no-org'}`
-    const ocKey = `outcomes_unlocked_at_${currentOrgId || 'no-org'}`
-    // eslint-disable-next-line no-console
-    console.log('[pilot-debug] usePilotProgress render', {
-      userId: user?.id ?? null,
-      currentOrgId: currentOrgId ?? null,
-      hasUserPilotProgressOnUser: userPilotProgress !== undefined,
-      userPilotProgressKeys: userPilotProgress ? Object.keys(userPilotProgress) : null,
-      queryStatus: { isLoading: query.isLoading, isFetching: query.isFetching, hasData: query.data !== undefined },
-      progressKeys: Object.keys(progress),
-      tbKey,
-      ocKey,
-      tradeBookValue: progress[tbKey] ?? null,
-      outcomesValue: progress[ocKey] ?? null,
-      hasUnlockedTradeBook: !!progress[tbKey],
-      hasUnlockedOutcomes: !!progress[ocKey],
-    })
-  }
-
   const markStage = useMutation({
     mutationFn: async (stage: PilotStage) => {
       if (!user?.id) return

--- a/src/hooks/usePilotProgress.ts
+++ b/src/hooks/usePilotProgress.ts
@@ -282,11 +282,20 @@ export function usePilotProgress() {
     progress,
     isLoading: query.isLoading,
     /** True when we have any source of truth for the unlock flags —
-     *  either the query resolved, or the localStorage cache had a
-     *  snapshot to fall back on. False during the brief cold-load
-     *  window where neither exists, which is when consumers should
-     *  hold rendering rather than flash a wrong gate decision. */
-    hasReadyProgress: !query.isLoading || cachedProgress != null,
+     *  either the query has resolved (query.data is defined, even as
+     *  {}), or the localStorage cache had a snapshot to fall back on.
+     *  False during the brief cold-load window where neither exists,
+     *  which is when consumers should hold rendering rather than flash
+     *  a wrong gate decision.
+     *
+     *  Implementation note: we check `query.data !== undefined` rather
+     *  than `!query.isLoading` because React Query reports
+     *  `isLoading: false` whenever the query is disabled (`enabled:
+     *  false`), including the transient render where `user?.id` hasn't
+     *  hydrated yet. Inverting isLoading made the flag spuriously
+     *  truthy in that window, which collapsed every defense on this
+     *  branch back to the same flicker the user was seeing. */
+    hasReadyProgress: query.data !== undefined || cachedProgress != null,
     hasUnlockedTradeBook: !!progress[tradeBookUnlockedKey(currentOrgId)],
     hasUnlockedOutcomes: !!progress[outcomesUnlockedKey(currentOrgId)],
     /** Per-org: true only if the user has reached Outcomes in the

--- a/src/hooks/usePilotProgress.ts
+++ b/src/hooks/usePilotProgress.ts
@@ -27,7 +27,7 @@
  * cleared via the Reset Progress button on OpsPilotPanel.
  */
 
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import * as Sentry from '@sentry/react'
 import { supabase } from '../lib/supabase'
@@ -123,29 +123,50 @@ export function usePilotProgress() {
     ...(query.data ?? {}),
   }
 
+  // Per-stage write tracker. Once we've kicked off a DB write for a
+  // (stage, org) pair in this session, every subsequent mutate() for
+  // the same key bails before issuing another network request — this
+  // is what dedupes a burst of useEffect re-fires (the original cause
+  // of the 10K-row pileup in pilot_telemetry_events). The set is
+  // checked synchronously, so even concurrent in-flight calls in the
+  // same microtask coordinate correctly.
+  //
+  // We can't dedupe by reading the cache anymore, because `onMutate`
+  // below sets the cache optimistically BEFORE this mutationFn runs.
+  // The previous version checked `queryClient.getQueryData(...)` here
+  // and so always bailed — onMutate flipped the cache, mutationFn saw
+  // the key, returned without writing, and the DB never got the
+  // unlock timestamp. That manifested downstream as per-org pilot
+  // flags vanishing on the next hard refresh (graduated_at_<orgId>,
+  // trade_book_unlocked_at_<orgId>, etc.).
+  const writeInFlightRef = useRef<Set<string>>(new Set())
+
   const markStage = useMutation({
     mutationFn: async (stage: PilotStage) => {
       if (!user?.id) return
       // All three stages are per-org (see file header).
       const key = stageToKey(stage, currentOrgId)
-      // Re-read the LATEST cached progress at mutate time rather than
-      // closing over the render-time `progress` const. Without this,
-      // a burst of useEffect re-fires (DecisionAccountabilityPage's
-      // graduation effect, the sequential-gate listeners) all see an
-      // empty `progress` closure from the same render and each one
-      // independently writes + logs, producing the 10K-row pileup we
-      // saw in pilot_telemetry_events. Pulling from the cache means
-      // the second call in the burst sees the just-written timestamp
-      // and bails before doing a DB write.
-      const latest = queryClient.getQueryData<PilotProgress>(['pilot-progress', user.id]) ?? progress
-      if (latest[key]) return
+      // Burst dedup — see writeInFlightRef comment above.
+      if (writeInFlightRef.current.has(key)) return
+      // Closure-captured `progress` is the snapshot at this render,
+      // BEFORE onMutate ran. If the key was already set then, this
+      // call is a re-fire of an already-completed mark — skip.
+      if (progress[key]) return
+      writeInFlightRef.current.add(key)
 
-      const nextProgress: PilotProgress = { ...latest, [key]: new Date().toISOString() }
-      const { error } = await supabase
-        .from('users')
-        .update({ pilot_progress: nextProgress })
-        .eq('id', user.id)
-      if (error) throw error
+      const nextProgress: PilotProgress = { ...progress, [key]: new Date().toISOString() }
+      try {
+        const { error } = await supabase
+          .from('users')
+          .update({ pilot_progress: nextProgress })
+          .eq('id', user.id)
+        if (error) throw error
+      } catch (err) {
+        // Allow retry on failure — keeping the ref locked here would
+        // leave the user stuck if the first attempt errored.
+        writeInFlightRef.current.delete(key)
+        throw err
+      }
       // Return the writer's stage so onSuccess can log telemetry exactly
       // once per real first-time unlock. (mutationFn used to call
       // logPilotEvent directly, which fired for every duplicate burst

--- a/src/hooks/usePilotProgress.ts
+++ b/src/hooks/usePilotProgress.ts
@@ -85,29 +85,15 @@ export function usePilotProgress() {
   const { currentOrgId } = useOrganization()
   const queryClient = useQueryClient()
 
-  // Synchronous cache of the user's pilot_progress JSONB, mirroring the
-  // `cachedHasGraduated` pattern below. Used as a render-time fallback
-  // when the query hasn't resolved (or for the brief window before
-  // user.id is even available to the query). Without this, a hard
-  // refresh leaves `hasUnlockedTradeBook` / `hasUnlockedOutcomes`
-  // undefined → falsy for the ~100-300ms it takes the query to
-  // resolve; during that window the System Loop highlights the wrong
-  // active stage and the Trade Book tab briefly renders the locked
-  // preview. Render-time fallback (not React Query `initialData`) is
-  // used because the latter is captured at first useQuery call time
-  // and doesn't reliably re-apply when user.id transitions from null
-  // to set on the second render.
-  const cachedProgress = useMemo<PilotProgress | null>(() => {
-    if (!user?.id) return null
-    try {
-      const raw = localStorage.getItem(`pilot_progress_${user.id}`)
-      if (!raw) return null
-      const parsed = JSON.parse(raw)
-      return (typeof parsed === 'object' && parsed !== null) ? (parsed as PilotProgress) : null
-    } catch {
-      return null
-    }
-  }, [user?.id])
+  // The auth-user-cache (populated synchronously by useAuth via
+  // getCachedUser()) already embeds the full users row, including the
+  // pilot_progress JSONB column. Earlier commits on this branch built
+  // a parallel `pilot_progress_<userId>` localStorage cache for the
+  // same data — a redundant layer that frequently sat empty on the
+  // first session under a new build, defeating every readiness gate
+  // downstream. Read pilot_progress straight off `user` instead:
+  // it's always there as long as the user is authenticated.
+  const userPilotProgress = (user as any)?.pilot_progress as PilotProgress | undefined
 
   const query = useQuery({
     queryKey: ['pilot-progress', user?.id],
@@ -124,25 +110,14 @@ export function usePilotProgress() {
     },
   })
 
-  // Effective progress: real query data when we have it, otherwise the
-  // localStorage cache. `query.data` is the server's view, `cachedProgress`
-  // is the previous session's snapshot. Falling back to the cache means
-  // every derived flag below (hasUnlockedTradeBook, hasUnlockedOutcomes,
-  // hasGraduated) returns the right value from the first paint.
-  const progress: PilotProgress = query.data ?? cachedProgress ?? {}
-
-  // Persist the freshest progress JSONB to localStorage so the next
-  // hard refresh hydrates with the same state instead of waiting on
-  // the network round-trip. Keyed per-user; the JSONB itself already
-  // encodes the per-org stage keys, so no extra org dimension needed.
-  useEffect(() => {
-    if (!user?.id || !query.data) return
-    try {
-      localStorage.setItem(`pilot_progress_${user.id}`, JSON.stringify(query.data))
-    } catch {
-      /* ignore */
-    }
-  }, [user?.id, query.data])
+  // Effective progress: real query data when we have it, otherwise
+  // the synchronous snapshot from the auth cache. `query.data` is
+  // the server's view; `userPilotProgress` is the snapshot taken
+  // at last useAuth refetch. Falling back to it means every derived
+  // flag below (hasUnlockedTradeBook, hasUnlockedOutcomes,
+  // hasGraduated) returns the right value from the very first paint
+  // for any authenticated user — no separate cache write needed.
+  const progress: PilotProgress = query.data ?? userPilotProgress ?? {}
 
   const markStage = useMutation({
     mutationFn: async (stage: PilotStage) => {
@@ -283,20 +258,13 @@ export function usePilotProgress() {
     isLoading: query.isLoading,
     /** True when we have any source of truth for the unlock flags —
      *  either the query has resolved (query.data is defined, even as
-     *  {}), or the localStorage cache had a snapshot to fall back on.
-     *  False during the brief cold-load window where neither exists,
-     *  which is when consumers should hold rendering rather than flash
-     *  a wrong gate decision.
-     *
-     *  Requires user.id to be set. Without that gate, the very first
-     *  render after a fresh login/hard-refresh evaluates as "ready"
-     *  even though both the query is disabled AND the cache useMemo
-     *  short-circuits on the null user.id — leaving downstream code
-     *  to render against empty data, which is exactly the case where
-     *  the user kept seeing the strip flash step 1 / step 3 before
-     *  snapping to step 4. */
+     *  {}), or the synchronous snapshot from the auth user cache is
+     *  present. The latter is the common case for any authenticated
+     *  user: useAuth hydrates `user.pilot_progress` from
+     *  localStorage on the very first render, so we have data to
+     *  read from before the React Query fetch even starts. */
     hasReadyProgress:
-      !!user?.id && (query.data !== undefined || cachedProgress != null),
+      !!user?.id && (query.data !== undefined || userPilotProgress !== undefined),
     hasUnlockedTradeBook: !!progress[tradeBookUnlockedKey(currentOrgId)],
     hasUnlockedOutcomes: !!progress[outcomesUnlockedKey(currentOrgId)],
     /** Per-org: true only if the user has reached Outcomes in the

--- a/src/hooks/usePilotProgress.ts
+++ b/src/hooks/usePilotProgress.ts
@@ -288,14 +288,15 @@ export function usePilotProgress() {
      *  which is when consumers should hold rendering rather than flash
      *  a wrong gate decision.
      *
-     *  Implementation note: we check `query.data !== undefined` rather
-     *  than `!query.isLoading` because React Query reports
-     *  `isLoading: false` whenever the query is disabled (`enabled:
-     *  false`), including the transient render where `user?.id` hasn't
-     *  hydrated yet. Inverting isLoading made the flag spuriously
-     *  truthy in that window, which collapsed every defense on this
-     *  branch back to the same flicker the user was seeing. */
-    hasReadyProgress: query.data !== undefined || cachedProgress != null,
+     *  Requires user.id to be set. Without that gate, the very first
+     *  render after a fresh login/hard-refresh evaluates as "ready"
+     *  even though both the query is disabled AND the cache useMemo
+     *  short-circuits on the null user.id — leaving downstream code
+     *  to render against empty data, which is exactly the case where
+     *  the user kept seeing the strip flash step 1 / step 3 before
+     *  snapping to step 4. */
+    hasReadyProgress:
+      !!user?.id && (query.data !== undefined || cachedProgress != null),
     hasUnlockedTradeBook: !!progress[tradeBookUnlockedKey(currentOrgId)],
     hasUnlockedOutcomes: !!progress[outcomesUnlockedKey(currentOrgId)],
     /** Per-org: true only if the user has reached Outcomes in the

--- a/src/hooks/usePilotProgress.ts
+++ b/src/hooks/usePilotProgress.ts
@@ -281,6 +281,12 @@ export function usePilotProgress() {
   return {
     progress,
     isLoading: query.isLoading,
+    /** True when we have any source of truth for the unlock flags —
+     *  either the query resolved, or the localStorage cache had a
+     *  snapshot to fall back on. False during the brief cold-load
+     *  window where neither exists, which is when consumers should
+     *  hold rendering rather than flash a wrong gate decision. */
+    hasReadyProgress: !query.isLoading || cachedProgress != null,
     hasUnlockedTradeBook: !!progress[tradeBookUnlockedKey(currentOrgId)],
     hasUnlockedOutcomes: !!progress[outcomesUnlockedKey(currentOrgId)],
     /** Per-org: true only if the user has reached Outcomes in the

--- a/src/hooks/usePilotProgress.ts
+++ b/src/hooks/usePilotProgress.ts
@@ -123,6 +123,31 @@ export function usePilotProgress() {
     ...(query.data ?? {}),
   }
 
+  // TEMP DEBUG — diagnosing the cold-load stage flicker. Logs each
+  // render of usePilotProgress so we can see whether user.pilot_progress
+  // is actually present on first paint, what currentOrgId resolves to,
+  // and whether the per-org unlock lookup actually finds its key.
+  // Remove after the bug is understood.
+  if (typeof window !== 'undefined') {
+    const tbKey = `trade_book_unlocked_at_${currentOrgId || 'no-org'}`
+    const ocKey = `outcomes_unlocked_at_${currentOrgId || 'no-org'}`
+    // eslint-disable-next-line no-console
+    console.log('[pilot-debug] usePilotProgress render', {
+      userId: user?.id ?? null,
+      currentOrgId: currentOrgId ?? null,
+      hasUserPilotProgressOnUser: userPilotProgress !== undefined,
+      userPilotProgressKeys: userPilotProgress ? Object.keys(userPilotProgress) : null,
+      queryStatus: { isLoading: query.isLoading, isFetching: query.isFetching, hasData: query.data !== undefined },
+      progressKeys: Object.keys(progress),
+      tbKey,
+      ocKey,
+      tradeBookValue: progress[tbKey] ?? null,
+      outcomesValue: progress[ocKey] ?? null,
+      hasUnlockedTradeBook: !!progress[tbKey],
+      hasUnlockedOutcomes: !!progress[ocKey],
+    })
+  }
+
   const markStage = useMutation({
     mutationFn: async (stage: PilotStage) => {
       if (!user?.id) return

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -916,6 +916,16 @@ export function DashboardPage() {
     if (pilotMode.effectiveIsPilot) {
       const feature = TAB_TYPE_TO_PILOT_FEATURE[activeTab.type]
       if (feature && pilotMode.accessFor(feature) === 'preview') {
+        // Cold-load guard: when the access decision isn't trustworthy
+        // yet (queries pending, no localStorage cache to fall back on)
+        // we'd otherwise default to 'preview' and flash the locked
+        // teaser before the queries land and reveal the user actually
+        // has full access. Render an empty container until the decision
+        // resolves — a brief blank is less jarring than the locked-then-
+        // unlocked flicker.
+        if (!pilotMode.accessIsReady) {
+          return <div className="h-full w-full" aria-busy="true" />
+        }
         if (activeTab.type === 'trade-book') return <PilotTradeBookPreview onGoToTradeLab={openPilotTradeLab} />
         if (activeTab.type === 'outcomes')   return <PilotOutcomesPreview onGoToTradeLab={openPilotTradeLab} />
       }


### PR DESCRIPTION
Previous attempts on this branch cached the unlock signals (pilot_progress, hasCommittedTradeInOrg) for synchronous render-time fallback. That solves the warm-cache case but does nothing on the very first cold load — fresh code, fresh cache, or any session where localStorage hasn't been populated under the new keys yet. The user kept seeing the same flicker because the cold-cache path still flashes through "wrong gate state for ~200ms, then snap to correct" while the queries fetch.

The fix has to defend against that path too. Approach: surface a single `accessIsReady` flag from `usePilotMode` (and the underlying `hasReadyProgress` from `usePilotProgress`) that's true only when the gate decision is trustworthy — either real query data is in hand OR the cache fallback has definitive values to lean on. Then teach the two surfaces that flash to hold a neutral render instead:

- `DashboardPage` renders an empty container for the trade-book and outcomes tab slots while `!pilotMode.accessIsReady` instead of defaulting to the locked preview component. A brief blank is less jarring than the locked-then-unlocked snap.

- `SystemLoopCard` now accepts a `loading` prop. When true, every stage card forces its `done` / `isActive` / `isOpen` flags to false so the strip renders all-neutral — no pulse on the wrong stage, no premature checkmark. `PilotActionDashboard` passes `loading={!hasReadyProgress}` so the strip stays neutral until the data lands and then snaps directly to the right state.

This combined with the earlier cache work gives both paths a clean outcome: warm-cache renders correctly on first paint; cold-cache renders neutral for the ~100-300ms it takes the queries to land, then snaps to correct without ever showing a wrong state.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
