### PR TITLE
fix(theme): stop opting users into a half-implemented dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Applies before CSS loads, so the first paint (including the boot
+         loader) uses the light palette instead of the OS's. The `dark` class
+         overrides this via `:root.dark { color-scheme: dark }` in index.css. -->
+    <meta name="color-scheme" content="light" />
     <meta http-equiv="Content-Security-Policy"
           content="default-src 'self';
                    script-src 'self';

--- a/src/components/auth/AuthLayout.tsx
+++ b/src/components/auth/AuthLayout.tsx
@@ -9,7 +9,7 @@ interface AuthLayoutProps {
 
 export function AuthLayout({ children, title, subtitle }: AuthLayoutProps) {
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col justify-center py-12 sm:px-6 lg:px-8">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex flex-col justify-center py-12 px-4 sm:px-6 lg:px-8">
       <div className="sm:mx-auto sm:w-full sm:max-w-md">
         <div className="text-center">
           <div className="flex justify-center mb-6">
@@ -19,9 +19,9 @@ export function AuthLayout({ children, title, subtitle }: AuthLayoutProps) {
               className="h-12 w-auto"
             />
           </div>
-          <h2 className="mt-6 text-2xl font-semibold text-gray-900">{title}</h2>
+          <h2 className="mt-6 text-2xl font-semibold text-gray-900 dark:text-white">{title}</h2>
           {subtitle && (
-            <p className="mt-2 text-sm text-gray-600">{subtitle}</p>
+            <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">{subtitle}</p>
           )}
         </div>
       </div>

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -160,7 +160,7 @@ export function LoginForm() {
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
       {error && (
-        <div className="bg-error-50 border border-error-200 text-error-700 px-4 py-3 rounded-lg">
+        <div className="bg-error-50 border border-error-200 text-error-700 dark:bg-error-900/30 dark:border-error-800 dark:text-error-300 px-4 py-3 rounded-lg">
           {error}
         </div>
       )}
@@ -177,11 +177,11 @@ export function LoginForm() {
 
       {/* SSO-required banner */}
       {ssoState === 'sso_required' && ssoResult?.org_name && (
-        <div className="bg-indigo-50 border border-indigo-200 text-indigo-800 px-4 py-3 rounded-lg flex items-start gap-3">
-          <Shield className="w-4 h-4 mt-0.5 flex-shrink-0 text-indigo-600" />
+        <div className="bg-indigo-50 border border-indigo-200 text-indigo-800 dark:bg-indigo-900/30 dark:border-indigo-800 dark:text-indigo-200 px-4 py-3 rounded-lg flex items-start gap-3">
+          <Shield className="w-4 h-4 mt-0.5 flex-shrink-0 text-indigo-600 dark:text-indigo-400" />
           <div>
             <p className="text-sm font-medium">{ssoResult.org_name} requires SSO</p>
-            <p className="text-xs text-indigo-600 mt-0.5">
+            <p className="text-xs text-indigo-600 dark:text-indigo-400 mt-0.5">
               Password sign-in is disabled for this organization. Use the SSO button below.
             </p>
           </div>
@@ -223,10 +223,11 @@ export function LoginForm() {
           {showPasswordField && (
             <div className="relative">
               <div className="absolute inset-0 flex items-center">
-                <div className="w-full border-t border-gray-200" />
+                <div className="w-full border-t border-gray-200 dark:border-gray-700" />
               </div>
               <div className="relative flex justify-center text-xs uppercase">
-                <span className="bg-white px-2 text-gray-400">or</span>
+                {/* Must match the Card surface it sits on, not the page. */}
+                <span className="bg-white dark:bg-gray-800 px-2 text-gray-400 dark:text-gray-500">or</span>
               </div>
             </div>
           )}
@@ -247,7 +248,7 @@ export function LoginForm() {
       )}
 
       <div className="text-center">
-        <span className="text-sm text-gray-600">
+        <span className="text-sm text-gray-600 dark:text-gray-400">
           Don't have an account?{' '}
           <Link
             to="/signup"

--- a/src/components/auth/ResetPasswordForm.tsx
+++ b/src/components/auth/ResetPasswordForm.tsx
@@ -48,7 +48,7 @@ export function ResetPasswordForm() {
   if (success) {
     return (
       <div className="text-center space-y-4">
-        <div className="bg-success-50 border border-success-200 text-success-700 px-4 py-3 rounded-lg">
+        <div className="bg-success-50 border border-success-200 text-success-700 dark:bg-success-900/30 dark:border-success-800 dark:text-success-300 px-4 py-3 rounded-lg">
           Password reset email sent! Check your inbox for further instructions.
         </div>
         <Link
@@ -64,7 +64,7 @@ export function ResetPasswordForm() {
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
       {error && (
-        <div className="bg-error-50 border border-error-200 text-error-700 px-4 py-3 rounded-lg">
+        <div className="bg-error-50 border border-error-200 text-error-700 dark:bg-error-900/30 dark:border-error-800 dark:text-error-300 px-4 py-3 rounded-lg">
           {error}
         </div>
       )}

--- a/src/components/auth/SignupForm.tsx
+++ b/src/components/auth/SignupForm.tsx
@@ -62,7 +62,7 @@ export function SignupForm() {
   if (success) {
     return (
       <div className="text-center space-y-4">
-        <div className="bg-success-50 border border-success-200 text-success-700 px-4 py-3 rounded-lg">
+        <div className="bg-success-50 border border-success-200 text-success-700 dark:bg-success-900/30 dark:border-success-800 dark:text-success-300 px-4 py-3 rounded-lg">
           Account created successfully! You can now sign in.
         </div>
         <Link
@@ -78,7 +78,7 @@ export function SignupForm() {
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
       {error && (
-        <div className="bg-error-50 border border-error-200 text-error-700 px-4 py-3 rounded-lg">
+        <div className="bg-error-50 border border-error-200 text-error-700 dark:bg-error-900/30 dark:border-error-800 dark:text-error-300 px-4 py-3 rounded-lg">
           {error}
         </div>
       )}
@@ -132,7 +132,7 @@ export function SignupForm() {
       </Button>
 
       <div className="text-center">
-        <span className="text-sm text-gray-600">
+        <span className="text-sm text-gray-600 dark:text-gray-400">
           Already have an account?{' '}
           <Link
             to="/login"

--- a/src/components/auth/UpdatePasswordForm.tsx
+++ b/src/components/auth/UpdatePasswordForm.tsx
@@ -60,7 +60,7 @@ export function UpdatePasswordForm() {
         <div className="flex justify-center">
           <CheckCircle2 className="h-12 w-12 text-success-500" />
         </div>
-        <div className="bg-success-50 border border-success-200 text-success-700 px-4 py-3 rounded-lg">
+        <div className="bg-success-50 border border-success-200 text-success-700 dark:bg-success-900/30 dark:border-success-800 dark:text-success-300 px-4 py-3 rounded-lg">
           Password updated successfully! Redirecting...
         </div>
       </div>
@@ -70,7 +70,7 @@ export function UpdatePasswordForm() {
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
       {error && (
-        <div className="bg-error-50 border border-error-200 text-error-700 px-4 py-3 rounded-lg">
+        <div className="bg-error-50 border border-error-200 text-error-700 dark:bg-error-900/30 dark:border-error-800 dark:text-error-300 px-4 py-3 rounded-lg">
           {error}
         </div>
       )}

--- a/src/components/ui/Badge.tsx
+++ b/src/components/ui/Badge.tsx
@@ -9,19 +9,21 @@ interface BadgeProps {
 }
 
 // Move static objects outside component
+// Dark variants use a translucent tint over the page rather than the solid -100
+// fills, which are far too bright against a dark surface.
 const VARIANTS = {
-  default: 'bg-gray-100 text-gray-800',
-  primary: 'bg-primary-100 text-primary-800',
-  secondary: 'bg-blue-100 text-blue-800',
-  success: 'bg-success-100 text-success-800',
-  warning: 'bg-warning-100 text-warning-800',
-  error: 'bg-error-100 text-error-800',
-  purple: 'bg-purple-100 text-purple-800',
-  blue: 'bg-blue-50 text-blue-700 border border-blue-200',
-  green: 'bg-green-50 text-green-700 border border-green-200',
-  gray: 'bg-gray-50 text-gray-600 border border-gray-200',
-  orange: 'bg-amber-50 text-amber-700 border border-amber-200',
-  slate: 'bg-slate-50 text-slate-700 border border-slate-300',
+  default: 'bg-gray-100 text-gray-800 dark:bg-gray-700 dark:text-gray-200',
+  primary: 'bg-primary-100 text-primary-800 dark:bg-primary-900/40 dark:text-primary-300',
+  secondary: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300',
+  success: 'bg-success-100 text-success-800 dark:bg-success-900/40 dark:text-success-300',
+  warning: 'bg-warning-100 text-warning-800 dark:bg-warning-900/40 dark:text-warning-300',
+  error: 'bg-error-100 text-error-800 dark:bg-error-900/40 dark:text-error-300',
+  purple: 'bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300',
+  blue: 'bg-blue-50 text-blue-700 border border-blue-200 dark:bg-blue-900/30 dark:text-blue-300 dark:border-blue-800',
+  green: 'bg-green-50 text-green-700 border border-green-200 dark:bg-green-900/30 dark:text-green-300 dark:border-green-800',
+  gray: 'bg-gray-50 text-gray-600 border border-gray-200 dark:bg-gray-800 dark:text-gray-300 dark:border-gray-700',
+  orange: 'bg-amber-50 text-amber-700 border border-amber-200 dark:bg-amber-900/30 dark:text-amber-300 dark:border-amber-800',
+  slate: 'bg-slate-50 text-slate-700 border border-slate-300 dark:bg-slate-800 dark:text-slate-300 dark:border-slate-600',
 } as const
 
 const SIZES = {

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -11,9 +11,9 @@ interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
 // Move static objects outside component to prevent recreating on each render
 const VARIANTS = {
   primary: 'bg-gradient-to-r from-primary-600 to-primary-700 text-white hover:from-primary-700 hover:to-primary-800 focus:ring-primary-500 shadow-sm',
-  secondary: 'bg-gray-600 text-white hover:bg-gray-700 focus:ring-gray-500 shadow-sm',
-  outline: 'border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 hover:border-gray-400 focus:ring-primary-500',
-  ghost: 'text-gray-700 hover:bg-gray-100 hover:text-gray-900 focus:ring-primary-500',
+  secondary: 'bg-gray-600 text-white hover:bg-gray-700 focus:ring-gray-500 shadow-sm dark:bg-gray-700 dark:hover:bg-gray-600',
+  outline: 'border border-gray-300 bg-white text-gray-700 hover:bg-gray-50 hover:border-gray-400 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-200 dark:hover:bg-gray-700 dark:hover:border-gray-500',
+  ghost: 'text-gray-700 hover:bg-gray-100 hover:text-gray-900 focus:ring-primary-500 dark:text-gray-300 dark:hover:bg-gray-800 dark:hover:text-white',
   danger: 'bg-error-600 text-white hover:bg-error-700 focus:ring-error-500 shadow-sm',
 } as const
 
@@ -23,7 +23,9 @@ const SIZES = {
   lg: 'px-6 py-3 text-base',
 } as const
 
-const BASE_CLASSES = 'inline-flex items-center justify-center font-medium rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed'
+// `focus:ring-offset-2` renders the offset in the page background colour, so it
+// needs a dark counterpart or the focus ring sits in a white halo.
+const BASE_CLASSES = 'inline-flex items-center justify-center font-medium rounded-lg transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-gray-900 disabled:opacity-50 disabled:cursor-not-allowed'
 
 export const Button = React.memo(forwardRef<HTMLButtonElement, ButtonProps>(function Button({
   variant = 'primary',

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -28,7 +28,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(({
   return (
     <div className="space-y-1">
       {label && (
-        <label htmlFor={inputId} className="block text-sm font-medium text-gray-700">
+        <label htmlFor={inputId} className="block text-sm font-medium text-gray-700 dark:text-gray-300">
           {label}
         </label>
       )}
@@ -38,8 +38,11 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(({
           id={inputId}
           className={clsx(
             'block w-full rounded-lg border border-gray-300 px-3 py-2 text-sm placeholder-gray-400 shadow-sm transition-colors cursor-text',
+            'bg-white text-gray-900',
+            'dark:bg-gray-800 dark:border-gray-600 dark:text-gray-100 dark:placeholder-gray-500',
             'focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500',
-            error && 'border-error-500 focus:border-error-500 focus:ring-error-500',
+            'disabled:bg-gray-50 dark:disabled:bg-gray-900',
+            error && 'border-error-500 dark:border-error-500 focus:border-error-500 focus:ring-error-500',
             (rightAdornment || loading) && 'pr-10', // Add padding to the right if adornment or loading spinner exists
             className
           )}
@@ -58,10 +61,10 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(({
         )}
       </div>
       {error && (
-        <p className="text-sm text-error-600">{error}</p>
+        <p className="text-sm text-error-600 dark:text-error-400">{error}</p>
       )}
       {helperText && !error && (
-        <p className="text-sm text-gray-500">{helperText}</p>
+        <p className="text-sm text-gray-500 dark:text-gray-400">{helperText}</p>
       )}
     </div>
   )

--- a/src/components/ui/Tooltip.tsx
+++ b/src/components/ui/Tooltip.tsx
@@ -3,6 +3,11 @@ import { createPortal } from 'react-dom'
 import { clsx } from 'clsx'
 import { Info } from 'lucide-react'
 
+// gray-900 is also the dark-mode page background, so the tooltip needs a
+// lighter surface in dark or it disappears into the page behind it.
+const TOOLTIP_SURFACE =
+  'fixed z-50 px-3 py-2 text-sm text-white bg-gray-900 dark:bg-gray-700 dark:ring-1 dark:ring-gray-600 rounded-lg shadow-lg max-w-xs pointer-events-none'
+
 interface TooltipProps {
   content: string
   children?: React.ReactNode
@@ -124,13 +129,13 @@ export function Tooltip({ content, children, position = 'top', className }: Tool
         <div
           ref={tooltipRef}
           style={coords ? { top: coords.top, left: coords.left } : { visibility: 'hidden', top: 0, left: 0 }}
-          className="fixed z-50 px-3 py-2 text-sm text-white bg-gray-900 rounded-lg shadow-lg max-w-xs pointer-events-none"
+          className={TOOLTIP_SURFACE}
         >
           {content}
           {coords && (
             <div
               className={clsx(
-                'absolute w-2 h-2 bg-gray-900 rotate-45',
+                'absolute w-2 h-2 bg-gray-900 dark:bg-gray-700 rotate-45',
                 position === 'top' && 'bottom-[-4px] left-1/2 -translate-x-1/2',
                 position === 'bottom' && 'top-[-4px] left-1/2 -translate-x-1/2',
                 position === 'left' && 'right-[-4px] top-1/2 -translate-y-1/2',
@@ -154,7 +159,7 @@ interface InfoTooltipProps {
 export function InfoTooltip({ content, position = 'top', iconClassName }: InfoTooltipProps) {
   return (
     <Tooltip content={content} position={position}>
-      <Info className={clsx('w-4 h-4 text-gray-400 hover:text-gray-600 transition-colors', iconClassName)} />
+      <Info className={clsx('w-4 h-4 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors', iconClassName)} />
     </Tooltip>
   )
 }

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -10,17 +10,34 @@ interface ThemeContextType {
 
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined)
 
+// Bumped from 'tesseract-theme'. The previous version seeded itself from
+// prefers-color-scheme and then persisted that value, so every user on a
+// dark-mode OS ended up with 'dark' saved without ever choosing it. Reading a
+// new key resets those users once; only a deliberate toggle persists from here.
+const THEME_STORAGE_KEY = 'tesseract-theme-v2'
+const LEGACY_THEME_STORAGE_KEY = 'tesseract-theme'
+
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
   const [theme, setTheme] = useState<Theme>(() => {
-    const saved = localStorage.getItem('tesseract-theme')
+    const saved = localStorage.getItem(THEME_STORAGE_KEY)
     if (saved === 'dark' || saved === 'light') {
       return saved as Theme
     }
-    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+    // Deliberately NOT falling back to prefers-color-scheme. Dark mode is only
+    // partially implemented across the app, so inferring it from the OS opted
+    // users into a half-styled theme they never asked for — light cards on a
+    // dark page and vice versa. Dark is opt-in via the toggle until coverage
+    // is complete; at that point this can go back to honouring the OS.
+    return 'light'
   })
 
+  // Drop the stale key so it can't be resurrected by older code paths.
   useEffect(() => {
-    localStorage.setItem('tesseract-theme', theme)
+    localStorage.removeItem(LEGACY_THEME_STORAGE_KEY)
+  }, [])
+
+  useEffect(() => {
+    localStorage.setItem(THEME_STORAGE_KEY, theme)
 
     if (theme === 'dark') {
       document.documentElement.classList.add('dark')

--- a/src/index.css
+++ b/src/index.css
@@ -4,6 +4,19 @@
 
 
 @layer base {
+  /* Tells the browser which palette to use for UA-rendered chrome: native form
+     controls, scrollbars, and Chrome/Edge "Auto Dark Mode". Without it, a
+     dark-mode OS renders inputs and selects dark no matter what our CSS says —
+     which is why the sign-in box looked dark while the page stayed light.
+     Bound to the `dark` class so it follows the app's theme, not the OS. */
+  :root {
+    color-scheme: light;
+  }
+
+  :root.dark {
+    color-scheme: dark;
+  }
+
   html {
     font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   }


### PR DESCRIPTION
ThemeContext seeded itself from prefers-color-scheme and then persisted that value, so every user on a dark-mode OS ended up with 'dark' saved without ever choosing it. Dark mode is only ~34% implemented (214 of 623 .tsx files use a dark: variant at all), so those users got a half-styled app: 277 files use bg-white with no dark:bg, 301 use text-gray-900 with no dark:text.

The login screen was the clearest symptom. Card.tsx is the only element in the auth tree with dark styling, so dark mode produced a dark card on a light page with light inputs.

- Drop the prefers-color-scheme fallback; dark is opt-in via the toggle.
- Bump the storage key to tesseract-theme-v2 so users already carrying a silently-persisted 'dark' reset once. The legacy key is removed on mount. ThemeContext is the only reader of either key.
- Declare color-scheme (CSS + meta) so UA-rendered chrome — native form controls, scrollbars, Chrome/Edge Auto Dark Mode — follows the app theme rather than the OS. This was never declared anywhere.
- Add dark variants to Input, Button, Badge and Tooltip, which had none and propagate to hundreds of surfaces. Button needed dark:focus:ring-offset-gray-900 or focus rings sit in a white halo; Tooltip was bg-gray-900, the same colour as the dark page background.
- Add dark variants across AuthLayout and all four auth forms.

Dark mode remains incomplete elsewhere; this makes the default safe and fixes the shared primitives rather than all ~300 remaining files.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
