### PR TITLE
fix(rls): let assignee see portfolio-less trade ideas

### DIFF
--- a/supabase/migrations/20260529150000_trade_queue_items_portfolioless_assignee_visible.sql
+++ b/supabase/migrations/20260529150000_trade_queue_items_portfolioless_assignee_visible.sql
@@ -1,0 +1,45 @@
+-- Extend the portfolio-less branch of the trade_queue_items SELECT
+-- policy so an explicitly-assigned user can also see the row, not
+-- just the creator.
+--
+-- The previous migration (20260529140000) added a portfolio-less
+-- branch that only granted visibility to the creator. That covers
+-- the case where a user captures an idea without picking a portfolio
+-- and keeps it as a personal draft. But it didn't cover the second
+-- expected UX: opening the idea card, assigning a teammate, and
+-- having the assignee pick it up from their own pipeline. Without
+-- this extension, the assignment would set the column but the
+-- assignee couldn't see the row until a portfolio was also attached.
+--
+-- The UPDATE policy already allows assignees to edit the row
+-- (auth.uid() = assigned_to is one of its OR'd branches), so this
+-- aligns SELECT with UPDATE.
+--
+-- Cross-org concern: there isn't one in practice. The recent user-
+-- picker sweep (fix/org-scope-remaining-user-pickers) restricts every
+-- assignee picker to current-org members via useOrgMembers, so the
+-- assignee will always be in the same org as the creator.
+
+DROP POLICY IF EXISTS "Trade queue: org-scoped access" ON trade_queue_items;
+
+CREATE POLICY "Trade queue: org-scoped access" ON trade_queue_items
+FOR SELECT TO authenticated
+USING (
+  -- Portfolio-less personal ideas: visible to the creator AND to any
+  -- explicitly assigned user. No org membership check applies because
+  -- there is no portfolio to hang one off of; the picker layer
+  -- restricts assignment to the creator's current-org members.
+  (
+    portfolio_id IS NULL
+    AND (created_by = auth.uid() OR assigned_to = auth.uid())
+  )
+  OR (
+    -- Portfolio-scoped: unchanged.
+    portfolio_in_current_org(portfolio_id)
+    AND (
+      sharing_visibility IS DISTINCT FROM 'private'
+      OR created_by = auth.uid()
+      OR assigned_to = auth.uid()
+    )
+  )
+);


### PR DESCRIPTION
Follows up on the portfolio-less SELECT fix that just landed. That migration's branch only granted visibility to the CREATOR of a portfolio-less row. The full UX expectation is "until they assign a portfolio OR another user" — so an assignee should also be able to pick the row up from their own pipeline.

Extends the portfolio-less branch:

  portfolio_id IS NULL AND (created_by = auth.uid() OR assigned_to = auth.uid())

This aligns SELECT with the existing UPDATE policy, which already allows assignees to edit the row. Cross-org is not a concern in practice — every assignee picker was restricted to current-org members via useOrgMembers in fix/org-scope-remaining-user-pickers, so the assignee will be in the same org as the creator.

Migration already applied to the live project via MCP.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
