### PR TITLE
fix(rls): allow portfolio-less trade ideas to be visible to creator

### DIFF
--- a/supabase/migrations/20260529140000_trade_queue_items_allow_no_portfolio.sql
+++ b/supabase/migrations/20260529140000_trade_queue_items_allow_no_portfolio.sql
@@ -1,0 +1,40 @@
+-- Allow `trade_queue_items` rows with `portfolio_id IS NULL` to be
+-- visible to their creator.
+--
+-- Symptom: a pilot user submitting a trade idea WITHOUT selecting a
+-- portfolio got a "Couldn't save trade idea due to permissions" toast.
+-- The INSERT itself was succeeding (INSERT policy is just
+-- `auth.uid() = created_by`), but the `.select()` chained on by the
+-- Supabase client ran the SELECT policy on the newly-inserted row:
+--
+--   portfolio_in_current_org(portfolio_id) AND (...)
+--
+-- That helper does a EXISTS lookup against `portfolios` keyed on the
+-- argument, so `portfolio_in_current_org(NULL)` returns FALSE. The
+-- creator's own brand-new row was instantly hidden from them, and
+-- PostgREST surfaced the empty result as a permission failure.
+--
+-- Fix: extend the policy with a branch for portfolio-less ideas
+-- (private to their creator). No org dimension exists for these rows
+-- so the only person who ever needs to read them is the user that
+-- created them — there is no cross-org concern.
+
+DROP POLICY IF EXISTS "Trade queue: org-scoped access" ON trade_queue_items;
+
+CREATE POLICY "Trade queue: org-scoped access" ON trade_queue_items
+FOR SELECT TO authenticated
+USING (
+  -- Portfolio-less personal ideas: visible only to the creator. No
+  -- org membership check applies because there is no portfolio to
+  -- hang one off of.
+  (portfolio_id IS NULL AND created_by = auth.uid())
+  OR (
+    -- Existing portfolio-scoped behavior, unchanged.
+    portfolio_in_current_org(portfolio_id)
+    AND (
+      sharing_visibility IS DISTINCT FROM 'private'
+      OR created_by = auth.uid()
+      OR assigned_to = auth.uid()
+    )
+  )
+);


### PR DESCRIPTION
Pilot user submitting a trade idea without selecting a portfolio got a "Couldn't save trade idea due to permissions" toast. Tracked it through the RLS:

  - INSERT policy is just `auth.uid() = created_by` — succeeds.
  - SELECT policy gates on portfolio_in_current_org(portfolio_id) AND (...) which is `EXISTS (SELECT 1 FROM portfolios WHERE id = ARG ...)`. For ARG = NULL the EXISTS is FALSE, so the just-inserted row is hidden from its own creator. The Supabase client's `.insert(...).select()` chain then surfaces the empty result as a permission failure, which the frontend turns into the misleading toast.

Symptom is a real "saved-but-invisible" data hazard, not just bad UX. The row WAS inserted; the user just couldn't see it.

Fix adds a branch to the SELECT policy for `portfolio_id IS NULL` rows — visible only to their creator. No org dimension exists for those rows, so there's no cross-org concern. The existing portfolio-scoped behavior is unchanged.

Migration already applied to the live project via MCP.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
