### PR TITLE
fix(ops): add missing morph_switch_org / morph_restore_org RPCs

### DIFF
--- a/supabase/migrations/20260529120000_morph_switch_org_rpcs.sql
+++ b/supabase/migrations/20260529120000_morph_switch_org_rpcs.sql
@@ -1,0 +1,110 @@
+-- Missing RPCs for the morph flow.
+--
+-- useMorphSession.ts has always called supabase.rpc('morph_switch_org')
+-- after start_morph_session, and supabase.rpc('morph_restore_org')
+-- after end_morph_session. Neither function ever existed in the
+-- database, so both calls fail silently — and the symptom is exactly
+-- what an ops user reported: morphing as another user swaps the
+-- header identity (Ryan Metz) but leaves the org switcher and every
+-- org-scoped query pointed at the admin's original org.
+--
+-- These two functions complete the flow by allowing the admin's
+-- `users.current_organization_id` to be temporarily switched to the
+-- morph target's org, then restored on unmorph. Both write to the
+-- admin's own row (auth.uid()), so the change is per-session and
+-- doesn't affect the morphed user.
+--
+-- Security: gated tightly so they can't be abused outside the morph
+-- flow itself.
+
+-- ────────────────────────────────────────────────────────────────────
+-- morph_switch_org
+--
+-- Called by the admin immediately after start_morph_session to point
+-- their `current_organization_id` at the target user's org. Bypasses
+-- the normal "is the user a member" check that set_current_org would
+-- apply (the whole point is to enter an org the admin isn't a member
+-- of). Tightly gated:
+--   1. Only platform admins can call.
+--   2. The caller must have an active, unexpired morph session.
+--   3. p_org_id must match the target_org_id captured at session start
+--      — preventing this RPC from being used as a backdoor to jump
+--      into any org once a morph session is active.
+-- ────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION morph_switch_org(p_org_id UUID)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_session_target_org UUID;
+BEGIN
+  IF NOT is_platform_admin() THEN
+    RAISE EXCEPTION 'Access denied: only platform admins can morph_switch_org';
+  END IF;
+
+  SELECT target_org_id INTO v_session_target_org
+  FROM morph_sessions
+  WHERE admin_user_id = auth.uid()
+    AND is_active = true
+    AND expires_at > now()
+  ORDER BY created_at DESC
+  LIMIT 1;
+
+  IF v_session_target_org IS NULL THEN
+    RAISE EXCEPTION 'No active morph session for this admin';
+  END IF;
+
+  IF v_session_target_org IS DISTINCT FROM p_org_id THEN
+    RAISE EXCEPTION 'p_org_id does not match the active morph session''s target_org_id';
+  END IF;
+
+  UPDATE users
+     SET current_organization_id = p_org_id,
+         updated_at = now()
+   WHERE id = auth.uid();
+END;
+$$;
+
+-- ────────────────────────────────────────────────────────────────────
+-- morph_restore_org
+--
+-- Called by the admin after end_morph_session to restore their
+-- original `current_organization_id`. The client passes the org id it
+-- saved at morph start; this function only writes it if the caller is
+-- actually an active member of that org (so it can't be abused to
+-- bounce into an arbitrary org post-morph).
+-- ────────────────────────────────────────────────────────────────────
+CREATE OR REPLACE FUNCTION morph_restore_org(p_org_id UUID)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NOT is_platform_admin() THEN
+    RAISE EXCEPTION 'Access denied: only platform admins can morph_restore_org';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM organization_memberships
+    WHERE user_id = auth.uid()
+      AND organization_id = p_org_id
+      AND status = 'active'
+  ) THEN
+    RAISE EXCEPTION 'Caller is not an active member of the target restore org';
+  END IF;
+
+  UPDATE users
+     SET current_organization_id = p_org_id,
+         updated_at = now()
+   WHERE id = auth.uid();
+END;
+$$;
+
+-- Allow authenticated users to call these — the in-function checks
+-- gate on is_platform_admin() and the morph session state, so the
+-- grant is safe (non-admin calls will RAISE EXCEPTION immediately).
+GRANT EXECUTE ON FUNCTION morph_switch_org(UUID) TO authenticated;
+GRANT EXECUTE ON FUNCTION morph_restore_org(UUID) TO authenticated;


### PR DESCRIPTION
useMorphSession.ts has always called supabase.rpc('morph_switch_org') right after start_morph_session and supabase.rpc('morph_restore_org') after end_morph_session, but neither RPC ever existed in the database. Both calls failed silently — so morphing as another user swapped the header identity (target user's name) but left the org switcher AND every org-scoped query rooted in the admin's original org. The symptom was "I'm Ryan in the header but still seeing my own orgs."

Adds the two functions:

  morph_switch_org(p_org_id UUID): writes the caller's
    users.current_organization_id to the target org. Tightly gated:
    requires is_platform_admin() AND an active unexpired morph session,
    AND p_org_id must match that session's target_org_id (so this
    RPC can't be used as a backdoor to jump into arbitrary orgs).

  morph_restore_org(p_org_id UUID): restores the caller's
    current_organization_id on unmorph. Requires is_platform_admin()
    AND that the caller is an active member of p_org_id (so it can
    only restore to a real org of theirs).

Both write only to auth.uid()'s row, so the change is per-admin and doesn't affect the morphed user. The migration has already been applied to the live project via MCP.

After this fix: starting a morph from /ops swaps current_organization_id to the target's org. The page reloads, OrganizationContext picks up the new value off the auth user, and the admin is now operating in the target's org context for the duration of the session.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
