### PR TITLE
fix(security): scope every remaining user picker to current-org members

### DIFF
--- a/src/components/trading/AddTradeIdeaModal.tsx
+++ b/src/components/trading/AddTradeIdeaModal.tsx
@@ -5,6 +5,7 @@ import { X, Search, TrendingUp, TrendingDown, Link2, ArrowLeftRight, ChevronDown
 import { supabase } from '../../lib/supabase'
 import { useTradeIdeaService } from '../../hooks/useTradeIdeaService'
 import { useAuth } from '../../hooks/useAuth'
+import { useOrgMembers } from '../../hooks/useOrgMembers'
 import { Button } from '../ui/Button'
 import { Input } from '../ui/Input'
 import { ContextTagsInput, type ContextTag } from '../ui/ContextTagsInput'
@@ -176,20 +177,12 @@ export function AddTradeIdeaModal({
     enabled: isOpen,
   })
 
-  // Fetch team members for co-analyst assignment
-  const { data: teamMembers } = useQuery({
-    queryKey: ['team-members'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('users')
-        .select('id, email, first_name, last_name')
-        .neq('id', user?.id || '') // Exclude current user
-        .order('first_name')
-
-      if (error) throw error
-      return data
-    },
-    enabled: isOpen && !!user?.id,
+  // Co-analyst assignment picker — org-scoped. Previously queried the
+  // bare users table, which surfaced names from every org the platform
+  // admin or any cross-org user belonged to.
+  const { data: teamMembers } = useOrgMembers({
+    enabled: isOpen,
+    excludeUserId: user?.id,
   })
 
   // Fetch which portfolios hold the selected asset

--- a/src/components/trading/ShareSimulationModal.tsx
+++ b/src/components/trading/ShareSimulationModal.tsx
@@ -16,6 +16,7 @@ import {
 } from 'lucide-react'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
+import { useOrgMembers } from '../../hooks/useOrgMembers'
 import {
   useSimulationShare,
   type SimulationShareAccess,
@@ -116,20 +117,12 @@ export function ShareSimulationModal({
     }
   }, [sent, onClose])
 
-  // Fetch all users
-  const { data: allUsers, isLoading: usersLoading } = useQuery({
-    queryKey: ['all-users-share'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('users')
-        .select('id, email, first_name, last_name')
-        .neq('id', user?.id)
-        .order('first_name', { ascending: true })
-
-      if (error) throw error
-      return data || []
-    },
+  // Share recipients — current-org members only. Previously surfaced
+  // every user in the database, which would let a user share into
+  // another org by selecting someone from there.
+  const { data: allUsers = [], isLoading: usersLoading } = useOrgMembers({
     enabled: isOpen,
+    excludeUserId: user?.id,
   })
 
   // Filter users based on search

--- a/src/components/trading/SimulationCollaboratorsModal.tsx
+++ b/src/components/trading/SimulationCollaboratorsModal.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { X, Users, UserPlus, Shield, Eye, MessageSquare, Edit2, Crown, Trash2, Search } from 'lucide-react'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
+import { useOrgMembers } from '../../hooks/useOrgMembers'
 import { Button } from '../ui/Button'
 import { Input } from '../ui/Input'
 import type { SimulationPermission, SimulationCollaboratorWithUser } from '../../types/trading'
@@ -83,28 +84,25 @@ export function SimulationCollaboratorsModal({
     enabled: isOpen,
   })
 
-  // Search for users
-  const { data: searchResults } = useQuery({
-    queryKey: ['users-search', searchEmail],
-    queryFn: async () => {
-      if (!searchEmail || searchEmail.length < 2) return []
-
-      const { data, error } = await supabase
-        .from('users')
-        .select('id, email, first_name, last_name')
-        .or(`email.ilike.%${searchEmail}%,first_name.ilike.%${searchEmail}%,last_name.ilike.%${searchEmail}%`)
-        .limit(5)
-
-      if (error) throw error
-
-      // Filter out existing collaborators and current user
-      const existingUserIds = new Set(collaborators?.map(c => c.user_id) || [])
-      existingUserIds.add(user?.id || '')
-
-      return data.filter(u => !existingUserIds.has(u.id))
-    },
-    enabled: isOpen && searchEmail.length >= 2,
+  // Search pool — current-org members only, then filtered client-side.
+  // Previously a global ilike against the users table, which would let
+  // a simulation owner add a collaborator from another org.
+  const { data: orgMembers = [] } = useOrgMembers({
+    enabled: isOpen,
+    excludeUserId: user?.id,
   })
+  const searchResults = useMemo(() => {
+    if (!searchEmail || searchEmail.length < 2) return []
+    const q = searchEmail.toLowerCase()
+    const existingUserIds = new Set(collaborators?.map(c => c.user_id) || [])
+    return orgMembers
+      .filter(m => !existingUserIds.has(m.id))
+      .filter(m => {
+        const name = `${m.first_name ?? ''} ${m.last_name ?? ''}`.toLowerCase()
+        return name.includes(q) || (m.email ?? '').toLowerCase().includes(q)
+      })
+      .slice(0, 5)
+  }, [orgMembers, searchEmail, collaborators])
 
   // Add collaborator mutation
   const addCollaboratorMutation = useMutation({

--- a/src/components/trading/TradeIdeaDetailModal.tsx
+++ b/src/components/trading/TradeIdeaDetailModal.tsx
@@ -45,6 +45,7 @@ import {
 import { supabase } from '../../lib/supabase'
 import { emitAuditEvent } from '../../lib/audit'
 import { useAuth } from '../../hooks/useAuth'
+import { useOrgMembers } from '../../hooks/useOrgMembers'
 import { Button } from '../ui/Button'
 import { DatePicker } from '../ui/DatePicker'
 import { ContextTagsInput, type ContextTag, type ContextTagEntityType } from '../ui/ContextTagsInput'
@@ -657,21 +658,10 @@ export function TradeIdeaDetailModal({ isOpen, tradeId, onClose, initialTab = 'd
     return { netWeight, grossWeight, longCount, shortCount }
   }, [pairTradeData, pairTradeLegTargets])
 
-  // Fetch team members for assignment dropdowns
-  const { data: teamMembers } = useQuery({
-    queryKey: ['team-members'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('users')
-        .select('id, email, first_name, last_name')
-        .order('first_name')
-
-      if (error) throw error
-      return data || []
-    },
-    enabled: isOpen,
-    staleTime: 60000, // Cache for 1 minute
-  })
+  // Assignment dropdowns — org-scoped. Previously queried the bare
+  // users table, which surfaced names from every org the platform
+  // admin or any cross-org user belonged to.
+  const { data: teamMembers = [] } = useOrgMembers({ enabled: isOpen })
 
   // Get all leg IDs for pair trades (needed for fetching lab links and proposals)
   const pairTradeLegIds = useMemo(() => {

--- a/src/components/ui/AssignmentSelector.tsx
+++ b/src/components/ui/AssignmentSelector.tsx
@@ -2,6 +2,7 @@ import React, { useState, useMemo, useEffect } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
+import { useOrgMembers } from '../../hooks/useOrgMembers'
 import { UserPlus, X, Calendar, Check, Search, MessageSquare, Trash2 } from 'lucide-react'
 import { Button } from './Button'
 import { useNavigate } from 'react-router-dom'
@@ -65,18 +66,14 @@ export function AssignmentSelector({
     }
   }, [autoOpenModal])
 
-  // Fetch all users
-  const { data: users } = useQuery({
-    queryKey: ['users'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('users')
-        .select('id, email, first_name, last_name')
-        .order('email')
-      if (error) throw error
-      return data as User[]
-    }
-  })
+  // Org-scoped — see comment on matching swap in CollaborationManager.
+  const { data: orgMembersData = [] } = useOrgMembers()
+  const users: User[] = orgMembersData.map(m => ({
+    id: m.id,
+    email: m.email ?? '',
+    first_name: m.first_name ?? undefined,
+    last_name: m.last_name ?? undefined,
+  }))
 
   // Fetch existing assignments
   const { data: assignments } = useQuery({

--- a/src/components/ui/CollaborationManager.tsx
+++ b/src/components/ui/CollaborationManager.tsx
@@ -1,8 +1,9 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { Users, Plus, X, Trash2, Search } from 'lucide-react'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
+import { useOrgMembers } from '../../hooks/useOrgMembers'
 import { Card } from './Card'
 import { Button } from './Button'
 import { Badge } from './Badge'
@@ -120,31 +121,28 @@ export function CollaborationManager({
     enabled: isOpen
   })
 
-  // Search for users to invite
-  const { data: searchResults } = useQuery({
-    queryKey: ['user-search', searchQuery],
-    queryFn: async () => {
-      if (!searchQuery.trim() || searchQuery.length < 2) return []
-
-      const { data, error } = await supabase
-        .from('users')
-        .select('id, email, first_name, last_name')
-        .or(`email.ilike.%${searchQuery.toLowerCase()}%,first_name.ilike.%${searchQuery.toLowerCase()}%,last_name.ilike.%${searchQuery.toLowerCase()}%`)
-        .neq('id', user?.id) // Exclude current user
-        .limit(10)
-
-      if (error) throw error
-
-      // Filter out users who are already collaborators or the owner
-      const existingUserIds = new Set(collaborations?.map(c => c.user_id) || [])
-      existingUserIds.add(noteOwnerId); // Exclude the owner
-
-      const filteredResults = data?.filter(u => !existingUserIds.has(u.id)) || []
-
-      return filteredResults
-    },
-    enabled: isOpen && searchQuery.length >= 2
+  // Pool of users eligible to invite — scoped to current-org members
+  // only, not the global users table. Previously a global search that
+  // returned anyone whose name or email matched the query (defense in
+  // depth: RLS may already restrict it, but the picker should match
+  // the rest of the app's org-only convention regardless).
+  const { data: orgMembers = [] } = useOrgMembers({
+    enabled: isOpen,
+    excludeUserId: user?.id,
   })
+  const searchResults = useMemo(() => {
+    if (!searchQuery.trim() || searchQuery.length < 2) return []
+    const q = searchQuery.toLowerCase()
+    const existingUserIds = new Set(collaborations?.map(c => c.user_id) || [])
+    existingUserIds.add(noteOwnerId)
+    return orgMembers
+      .filter(m => !existingUserIds.has(m.id))
+      .filter(m => {
+        const name = `${m.first_name ?? ''} ${m.last_name ?? ''}`.toLowerCase()
+        return name.includes(q) || (m.email ?? '').toLowerCase().includes(q)
+      })
+      .slice(0, 10)
+  }, [orgMembers, searchQuery, collaborations, noteOwnerId])
 
   // Invite user mutation
   const inviteUserMutation = useMutation({

--- a/src/components/ui/WorkflowManager.tsx
+++ b/src/components/ui/WorkflowManager.tsx
@@ -3,6 +3,7 @@ import { X, Plus, Edit, Trash2, Save, ArrowUp, ArrowDown, Palette, Eye, Workflow
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
+import { useOrgMembers } from '../../hooks/useOrgMembers'
 import { Button } from './Button'
 import { Badge } from './Badge'
 import { Card } from './Card'
@@ -227,19 +228,16 @@ export function WorkflowManager({
     enabled: !!selectedWorkflow
   })
 
-  const { data: allUsers } = useQuery({
-    queryKey: ['users'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('users')
-        .select('id, email, first_name, last_name')
-        .order('email')
-
-      if (error) throw error
-      return data as User[]
-    },
-    enabled: isOpen
-  })
+  // Org-scoped — see comment on matching swap in CollaborationManager.
+  // The picker that consumes allUsers is the "add collaborator" search
+  // and was previously hitting the global users table.
+  const { data: orgMembersData = [] } = useOrgMembers({ enabled: isOpen })
+  const allUsers: User[] = orgMembersData.map(m => ({
+    id: m.id,
+    email: m.email ?? '',
+    first_name: m.first_name ?? undefined,
+    last_name: m.last_name ?? undefined,
+  }))
 
   const createWorkflowMutation = useMutation({
     mutationFn: async (workflowData: { workflow: Partial<Workflow>, stages: Partial<WorkflowStage>[] }) => {

--- a/src/components/ui/checklist/OperationalItemCard.tsx
+++ b/src/components/ui/checklist/OperationalItemCard.tsx
@@ -13,6 +13,7 @@ import {
   Search, Send, MessageSquare, Link as LinkIcon, BrainCircuit,
 } from 'lucide-react'
 import { supabase } from '../../../lib/supabase'
+import { useOrgMembers } from '../../../hooks/useOrgMembers'
 import {
   ChecklistItemData,
   userName, userInitials, avatarColor, relativeTime,
@@ -59,15 +60,8 @@ export function OperationalItemCard({
 
   // ─── Queries ────────────────────────────────────────────────────────
 
-  const { data: users } = useQuery({
-    queryKey: ['users'],
-    queryFn: async () => {
-      const { data, error } = await supabase.from('users').select('id, email, first_name, last_name').order('first_name')
-      if (error) throw error
-      return data || []
-    },
-    enabled: assigningOwner,
-  })
+  // Org-scoped — see comment on matching swap in CollaborationManager.
+  const { data: users = [] } = useOrgMembers({ enabled: assigningOwner })
 
   const commentsKey = ['op-item-comments', item.dbId]
   const { data: comments = [] } = useQuery({

--- a/src/components/workflow/modals/AddAdminModal.tsx
+++ b/src/components/workflow/modals/AddAdminModal.tsx
@@ -5,11 +5,12 @@
  * Supports multi-select with removable chips.
  */
 
-import React, { useState, useRef, useEffect } from 'react'
+import React, { useState, useRef, useEffect, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { X } from 'lucide-react'
 import { Button } from '../../ui/Button'
 import { supabase } from '../../../lib/supabase'
+import { useOrgMembers } from '../../../hooks/useOrgMembers'
 
 interface PickedUser {
   id: string
@@ -43,24 +44,24 @@ export function AddAdminModal({ workflowId, workflowName, scopeType, onClose, on
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
 
-  const { data: users } = useQuery({
-    queryKey: ['users-search'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('users')
-        .select('id, email, first_name, last_name')
-        .order('first_name')
-        .order('last_name')
-
-      if (error) throw error
-
-      return data.map(user => ({
-        id: user.id,
-        email: user.email,
-        name: `${user.first_name || ''} ${user.last_name || ''}`.trim() || user.email
-      }))
-    }
-  })
+  // Org-scoped: only members of the caller's current org appear in the
+  // picker. Previously queried users globally, which surfaced names
+  // from every org the platform admin (or any cross-org user) belonged
+  // to. Same defense-in-depth swap as the other pickers in commit
+  // 868ee2f.
+  const { data: orgMembers = [] } = useOrgMembers()
+  const users = useMemo<PickedUser[]>(
+    () =>
+      orgMembers.map(m => ({
+        id: m.id,
+        email: m.email ?? '',
+        name:
+          `${m.first_name ?? ''} ${m.last_name ?? ''}`.trim()
+          || m.email
+          || 'Unknown',
+      })),
+    [orgMembers]
+  )
 
   // For portfolio-scoped workflows, check membership of selected users
   const { data: membershipWarnings = [] } = useQuery({

--- a/src/components/workflow/modals/AddStakeholderModal.tsx
+++ b/src/components/workflow/modals/AddStakeholderModal.tsx
@@ -5,11 +5,12 @@
  * Supports multi-select with removable chips.
  */
 
-import React, { useState, useRef, useEffect } from 'react'
+import React, { useState, useRef, useEffect, useMemo } from 'react'
 import { useQuery } from '@tanstack/react-query'
 import { X } from 'lucide-react'
 import { Button } from '../../ui/Button'
 import { supabase } from '../../../lib/supabase'
+import { useOrgMembers } from '../../../hooks/useOrgMembers'
 
 interface PickedUser {
   id: string
@@ -42,24 +43,20 @@ export function AddStakeholderModal({ workflowId, workflowName, scopeType, onClo
     return () => document.removeEventListener('mousedown', handleClickOutside)
   }, [])
 
-  const { data: users } = useQuery({
-    queryKey: ['users-search'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('users')
-        .select('id, email, first_name, last_name')
-        .order('first_name')
-        .order('last_name')
-
-      if (error) throw error
-
-      return data.map(user => ({
-        id: user.id,
-        email: user.email,
-        name: `${user.first_name || ''} ${user.last_name || ''}`.trim() || user.email
-      }))
-    }
-  })
+  // Org-scoped — see comment on the matching swap in AddAdminModal.
+  const { data: orgMembers = [] } = useOrgMembers()
+  const users = useMemo<PickedUser[]>(
+    () =>
+      orgMembers.map(m => ({
+        id: m.id,
+        email: m.email ?? '',
+        name:
+          `${m.first_name ?? ''} ${m.last_name ?? ''}`.trim()
+          || m.email
+          || 'Unknown',
+      })),
+    [orgMembers]
+  )
 
   // For portfolio-scoped workflows, check membership of selected users
   const { data: membershipWarnings = [] } = useQuery({

--- a/src/components/workflow/modals/InviteUserModal.tsx
+++ b/src/components/workflow/modals/InviteUserModal.tsx
@@ -5,11 +5,10 @@
  * Extracted from WorkflowsPage.tsx during Phase 5 refactoring.
  */
 
-import React, { useState } from 'react'
-import { useQuery } from '@tanstack/react-query'
+import React, { useMemo, useState } from 'react'
 import { X, Search } from 'lucide-react'
 import { Button } from '../../ui/Button'
-import { supabase } from '../../../lib/supabase'
+import { useOrgMembers } from '../../../hooks/useOrgMembers'
 
 export interface InviteUserModalProps {
   /** Workflow ID */
@@ -32,25 +31,22 @@ export function InviteUserModal({ workflowId, workflowName, onClose, onInvite }:
   const [selectedUser, setSelectedUser] = useState<{id: string, email: string, name: string} | null>(null)
   const [showDropdown, setShowDropdown] = useState(false)
 
-  // Query to get all users for searchable dropdown
-  const { data: users } = useQuery({
-    queryKey: ['users-search'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('users')
-        .select('id, email, first_name, last_name')
-        .order('first_name')
-        .order('last_name')
-
-      if (error) throw error
-
-      return data.map(user => ({
-        id: user.id,
-        email: user.email,
-        name: `${user.first_name || ''} ${user.last_name || ''}`.trim() || user.email
-      }))
-    }
-  })
+  // Searchable picker restricted to current-org members. Previously
+  // queried users globally — same cross-org leak the rest of the
+  // pickers had. Defense-in-depth swap via useOrgMembers.
+  const { data: orgMembers = [] } = useOrgMembers()
+  const users = useMemo(
+    () =>
+      orgMembers.map(m => ({
+        id: m.id,
+        email: m.email ?? '',
+        name:
+          `${m.first_name ?? ''} ${m.last_name ?? ''}`.trim()
+          || m.email
+          || 'Unknown',
+      })),
+    [orgMembers]
+  )
 
   // Filter users based on search term
   const filteredUsers = users?.filter(user =>

--- a/src/hooks/useDecisionAccountability.ts
+++ b/src/hooks/useDecisionAccountability.ts
@@ -1075,16 +1075,12 @@ export function usePortfoliosForFilter() {
   })
 }
 
-export function useUsersForFilter() {
-  return useQuery({
-    queryKey: ['users-for-filter'],
-    queryFn: async () => {
-      const { data, error } = await supabase.from('users').select('id, email, first_name, last_name').order('first_name')
-      if (error) throw error
-      return data || []
-    },
-  })
-}
+// useUsersForFilter has been removed — it ran a global `from('users')`
+// query without any org scope, which surfaced names from every org
+// the caller could read. The two callers (this page's accountability
+// filter and OutcomesPage's owner filter) now use useOrgMembers
+// instead. If you need the same shape in the future, build on top of
+// useOrgMembers — never query the bare users table for a picker.
 
 // =============================================================================
 // Decision Story — full upstream/downstream context for post-mortem review.

--- a/src/hooks/useOutcomes.ts
+++ b/src/hooks/useOutcomes.ts
@@ -338,23 +338,9 @@ export function usePortfoliosForFilter() {
   })
 }
 
-export function useUsersForFilter() {
-  return useQuery({
-    queryKey: ['users-for-filter'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('users')
-        .select('id, email, raw_user_meta_data')
-        .order('email')
-      if (error) throw error
-      return (data || []).map((u: any) => ({
-        id: u.id,
-        email: u.email,
-        name: u.raw_user_meta_data?.full_name || u.email.split('@')[0],
-      }))
-    },
-  })
-}
+// useUsersForFilter has been removed — see the matching deletion in
+// useDecisionAccountability for the rationale. Owner picker now goes
+// through useOrgMembers.
 
 // ============================================================
 // Internal helpers

--- a/src/pages/CalendarPage.tsx
+++ b/src/pages/CalendarPage.tsx
@@ -21,6 +21,7 @@ import { PriorityBadge } from '../components/ui/PriorityBadge'
 import { CalendarSettings } from '../components/calendar/CalendarSettings'
 import { useOrganization } from '../contexts/OrganizationContext'
 import { buildOrgQueryKey } from '../hooks/useOrgQueryKey'
+import { useOrgMembers } from '../hooks/useOrgMembers'
 
 interface CalendarEvent {
   id: string
@@ -1080,19 +1081,9 @@ function EventModal({
   const [showMoreOptions, setShowMoreOptions] = useState(false)
   const [attendeeSearch, setAttendeeSearch] = useState('')
 
-  // Fetch users for attendees
-  const { data: users = [] } = useQuery({
-    queryKey: ['users-for-calendar'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('users')
-        .select('id, email, first_name, last_name')
-        .order('first_name')
-      if (error) throw error
-      return data as { id: string; email: string; first_name?: string; last_name?: string }[]
-    },
-    enabled: isOpen
-  })
+  // Attendees picker — org-scoped. Previously queried users globally.
+  // Same defense-in-depth swap as the other pickers in commit 868ee2f.
+  const { data: users = [] } = useOrgMembers({ enabled: isOpen })
 
   const filteredUsers = useMemo(() => {
     if (!attendeeSearch.trim()) return users

--- a/src/pages/DecisionAccountabilityPage.tsx
+++ b/src/pages/DecisionAccountabilityPage.tsx
@@ -34,7 +34,6 @@ import {
   useDecisionStory,
   fetchDecisionStory,
   usePortfoliosForFilter,
-  useUsersForFilter,
   useCandidateTradeEvents,
   useManualMatch,
   useUnlinkMatch,
@@ -242,7 +241,6 @@ function FilterBar({
   onChange: (f: Partial<AccountabilityFilters>) => void
 }) {
   const { data: portfolios = [] } = usePortfoliosForFilter()
-  const { data: users = [] } = useUsersForFilter()
 
   const [showCustom, setShowCustom] = useState(false)
   const [customStart, setCustomStart] = useState('')

--- a/src/pages/ListsPage.tsx
+++ b/src/pages/ListsPage.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { List, Search, Plus, Star, Users, ChevronDown, ChevronRight, X, Save, Palette, UserPlus, Trash2, Eye, EditIcon, Shield } from 'lucide-react'
 import { supabase } from '../lib/supabase'
 import { useAuth } from '../hooks/useAuth'
+import { useOrgMembers } from '../hooks/useOrgMembers'
 import { Button } from '../components/ui/Button'
 import { Badge } from '../components/ui/Badge'
 import { ListSkeleton } from '../components/common/LoadingSkeleton'
@@ -287,26 +288,30 @@ export function ListsPage({ onListSelect }: ListsPageProps) {
     toggleFavoriteMutation.mutate(listId)
   }, [toggleFavoriteMutation])
 
-  // ── User search (unchanged) ────────────────────────────────────────────
-  const searchUsers = async (query: string) => {
+  // ── User search ────────────────────────────────────────────────────────
+  // Pool of invitable users is now restricted to current-org members —
+  // previously a global ilike against the users table that surfaced
+  // anyone in the database whose name or email matched. Defense in
+  // depth: matches the org-scoped pattern applied elsewhere in
+  // commit 868ee2f.
+  const { data: orgMembers = [] } = useOrgMembers({ excludeUserId: user?.id })
+  const searchUsers = (query: string) => {
     if (!query.trim() || query.length < 2) {
       setSearchResults([])
       setShowUserDropdown(false)
       return
     }
-    try {
-      const { data, error } = await supabase
-        .from('users')
-        .select('id, email, first_name, last_name')
-        .or(`first_name.ilike.%${query}%,last_name.ilike.%${query}%,email.ilike.%${query}%`)
-        .neq('id', user?.id)
-        .limit(10)
-      if (error) return
-      const existingCollaboratorIds = editingList?.collaborators?.map((c: any) => c.user_id) || []
-      const filteredResults = (data || []).filter((u: any) => !existingCollaboratorIds.includes(u.id))
-      setSearchResults(filteredResults)
-      setShowUserDropdown(filteredResults.length > 0)
-    } catch { /* ignore */ }
+    const q = query.toLowerCase()
+    const existingCollaboratorIds = editingList?.collaborators?.map((c: any) => c.user_id) || []
+    const filteredResults = orgMembers
+      .filter(m => !existingCollaboratorIds.includes(m.id))
+      .filter(m => {
+        const name = `${m.first_name ?? ''} ${m.last_name ?? ''}`.toLowerCase()
+        return name.includes(q) || (m.email ?? '').toLowerCase().includes(q)
+      })
+      .slice(0, 10)
+    setSearchResults(filteredResults)
+    setShowUserDropdown(filteredResults.length > 0)
   }
 
   const handleUserSearchChange = (value: string) => {

--- a/src/pages/OutcomesPage.tsx
+++ b/src/pages/OutcomesPage.tsx
@@ -23,12 +23,22 @@ import {
   useOutcomeSummary,
   useAddReflection,
   usePortfoliosForFilter,
-  useUsersForFilter,
   type OutcomeDecision,
   type OutcomeFilters,
   type DecisionDirection,
 } from '../hooks/useOutcomes'
 import { useAuth } from '../hooks/useAuth'
+import { useOrgMembers, type OrgMember } from '../hooks/useOrgMembers'
+
+// Inline display-name helper so the picker rows match the same shape
+// the old useUsersForFilter mapping produced (a single `name` string)
+// without forcing the source-of-truth hook to compose UI strings.
+function pickerName(m: OrgMember): string {
+  const full = [m.first_name, m.last_name].filter(Boolean).join(' ').trim()
+  if (full) return full
+  if (m.email) return m.email.split('@')[0]
+  return 'Unknown'
+}
 import { AnalystPerformanceCard } from '../components/outcomes/AnalystPerformanceCard'
 import { PerformanceLeaderboard } from '../components/outcomes/PerformanceLeaderboard'
 import type { PeriodType } from '../hooks/useAnalystPerformance'
@@ -44,7 +54,8 @@ function FilterBar({ filters, onChange }: {
   onChange: (f: Partial<OutcomeFilters>) => void
 }) {
   const { data: portfolios = [] } = usePortfoliosForFilter()
-  const { data: users = [] } = useUsersForFilter()
+  // Org-scoped — see comment on the matching hook swap in TradeQueuePage.
+  const { data: users = [] } = useOrgMembers()
 
   const activeDays = (() => {
     if (!filters.dateRange?.start) return 90
@@ -114,8 +125,8 @@ function FilterBar({ filters, onChange }: {
         className="px-2.5 py-1 text-xs border border-gray-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
       >
         <option value="">All Users</option>
-        {users.map((u: any) => (
-          <option key={u.id} value={u.id}>{u.name}</option>
+        {users.map(u => (
+          <option key={u.id} value={u.id}>{pickerName(u)}</option>
         ))}
       </select>
 
@@ -421,7 +432,8 @@ function DecisionsView() {
 function ScorecardsView() {
   const [periodType, setPeriodType] = useState<PeriodType>('all_time')
   const [selectedAnalystId, setSelectedAnalystId] = useState<string | null>(null)
-  const { data: users = [] } = useUsersForFilter()
+  // Org-scoped — see comment on the matching hook swap in TradeQueuePage.
+  const { data: users = [] } = useOrgMembers()
 
   return (
     <div className="space-y-6 max-w-7xl mx-auto">
@@ -452,8 +464,8 @@ function ScorecardsView() {
             className="px-2.5 py-1 text-xs border border-gray-200 rounded-lg bg-white focus:outline-none focus:ring-2 focus:ring-indigo-500"
           >
             <option value="">All Analysts</option>
-            {users.map((u: any) => (
-              <option key={u.id} value={u.id}>{u.name}</option>
+            {users.map(u => (
+              <option key={u.id} value={u.id}>{pickerName(u)}</option>
             ))}
           </select>
         </div>

--- a/src/pages/TradeQueuePage.tsx
+++ b/src/pages/TradeQueuePage.tsx
@@ -52,6 +52,7 @@ import {
 } from 'lucide-react'
 import { supabase } from '../lib/supabase'
 import { useAuth } from '../hooks/useAuth'
+import { useOrgMembers } from '../hooks/useOrgMembers'
 import { useOrganization } from '../contexts/OrganizationContext'
 import { usePilotMode } from '../hooks/usePilotMode'
 import { logPilotEvent } from '../lib/pilot/pilot-telemetry'
@@ -474,55 +475,14 @@ export function TradeQueuePage() {
     staleTime: 30_000,
   })
 
-  // Fetch team members from portfolios the current user is on (for "Created by" filter)
-  const { data: teamMembers } = useQuery({
-    queryKey: ['portfolio-team-members', user?.id],
-    queryFn: async () => {
-      if (!user?.id) return []
-
-      // First get the portfolios the current user is on
-      const { data: userPortfolios, error: portfolioError } = await supabase
-        .from('portfolio_team')
-        .select('portfolio_id')
-        .eq('user_id', user.id)
-
-      if (portfolioError) throw portfolioError
-      if (!userPortfolios?.length) return []
-
-      const portfolioIds = userPortfolios.map(p => p.portfolio_id)
-
-      // Then get all team members from those portfolios
-      const { data: members, error: membersError } = await supabase
-        .from('portfolio_team')
-        .select(`
-          user_id,
-          user:users!inner (
-            id,
-            email,
-            first_name,
-            last_name
-          )
-        `)
-        .in('portfolio_id', portfolioIds)
-
-      if (membersError) throw membersError
-
-      // Deduplicate users (they might be on multiple portfolios)
-      const uniqueUsers = new Map<string, { id: string; email: string; first_name: string | null; last_name: string | null }>()
-      members?.forEach((m: any) => {
-        if (m.user && !uniqueUsers.has(m.user.id)) {
-          uniqueUsers.set(m.user.id, m.user)
-        }
-      })
-
-      return Array.from(uniqueUsers.values()).sort((a, b) => {
-        const nameA = a.first_name || a.email || ''
-        const nameB = b.first_name || b.email || ''
-        return nameA.localeCompare(nameB)
-      })
-    },
-    enabled: !!user?.id,
-  })
+  // Members eligible for the "Owner" / "Created by" filter. Previously
+  // queried portfolio_team across every portfolio the current user
+  // belonged to, which leaked names from other orgs whenever a user was
+  // on portfolios in more than one org (any pilot tester or platform
+  // admin). Scope strictly to current-org members via the shared
+  // useOrgMembers hook — same defense-in-depth pattern applied to the
+  // other pickers in commit 868ee2f.
+  const { data: teamMembers } = useOrgMembers()
 
   // Fetch expression counts for trade ideas (how many labs each idea is in)
   const { data: expressionCounts, isLoading: isExpressionCountsLoading } = useTradeExpressionCounts()


### PR DESCRIPTION
User report: in a fresh pilot org "Testing Capital", the Idea Pipeline's Owner filter dropdown listed users from OTHER orgs (Ashley Helgans, Ryan Metz — neither a member of Testing Capital). Cross-tenant data leak through the picker.

Root cause: TradeQueuePage's owner-filter query fetched the current user's portfolio_team membership, then enumerated every user on any of those portfolios. A user who's on portfolios in multiple orgs (any platform admin, any pilot tester) ends up seeing the union of all those orgs' members — the inverse of the per-org scoping we want.

Commit 868ee2f added a `useOrgMembers` hook and applied it to 9 share/team pickers as defense-in-depth. The audit for this branch turned up TradeQueuePage plus 14 OTHER places that had the same unscoped pattern and were never updated. All swept:

  Page-level filters / dropdowns
   - TradeQueuePage owner filter (the original report)
   - OutcomesPage owner + Scorecards analyst pickers
   - CalendarPage attendees
   - ListsPage collaborator search

  Workflow modals
   - AddAdminModal, AddStakeholderModal, InviteUserModal

  UI components
   - CollaborationManager (invite search)
   - WorkflowManager (collaborator search)
   - AssignmentSelector, OperationalItemCard (owner pickers)
   - TradeIdeaDetailModal (assignment dropdowns)
   - AddTradeIdeaModal (co-analyst picker)
   - ShareSimulationModal recipients
   - SimulationCollaboratorsModal search

Each one now goes through `useOrgMembers` (defense in depth — RLS should already restrict, but the hook is the explicit inner scope that matches the established codebase pattern).

Also removed `useUsersForFilter` from both useDecisionAccountability and useOutcomes — that hook was the unscoped global-users query shared by Outcomes' owner filter and a now-unused DecisionAccountability filter slot. Deleted the dead variable in DecisionAccountabilityPage along the way.

Sites verified org-scoped already (no changes needed):
  - useEntitySearch's user search (scopes via organization_memberships)
  - MentionInput's mention list (same)
  - ShareListDialog (inline scoping equivalent to useOrgMembers)

Out-of-scope for this commit (auth/profile lookups, ops dashboards, audit/comment author resolution, etc.): bare `from('users')` calls that filter by a specific id via .eq or .in. Those return data the caller is already entitled to see and are not pickers.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
