### PR TITLE
fix(idea-pipeline): scope kanban to current org

### DIFF
--- a/src/pages/TradeQueuePage.tsx
+++ b/src/pages/TradeQueuePage.tsx
@@ -355,22 +355,30 @@ export function TradeQueuePage() {
     })
   }
 
-  // Fetch trade queue items
+  // Fetch trade queue items — strictly scoped to the current org via the
+  // inner-joined portfolios filter. RLS alone allows reads across every
+  // org the user belongs to, so a multi-pilot tester would see Tester
+  // Capital's CVX on AAAAA's kanban. Portfolio-less rows have no org by
+  // definition, so they don't belong on any org's pipeline view either —
+  // they're reachable via the asset page / direct URL if the user needs
+  // to attach them later.
   const { data: tradeItems, isLoading, error } = useQuery({
-    queryKey: ['trade-queue-items'],
+    queryKey: ['trade-queue-items', currentOrgId],
     queryFn: async () => {
+      if (!currentOrgId) return [] as TradeQueueItemWithDetails[]
       const { data, error } = await supabase
         .from('trade_queue_items')
         .select(`
           *,
           assets (id, symbol, company_name, sector),
-          portfolios (id, name, portfolio_id),
+          portfolios!inner (id, name, portfolio_id, organization_id),
           users:created_by (id, email, first_name, last_name),
           trade_queue_comments (id),
           trade_queue_votes (id, vote),
           pair_trades (id, name, description, rationale, urgency, status)
         `)
         .eq('visibility_tier', 'active')
+        .eq('portfolios.organization_id', currentOrgId)
         .order('priority', { ascending: false })
         .order('created_at', { ascending: false })
 


### PR DESCRIPTION
TradeQueuePage's main trade_queue_items query had no organization filter — just visibility_tier='active'. RLS allows reads across every org the user belongs to, so a multi-pilot tester landed on AAAAA's Idea Pipeline and saw their portfolio-less CVX (created when they were in Tester Capital) appearing as a kanban card. Same root cause as the dedup warning bleed fixed in ec55488, just on a different surface.

INNER JOIN portfolios with `.eq('portfolios.organization_id', currentOrgId)` filters out:
  - Trade items whose portfolio is in another org
  - Portfolio-less items (no portfolio row → inner join excludes)

Portfolio-less ideas remain reachable via the asset page / direct URL for any user who needs to attach them later, but no longer bleed onto the kanban of an org they were never tied to.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
