### PR TITLE
feat(mobile): add responsive shell foundation

### DIFF
--- a/src/components/communication/CommunicationPane.tsx
+++ b/src/components/communication/CommunicationPane.tsx
@@ -8,6 +8,8 @@ import { clsx } from 'clsx'
 import type { SidebarMode, SelectedItem, InspectableItemType } from '../../stores/sidebarStore'
 
 interface CommunicationPaneProps {
+  /** Presents the pane as a bottom sheet instead of a fixed right rail. */
+  isMobile?: boolean
   isOpen: boolean
   onToggle: () => void
   isFullscreen: boolean
@@ -34,6 +36,7 @@ interface CommunicationPaneProps {
 }
 
 export function CommunicationPane({
+  isMobile = false,
   isOpen,
   onToggle,
   isFullscreen,
@@ -160,9 +163,19 @@ export function CommunicationPane({
 
   return (
     <div className={clsx(
-      'fixed right-0 top-16 bottom-0 bg-white border-l border-gray-200 shadow-lg transform transition-transform duration-300 ease-in-out z-30',
-      isFullscreen ? 'left-0' : 'w-96',
-      isOpen ? 'translate-x-0' : 'translate-x-full'
+      'fixed bg-white shadow-lg transform transition-transform duration-300 ease-in-out z-30',
+      // Phone: a bottom sheet that rises over the content, leaving the header
+      // reachable. Desktop: the original right rail.
+      isMobile
+        ? clsx(
+            'inset-x-0 bottom-0 top-16 w-full rounded-t-2xl border-t border-gray-200',
+            isOpen ? 'translate-y-0' : 'translate-y-full'
+          )
+        : clsx(
+            'right-0 top-16 bottom-0 border-l border-gray-200',
+            isFullscreen ? 'left-0' : 'w-96',
+            isOpen ? 'translate-x-0' : 'translate-x-full'
+          )
     )}>
       <div className="flex flex-col h-full">
         {/* Header */}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -15,6 +15,7 @@ import { ProfilePage } from '../../pages/ProfilePage'
 import { SettingsPage } from '../../pages/SettingsPage'
 import { SetupWizard } from '../onboarding/SetupWizard'
 import { TesseractLogo } from '../ui/TesseractLogo'
+import { useIsMobile } from '../../hooks/useMediaQuery'
 // SetupWizard removed — org creation disabled for normal users
 
 interface HeaderProps {
@@ -28,6 +29,9 @@ interface HeaderProps {
   commPaneView?: string
   onShowAI?: () => void
   onShowThoughts?: () => void
+  /** Phone only — the Tesseract mark opens the nav drawer instead of the
+   *  app-launcher dropdown, which is wider than a phone viewport. */
+  onOpenMobileNav?: () => void
 }
 
 export function Header({
@@ -40,8 +44,10 @@ export function Header({
   onToggleCommPane,
   commPaneView = 'thoughts',
   onShowAI = () => {},
-  onShowThoughts = () => {}
+  onShowThoughts = () => {},
+  onOpenMobileNav
 }: HeaderProps) {
+  const isMobile = useIsMobile()
   const [showUserMenu, setShowUserMenu] = useState(false)
   const [showAppMenu, setShowAppMenu] = useState(false)
   const [showOrgSwitcher, setShowOrgSwitcher] = useState(false)
@@ -292,22 +298,26 @@ export function Header({
             <div className="relative" ref={appMenuRef}>
               <button
                 onClick={() => {
-                  setShowAppMenu(!showAppMenu)
                   // Tick off post-graduation Get Started step 1.
                   // PilotPostGradGetStarted listens for this and marks
                   // the stage; markStage is self-deduped so re-clicks
                   // don't repeatedly hit the DB.
                   window.dispatchEvent(new CustomEvent('pilot-postgrad:app-launcher-opened'))
+                  if (isMobile && onOpenMobileNav) {
+                    onOpenMobileNav()
+                    return
+                  }
+                  setShowAppMenu(!showAppMenu)
                 }}
-                className="flex items-center justify-center w-9 h-9 -ml-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-                aria-label="App launcher"
-                title="App launcher"
+                className="flex items-center justify-center w-11 h-11 -ml-2 md:w-9 md:h-9 md:-ml-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                aria-label={isMobile ? 'Open navigation' : 'App launcher'}
+                title={isMobile ? 'Menu' : 'App launcher'}
               >
                 <TesseractLogo size={28} />
               </button>
 
               {/* App Launcher Panel */}
-              {showAppMenu && pilotMode.effectiveIsPilot && (
+              {showAppMenu && !isMobile && pilotMode.effectiveIsPilot && (
                 <div className="absolute left-0 top-full mt-2 w-80 bg-white dark:bg-gray-800 rounded-xl shadow-xl border border-gray-200 dark:border-gray-700 py-3 z-50">
                   {/* Pilot badge */}
                   <div className="px-4 pb-2 flex items-center gap-1.5">
@@ -427,7 +437,7 @@ export function Header({
               )}
 
               {/* Full (non-pilot) app menu */}
-              {showAppMenu && !pilotMode.effectiveIsPilot && (
+              {showAppMenu && !isMobile && !pilotMode.effectiveIsPilot && (
                 <div className="absolute left-0 top-full mt-2 w-80 bg-white dark:bg-gray-800 rounded-xl shadow-xl border border-gray-200 dark:border-gray-700 py-3 z-50">
                   {/* Future: System status row can be added here */}
 

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -10,6 +10,8 @@ import { useCommunication } from '../../hooks/useCommunication'
 import { useNotifications } from '../../hooks/useNotifications'
 import { useSidebarStore, type InspectableItemType } from '../../stores/sidebarStore'
 import { useOrganization } from '../../contexts/OrganizationContext'
+import { useIsMobile } from '../../hooks/useMediaQuery'
+import { MobileNavDrawer } from '../mobile/MobileNavDrawer'
 
 interface LayoutProps {
   children: React.ReactNode
@@ -58,6 +60,18 @@ export function Layout({
   const [commPaneContext, setCommPaneContext] = useState<{ contextType?: string, contextId?: string, contextTitle?: string } | null>(null)
   const [isFocusMode, setIsFocusMode] = useState(false)
   const { hasUnreadNotifications } = useNotifications()
+
+  // On phones the tab strip is replaced by a nav drawer opened from the
+  // Tesseract mark — the Chrome-tab metaphor assumes you are juggling several
+  // surfaces at once, which does not survive a 390px viewport.
+  const isMobile = useIsMobile()
+  const [isMobileNavOpen, setIsMobileNavOpen] = useState(false)
+
+  // Close the drawer if the viewport grows back to desktop mid-session
+  // (rotation, or a resized browser window), so it cannot get stranded open.
+  useEffect(() => {
+    if (!isMobile) setIsMobileNavOpen(false)
+  }, [isMobile])
 
   // Global sidebar store for thoughts capture/inspect modes
   const {
@@ -393,6 +407,7 @@ export function Layout({
         commPaneView={commPaneView}
         onShowAI={handleShowAI}
         onShowThoughts={handleShowThoughts}
+        onOpenMobileNav={() => setIsMobileNavOpen(true)}
       />
       {isOrgArchived && (
         <div className="bg-amber-50 border-b border-amber-200 px-4 py-2 flex items-center justify-center gap-2 text-sm text-amber-800">
@@ -401,18 +416,20 @@ export function Layout({
           <span className="text-amber-600">All data is read-only. Contact a platform administrator to restore.</span>
         </div>
       )}
-      <TabManager
-        tabs={tabs}
-        activeTabId={activeTabId}
-        onTabChange={onTabChange}
-        onTabClose={onTabClose}
-        onCloseTabs={onCloseTabs}
-        onNewTab={onNewTab}
-        onTabReorder={onTabReorder}
-        onTabsReorder={onTabsReorder}
-        onFocusSearch={onFocusSearch}
-        hideNewTab={hideNewTab}
-      />
+      {!isMobile && (
+        <TabManager
+          tabs={tabs}
+          activeTabId={activeTabId}
+          onTabChange={onTabChange}
+          onTabClose={onTabClose}
+          onCloseTabs={onCloseTabs}
+          onNewTab={onNewTab}
+          onTabReorder={onTabReorder}
+          onTabsReorder={onTabsReorder}
+          onFocusSearch={onFocusSearch}
+          hideNewTab={hideNewTab}
+        />
+      )}
       <main className="flex-1 min-h-0 overflow-hidden">
         {(() => {
           const activeTab = tabs.find(tab => tab.id === activeTabId)
@@ -422,9 +439,11 @@ export function Layout({
             <div className={clsx(
               "relative h-full flex flex-col",
               isFullWidth ? "overflow-hidden" : isCompactPad ? "overflow-hidden p-2" : "overflow-auto",
-              !isFullWidth && !isCompactPad && "px-4 sm:px-6 lg:px-8 py-6",
+              !isFullWidth && !isCompactPad && "px-3 py-4 sm:px-6 sm:py-6 lg:px-8",
               "transition-[margin] duration-300 ease-in-out",
-              isCommPaneOpen && !isCommPaneFullscreen ? "mr-96" : "mr-0",
+              // The comm pane becomes a bottom sheet on phones, so it must not
+              // reserve a 384px right margin out of a 390px viewport.
+              isCommPaneOpen && !isCommPaneFullscreen && !isMobile ? "mr-96" : "mr-0",
               isFocusMode && "ring-4 ring-primary-400 ring-opacity-50"
             )}>
           {isFocusMode && (
@@ -446,6 +465,7 @@ export function Layout({
       </main>
       
       <CommunicationPane
+        isMobile={isMobile}
         isOpen={isCommPaneOpen}
         onToggle={toggleCommPane}
         isFullscreen={isCommPaneFullscreen}
@@ -476,6 +496,19 @@ export function Layout({
           }
         }}
       />
+
+      {isMobile && (
+        <MobileNavDrawer
+          open={isMobileNavOpen}
+          onClose={() => setIsMobileNavOpen(false)}
+          onSearchResult={onSearchResult}
+          onOpenSearch={onFocusSearch}
+          tabs={tabs}
+          activeTabId={activeTabId}
+          onTabChange={onTabChange}
+          onTabClose={onTabClose}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/mobile/BottomSheet.tsx
+++ b/src/components/mobile/BottomSheet.tsx
@@ -1,0 +1,276 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { clsx } from 'clsx'
+import { X } from 'lucide-react'
+import { useKeyboardInset, useViewportHeight } from '../../hooks/useMediaQuery'
+
+export interface BottomSheetProps {
+  open: boolean
+  onClose: () => void
+  title?: React.ReactNode
+  /** Right-aligned content in the header row (actions, status). */
+  headerAccessory?: React.ReactNode
+  /**
+   * Heights as a fraction of the visible viewport, smallest first. Dragging
+   * down steps to the next-smaller point and dismisses from the smallest.
+   */
+  snapPoints?: number[]
+  initialSnapIndex?: number
+  /** Size to content instead of using snap points. Best for short editors. */
+  fitContent?: boolean
+  /** Pinned below the scrolling body — use for commit/cancel actions. */
+  footer?: React.ReactNode
+  showHandle?: boolean
+  showCloseButton?: boolean
+  dismissOnBackdrop?: boolean
+  /** Set false while a commit is in flight to stop an accidental dismiss. */
+  dismissible?: boolean
+  /**
+   * Lift the sheet above the on-screen keyboard. On by default — the sizing
+   * editor is useless if the numeric field is behind the keyboard.
+   */
+  avoidKeyboard?: boolean
+  className?: string
+  contentClassName?: string
+  'aria-label'?: string
+  children: React.ReactNode
+}
+
+/** Drag distance past which a flick counts as dismiss intent. */
+const DISMISS_DISTANCE = 88
+/** px per ms — a fast flick dismisses even on a short drag. */
+const DISMISS_VELOCITY = 0.45
+/** Upward drag that promotes the sheet to the next snap point. */
+const EXPAND_DISTANCE = 40
+/** Backdrop left visible at the top so the sheet never reads as a full page. */
+const TOP_PEEK = 24
+const EXIT_MS = 240
+
+export function BottomSheet({
+  open,
+  onClose,
+  title,
+  headerAccessory,
+  snapPoints = [0.6],
+  initialSnapIndex = 0,
+  fitContent = false,
+  footer,
+  showHandle = true,
+  showCloseButton = true,
+  dismissOnBackdrop = true,
+  dismissible = true,
+  avoidKeyboard = true,
+  className,
+  contentClassName,
+  'aria-label': ariaLabel,
+  children,
+}: BottomSheetProps) {
+  const viewportHeight = useViewportHeight()
+  const rawKeyboardInset = useKeyboardInset()
+  const keyboardInset = avoidKeyboard ? rawKeyboardInset : 0
+
+  const [mounted, setMounted] = useState(open)
+  const [visible, setVisible] = useState(false)
+  const [snapIndex, setSnapIndex] = useState(initialSnapIndex)
+  const [dragY, setDragY] = useState(0)
+  const [dragging, setDragging] = useState(false)
+
+  const sheetRef = useRef<HTMLDivElement>(null)
+  const dragRef = useRef<{ startY: number; startTime: number; lastY: number; lastTime: number } | null>(null)
+
+  const requestClose = useCallback(() => {
+    if (!dismissible) return
+    onClose()
+  }, [dismissible, onClose])
+
+  // Mount/unmount around the transition so the exit animation can play.
+  useEffect(() => {
+    if (open) {
+      setMounted(true)
+      setSnapIndex(initialSnapIndex)
+      setDragY(0)
+      const frame = requestAnimationFrame(() => setVisible(true))
+      return () => cancelAnimationFrame(frame)
+    }
+    setVisible(false)
+    const timer = setTimeout(() => setMounted(false), EXIT_MS)
+    return () => clearTimeout(timer)
+    // `initialSnapIndex` is read only at open time — changing it mid-open
+    // would yank the sheet out from under the user.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open])
+
+  // Lock background scroll. Without this, scrolling inside the sheet chains to
+  // the page behind it and the whole app drifts under the sheet.
+  useEffect(() => {
+    if (!mounted) return
+    const previous = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = previous
+    }
+  }, [mounted])
+
+  useEffect(() => {
+    if (!open) return
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.stopPropagation()
+        requestClose()
+      }
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [open, requestClose])
+
+  useEffect(() => {
+    if (visible) sheetRef.current?.focus({ preventScroll: true })
+  }, [visible])
+
+  const available = Math.max(0, viewportHeight - keyboardInset)
+  const snap = snapPoints[Math.min(snapIndex, snapPoints.length - 1)] ?? 0.6
+  const sheetHeight = fitContent
+    ? undefined
+    : Math.min(available * snap, available - TOP_PEEK)
+
+  const onPointerDown = (event: React.PointerEvent) => {
+    if (!dismissible) return
+    dragRef.current = {
+      startY: event.clientY,
+      startTime: event.timeStamp,
+      lastY: event.clientY,
+      lastTime: event.timeStamp,
+    }
+    setDragging(true)
+    event.currentTarget.setPointerCapture(event.pointerId)
+  }
+
+  const onPointerMove = (event: React.PointerEvent) => {
+    const state = dragRef.current
+    if (!state) return
+    const delta = event.clientY - state.startY
+    state.lastY = event.clientY
+    state.lastTime = event.timeStamp
+    // Upward drag only travels if there is a larger snap point to reach.
+    const canExpand = !fitContent && snapIndex < snapPoints.length - 1
+    setDragY(delta < 0 && !canExpand ? delta * 0.25 : delta)
+  }
+
+  const endDrag = (event: React.PointerEvent) => {
+    const state = dragRef.current
+    if (!state) return
+    dragRef.current = null
+    setDragging(false)
+
+    const delta = event.clientY - state.startY
+    const elapsed = Math.max(1, event.timeStamp - state.startTime)
+    const velocity = delta / elapsed
+
+    setDragY(0)
+
+    const wantsDismiss = delta > DISMISS_DISTANCE || velocity > DISMISS_VELOCITY
+    const wantsExpand = delta < -EXPAND_DISTANCE || velocity < -DISMISS_VELOCITY
+
+    if (wantsDismiss) {
+      if (fitContent || snapIndex === 0) {
+        requestClose()
+      } else {
+        setSnapIndex(index => Math.max(0, index - 1))
+      }
+      return
+    }
+    if (wantsExpand && !fitContent && snapIndex < snapPoints.length - 1) {
+      setSnapIndex(index => Math.min(snapPoints.length - 1, index + 1))
+    }
+  }
+
+  if (!mounted || typeof document === 'undefined') return null
+
+  const translateY = visible ? Math.max(0, dragY) : (sheetHeight ?? 400) + 40
+
+  return createPortal(
+    <div className="fixed inset-0 z-[60] flex flex-col justify-end" role="presentation">
+      <div
+        className={clsx(
+          'absolute inset-0 bg-gray-900/40 transition-opacity duration-200',
+          visible ? 'opacity-100' : 'opacity-0'
+        )}
+        onClick={dismissOnBackdrop ? requestClose : undefined}
+        aria-hidden="true"
+      />
+
+      <div
+        ref={sheetRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label={ariaLabel ?? (typeof title === 'string' ? title : 'Sheet')}
+        tabIndex={-1}
+        className={clsx(
+          'relative flex flex-col w-full bg-white dark:bg-gray-900',
+          'rounded-t-2xl shadow-2xl border-t border-gray-200 dark:border-gray-700',
+          'outline-none overflow-hidden',
+          !dragging && 'transition-transform duration-300 ease-out',
+          className
+        )}
+        style={{
+          height: sheetHeight,
+          maxHeight: available - TOP_PEEK,
+          marginBottom: keyboardInset,
+          transform: `translateY(${translateY}px)`,
+        }}
+      >
+        {/* Drag affordance. Pointer handlers live on this row rather than the
+            whole sheet so drags inside the body scroll the content instead. */}
+        {(showHandle || title || showCloseButton) && (
+          <div
+            className="flex-shrink-0 touch-none select-none cursor-grab active:cursor-grabbing"
+            onPointerDown={onPointerDown}
+            onPointerMove={onPointerMove}
+            onPointerUp={endDrag}
+            onPointerCancel={endDrag}
+          >
+            {showHandle && (
+              <div className="flex justify-center pt-3 pb-1">
+                <div className="h-1.5 w-10 rounded-full bg-gray-300 dark:bg-gray-600" />
+              </div>
+            )}
+            {(title || showCloseButton || headerAccessory) && (
+              <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-100 dark:border-gray-800">
+                <div className="flex-1 min-w-0">
+                  {typeof title === 'string' ? (
+                    <h2 className="text-base font-semibold text-gray-900 dark:text-white truncate">{title}</h2>
+                  ) : (
+                    title
+                  )}
+                </div>
+                {headerAccessory}
+                {showCloseButton && (
+                  <button
+                    type="button"
+                    onClick={requestClose}
+                    disabled={!dismissible}
+                    className="flex items-center justify-center h-11 w-11 -mr-2 rounded-full text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800 disabled:opacity-40"
+                    aria-label="Close"
+                  >
+                    <X className="h-5 w-5" />
+                  </button>
+                )}
+              </div>
+            )}
+          </div>
+        )}
+
+        <div className={clsx('flex-1 min-h-0 overflow-y-auto overscroll-contain', contentClassName)}>
+          {children}
+        </div>
+
+        {footer && (
+          <div className="flex-shrink-0 border-t border-gray-200 dark:border-gray-700 px-4 py-3 pb-safe bg-white dark:bg-gray-900">
+            {footer}
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/src/components/mobile/DesktopOnlyCard.tsx
+++ b/src/components/mobile/DesktopOnlyCard.tsx
@@ -1,0 +1,77 @@
+import { clsx } from 'clsx'
+import { Monitor } from 'lucide-react'
+import { getMobileNavSurfaces, getMobileSurface } from '../../lib/mobile/mobile-surfaces'
+
+interface DesktopOnlyCardProps {
+  /** Tab type, used to look up the title and the reason. */
+  type: string
+  /** Overrides the registry title when a tab has a more specific name. */
+  title?: string
+  onOpenSurface?: (result: any) => void
+}
+
+/**
+ * Shown in place of a surface that has no phone treatment.
+ *
+ * The point is to be honest rather than to half-render a desktop layout: a
+ * clear reason plus somewhere useful to go beats a squeezed grid the user
+ * cannot operate.
+ */
+export function DesktopOnlyCard({ type, title, onOpenSurface }: DesktopOnlyCardProps) {
+  const surface = getMobileSurface(type)
+  const Icon = surface?.icon ?? Monitor
+  const heading = title ?? surface?.title ?? 'This surface'
+  const reason =
+    surface?.desktopReason ??
+    'This surface has not been adapted for phone screens yet, so it would not be usable here.'
+
+  const suggestions = getMobileNavSurfaces('core').slice(0, 6)
+
+  return (
+    <div className="h-full overflow-y-auto px-5 py-8">
+      <div className="mx-auto w-full max-w-md">
+        <div className={clsx('w-14 h-14 rounded-2xl flex items-center justify-center mb-5', surface?.bg ?? 'bg-gray-100')}>
+          <Icon className={clsx('h-7 w-7', surface?.color ?? 'text-gray-500')} />
+        </div>
+
+        <h1 className="text-xl font-semibold text-gray-900 dark:text-white">
+          {heading} is desktop only
+        </h1>
+        <p className="mt-2 text-sm leading-relaxed text-gray-600 dark:text-gray-300">{reason}</p>
+        <p className="mt-3 text-sm leading-relaxed text-gray-500 dark:text-gray-400">
+          Open Tesseract on a laptop to use it. Everything below works on your phone.
+        </p>
+
+        {onOpenSurface && (
+          <div className="mt-7">
+            <div className="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500 mb-2">
+              Available here
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              {suggestions.map(item => {
+                const ItemIcon = item.icon
+                return (
+                  <button
+                    key={item.type}
+                    type="button"
+                    onClick={() =>
+                      onOpenSurface({ id: item.type, title: item.title, type: item.type, data: null })
+                    }
+                    className="flex items-center gap-3 min-h-[56px] px-3 rounded-xl border border-gray-200 dark:border-gray-700 text-left hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+                  >
+                    <div className={clsx('w-8 h-8 rounded-lg flex items-center justify-center flex-shrink-0', item.bg)}>
+                      <ItemIcon className={clsx('h-4 w-4', item.color)} />
+                    </div>
+                    <span className="text-sm font-medium text-gray-800 dark:text-gray-100 truncate">
+                      {item.title}
+                    </span>
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/mobile/MobileNavDrawer.tsx
+++ b/src/components/mobile/MobileNavDrawer.tsx
@@ -1,0 +1,266 @@
+import { useEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
+import { clsx } from 'clsx'
+import { ChevronRight, Monitor, Search, X } from 'lucide-react'
+import { TesseractLogo } from '../ui/TesseractLogo'
+import { useOrganization } from '../../contexts/OrganizationContext'
+import {
+  getDesktopOnlyNavSurfaces,
+  getMobileNavSurfaces,
+  getMobileSurface,
+  type MobileSurface,
+} from '../../lib/mobile/mobile-surfaces'
+import type { Tab } from '../layout/TabManager'
+
+interface MobileNavDrawerProps {
+  open: boolean
+  onClose: () => void
+  onSearchResult?: (result: any) => void
+  onOpenSearch?: () => void
+  tabs: Tab[]
+  activeTabId?: string
+  onTabChange: (tabId: string) => void
+  onTabClose: (tabId: string) => void
+}
+
+/**
+ * Phone navigation. Replaces the desktop tab strip, which assumes you are
+ * juggling several surfaces at once — a workspace metaphor that does not
+ * survive a 390px screen.
+ *
+ * Open tabs are still reachable, but demoted to a "Recent" list rather than
+ * being the primary navigation model.
+ */
+export function MobileNavDrawer({
+  open,
+  onClose,
+  onSearchResult,
+  onOpenSearch,
+  tabs,
+  activeTabId,
+  onTabChange,
+  onTabClose,
+}: MobileNavDrawerProps) {
+  const { currentOrg } = useOrganization()
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const previous = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = previous
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [open, onClose])
+
+  useEffect(() => {
+    if (open) panelRef.current?.focus({ preventScroll: true })
+  }, [open])
+
+  const openSurface = (surface: MobileSurface) => {
+    onClose()
+    onSearchResult?.({ id: surface.type, title: surface.title, type: surface.type, data: null })
+  }
+
+  const recentTabs = tabs.filter(tab => !tab.isBlank)
+
+  if (typeof document === 'undefined') return null
+
+  return createPortal(
+    <div
+      className={clsx('fixed inset-0 z-[70]', open ? 'pointer-events-auto' : 'pointer-events-none')}
+      role="presentation"
+    >
+      <div
+        className={clsx(
+          'absolute inset-0 bg-gray-900/40 transition-opacity duration-200',
+          open ? 'opacity-100' : 'opacity-0'
+        )}
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      <div
+        ref={panelRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Navigation"
+        tabIndex={-1}
+        className={clsx(
+          'absolute inset-y-0 left-0 w-[86%] max-w-sm flex flex-col outline-none',
+          'bg-white dark:bg-gray-900 shadow-2xl',
+          'transition-transform duration-300 ease-out',
+          open ? 'translate-x-0' : '-translate-x-full'
+        )}
+      >
+        <div className="flex items-center gap-3 px-4 h-16 border-b border-gray-200 dark:border-gray-700 pt-safe">
+          <TesseractLogo size={26} />
+          <div className="flex-1 min-w-0">
+            <div className="text-sm font-semibold text-gray-900 dark:text-white truncate">
+              {currentOrg?.name ?? 'Tesseract'}
+            </div>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex items-center justify-center h-11 w-11 -mr-2 rounded-full text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800"
+            aria-label="Close navigation"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto overscroll-contain pb-safe">
+          {onOpenSearch && (
+            <div className="p-3">
+              <button
+                type="button"
+                onClick={() => {
+                  onClose()
+                  onOpenSearch()
+                }}
+                className="w-full flex items-center gap-3 h-12 px-3 rounded-xl bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400"
+              >
+                <Search className="h-5 w-5" />
+                <span className="text-sm">Search assets, notes, people…</span>
+              </button>
+            </div>
+          )}
+
+          {recentTabs.length > 0 && (
+            <NavSection title="Recent">
+              {recentTabs.map(tab => {
+                const surface = getMobileSurface(tab.type)
+                const Icon = surface?.icon
+                return (
+                  <div
+                    key={tab.id}
+                    className={clsx(
+                      'flex items-center gap-3 pl-4 pr-2 rounded-lg',
+                      tab.id === activeTabId && 'bg-primary-50 dark:bg-primary-900/20'
+                    )}
+                  >
+                    <button
+                      type="button"
+                      onClick={() => {
+                        onClose()
+                        onTabChange(tab.id)
+                      }}
+                      className="flex-1 flex items-center gap-3 min-h-[48px] text-left min-w-0"
+                    >
+                      {Icon ? (
+                        <Icon className={clsx('h-4 w-4 flex-shrink-0', surface?.color)} />
+                      ) : (
+                        <span className="h-4 w-4 flex-shrink-0" />
+                      )}
+                      <span
+                        className={clsx(
+                          'text-sm truncate',
+                          tab.id === activeTabId
+                            ? 'font-semibold text-primary-700 dark:text-primary-300'
+                            : 'text-gray-700 dark:text-gray-200'
+                        )}
+                      >
+                        {tab.title}
+                      </span>
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onTabClose(tab.id)}
+                      className="flex items-center justify-center h-11 w-11 rounded-full text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800"
+                      aria-label={`Close ${tab.title}`}
+                    >
+                      <X className="h-4 w-4" />
+                    </button>
+                  </div>
+                )
+              })}
+            </NavSection>
+          )}
+
+          <NavSection title="Core">
+            {getMobileNavSurfaces('core').map(surface => (
+              <NavRow key={surface.type} surface={surface} onSelect={openSurface} />
+            ))}
+          </NavSection>
+
+          <NavSection title="Work">
+            {getMobileNavSurfaces('work').map(surface => (
+              <NavRow key={surface.type} surface={surface} onSelect={openSurface} />
+            ))}
+          </NavSection>
+
+          <NavSection title="Desktop only">
+            <p className="px-4 pb-2 text-xs text-gray-400 dark:text-gray-500">
+              These need a larger screen. Opening one explains why.
+            </p>
+            {getDesktopOnlyNavSurfaces().map(surface => (
+              <NavRow key={surface.type} surface={surface} onSelect={openSurface} dimmed />
+            ))}
+          </NavSection>
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}
+
+function NavSection({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="pb-2">
+      <div className="px-4 pt-4 pb-1">
+        <span className="text-xs font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+          {title}
+        </span>
+      </div>
+      <div className="px-1">{children}</div>
+    </div>
+  )
+}
+
+function NavRow({
+  surface,
+  onSelect,
+  dimmed = false,
+}: {
+  surface: MobileSurface
+  onSelect: (surface: MobileSurface) => void
+  dimmed?: boolean
+}) {
+  const Icon = surface.icon
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(surface)}
+      className={clsx(
+        'w-full flex items-center gap-3 min-h-[52px] px-3 rounded-xl text-left',
+        'hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors',
+        dimmed && 'opacity-60'
+      )}
+    >
+      <div className={clsx('w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0', surface.bg)}>
+        <Icon className={clsx('h-5 w-5', surface.color)} />
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="text-sm font-medium text-gray-900 dark:text-gray-100">{surface.title}</div>
+        {surface.mobileNote && (
+          <div className="text-xs text-gray-500 dark:text-gray-400 truncate">{surface.mobileNote}</div>
+        )}
+      </div>
+      {dimmed ? (
+        <Monitor className="h-4 w-4 text-gray-400 flex-shrink-0" />
+      ) : (
+        <ChevronRight className="h-4 w-4 text-gray-300 dark:text-gray-600 flex-shrink-0" />
+      )}
+    </button>
+  )
+}

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,110 @@
+import { useEffect, useState } from 'react'
+
+/**
+ * Breakpoints intentionally match Tailwind's stock scale so that a
+ * `useIsMobile()` branch in JS and a `md:` prefix in CSS always agree.
+ * Divergence between the two is the classic source of "the layout is
+ * mobile but the component thinks it's desktop" bugs.
+ */
+export const MOBILE_QUERY = '(max-width: 767px)' // below Tailwind `md`
+export const TABLET_QUERY = '(min-width: 768px) and (max-width: 1023px)'
+export const COARSE_POINTER_QUERY = '(pointer: coarse)'
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return false
+    return window.matchMedia(query).matches
+  })
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return
+
+    const list = window.matchMedia(query)
+    // Re-sync on mount: the query may have changed between the lazy
+    // initializer and this effect (e.g. an orientation change during hydration).
+    setMatches(list.matches)
+
+    const onChange = (event: MediaQueryListEvent) => setMatches(event.matches)
+    list.addEventListener('change', onChange)
+    return () => list.removeEventListener('change', onChange)
+  }, [query])
+
+  return matches
+}
+
+/** True on phone-width viewports. The single switch for mobile layout branching. */
+export function useIsMobile(): boolean {
+  return useMediaQuery(MOBILE_QUERY)
+}
+
+export function useIsTablet(): boolean {
+  return useMediaQuery(TABLET_QUERY)
+}
+
+/**
+ * Touch-primary input, independent of width. Use this for hit-target and
+ * hover-affordance decisions — a hover-only toolbar is wrong on a touch
+ * laptop even when the viewport is wide.
+ */
+export function useIsTouch(): boolean {
+  return useMediaQuery(COARSE_POINTER_QUERY)
+}
+
+/**
+ * Visible viewport height, excluding the on-screen keyboard where the browser
+ * reports it. `window.innerHeight` does not shrink when the keyboard opens on
+ * iOS, so anything anchored to the bottom ends up underneath it.
+ */
+export function useViewportHeight(): number {
+  const [height, setHeight] = useState(() =>
+    typeof window === 'undefined' ? 0 : window.visualViewport?.height ?? window.innerHeight
+  )
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+
+    const update = () => setHeight(window.visualViewport?.height ?? window.innerHeight)
+    update()
+
+    const viewport = window.visualViewport
+    viewport?.addEventListener('resize', update)
+    viewport?.addEventListener('scroll', update)
+    window.addEventListener('resize', update)
+    window.addEventListener('orientationchange', update)
+    return () => {
+      viewport?.removeEventListener('resize', update)
+      viewport?.removeEventListener('scroll', update)
+      window.removeEventListener('resize', update)
+      window.removeEventListener('orientationchange', update)
+    }
+  }, [])
+
+  return height
+}
+
+/**
+ * Height of the space the on-screen keyboard is covering, in px (0 when closed).
+ * Bottom-anchored surfaces should offset by this so inputs stay visible.
+ */
+export function useKeyboardInset(): number {
+  const [inset, setInset] = useState(0)
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.visualViewport) return
+
+    const viewport = window.visualViewport
+    const update = () => {
+      setInset(Math.max(0, window.innerHeight - viewport.height - viewport.offsetTop))
+    }
+    update()
+
+    viewport.addEventListener('resize', update)
+    viewport.addEventListener('scroll', update)
+    return () => {
+      viewport.removeEventListener('resize', update)
+      viewport.removeEventListener('scroll', update)
+    }
+  }, [])
+
+  return inset
+}

--- a/src/index.css
+++ b/src/index.css
@@ -92,6 +92,92 @@
   }
 }
 
+@layer utilities {
+  /* Safe-area insets — notch and home-indicator padding. Zero on desktop. */
+  .pt-safe { padding-top: env(safe-area-inset-top, 0px); }
+  .pb-safe { padding-bottom: env(safe-area-inset-bottom, 0px); }
+  .pl-safe { padding-left: env(safe-area-inset-left, 0px); }
+  .pr-safe { padding-right: env(safe-area-inset-right, 0px); }
+
+  /* Opt in where a row genuinely must scroll sideways (a wide table kept as a
+     table). Adds momentum scrolling and stops the scroll chaining to the page. */
+  .mobile-scroll-x {
+    overflow-x: auto;
+    overscroll-behavior-x: contain;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  /* Opt out of the global minimum hit area below — for chips, inline badges
+     and dense toolbars where a 44px box would wreck the layout. */
+  .no-touch-target {
+    min-height: 0;
+    min-width: 0;
+  }
+}
+
+/* ---------------------------------------------------------------------------
+   Mobile base layer.
+
+   Scoped to phone widths so desktop rendering is untouched. These are blunt
+   global rules on purpose: the app has ~540 `p-1` wrappers and ~2,000 12-14px
+   icons, so per-component fixes do not scale. Use `.no-touch-target` to opt a
+   specific control out.
+   --------------------------------------------------------------------------- */
+@media (max-width: 767px) {
+  /* Horizontal scroll containment. Any single overflowing child otherwise
+     makes the entire page pannable, which breaks every fixed element. */
+  html,
+  body {
+    overflow-x: hidden;
+    max-width: 100vw;
+  }
+
+  #root {
+    overflow-x: hidden;
+    max-width: 100vw;
+  }
+
+  /* iOS zooms the viewport when a focused input's font-size is under 16px, and
+     never zooms back out. This is the single most common "my app feels broken
+     on iPhone" bug. */
+  input,
+  select,
+  textarea {
+    font-size: 16px;
+  }
+
+  /* Kill the grey flash on tap; we render our own active states. */
+  a,
+  button,
+  [role='button'] {
+    -webkit-tap-highlight-color: transparent;
+  }
+}
+
+@media (max-width: 767px) and (pointer: coarse) {
+  button:not(.no-touch-target),
+  [role='button']:not(.no-touch-target),
+  [role='tab']:not(.no-touch-target),
+  select:not(.no-touch-target) {
+    min-height: 44px;
+    min-width: 44px;
+  }
+
+  /* Inline controls inside prose or a text run should not become 44px blocks. */
+  p button:not(.no-touch-target),
+  span > button:not(.no-touch-target),
+  label button:not(.no-touch-target) {
+    min-height: 0;
+    min-width: 0;
+  }
+
+  /* Hover-reveal patterns have no touch equivalent — show them outright. */
+  .group:hover .group-hover\:opacity-100,
+  .opacity-0.group-hover\:opacity-100 {
+    opacity: 1;
+  }
+}
+
 @layer components {
   .sidebar-nav-item {
     @apply flex items-center px-3 py-2 text-sm font-medium rounded-lg transition-all duration-200;

--- a/src/lib/mobile/mobile-surfaces.ts
+++ b/src/lib/mobile/mobile-surfaces.ts
@@ -1,0 +1,219 @@
+import {
+  Activity, Beaker, BookOpen, Briefcase, Building2, Calendar, FileText, Flag,
+  FolderKanban, FolderOpen, LineChart, Lightbulb, List, ListTodo, Repeat,
+  Shield, StickyNote, Tag, Target, TrendingUp, Users,
+} from 'lucide-react'
+import type { LucideIcon } from 'lucide-react'
+
+/**
+ * How much of a surface works on a phone.
+ *
+ *  full         — purpose-built mobile treatment, including editing.
+ *  read-only    — safe to view on a phone; authoring stays on desktop.
+ *  desktop-only — renders a DesktopOnlyCard instead of the real surface.
+ *
+ * This registry is the one place "what works on mobile" is decided. Adding a
+ * mobile treatment to a surface should be a one-line change here plus the
+ * component work — never a scattered hunt for breakpoint branches.
+ */
+export type MobileSupportLevel = 'full' | 'read-only' | 'desktop-only'
+
+export type MobileSurfaceGroup = 'core' | 'work' | 'admin'
+
+export interface MobileSurface {
+  /** Matches `Tab['type']` in components/layout/TabManager.tsx. */
+  type: string
+  title: string
+  icon: LucideIcon
+  color: string
+  bg: string
+  support: MobileSupportLevel
+  group: MobileSurfaceGroup
+  /** Shown on the DesktopOnlyCard. Say what the constraint actually is. */
+  desktopReason?: string
+  /** Shown in the nav drawer for partially-supported surfaces. */
+  mobileNote?: string
+  /** Surfaces reachable from the drawer. Detail types (asset, note) are not. */
+  inNav?: boolean
+}
+
+export const MOBILE_SURFACES: MobileSurface[] = [
+  // ---- Core ---------------------------------------------------------------
+  {
+    type: 'dashboard', title: 'Dashboard', icon: Activity,
+    color: 'text-primary-600', bg: 'bg-primary-50',
+    support: 'full', group: 'core', inNav: true,
+  },
+  {
+    type: 'idea-generator', title: 'Ideas', icon: Lightbulb,
+    color: 'text-purple-500', bg: 'bg-purple-50',
+    support: 'full', group: 'core', inNav: true,
+  },
+  {
+    type: 'trade-queue', title: 'Pipeline', icon: ListTodo,
+    color: 'text-amber-500', bg: 'bg-amber-50',
+    support: 'full', group: 'core', inNav: true,
+    mobileNote: 'One stage at a time — tap a card to move it',
+  },
+  {
+    type: 'trade-lab', title: 'Trade Lab', icon: Beaker,
+    color: 'text-orange-500', bg: 'bg-orange-50',
+    support: 'full', group: 'core', inNav: true,
+    mobileNote: 'Size positions from the holdings list',
+  },
+  {
+    type: 'trade-book', title: 'Trade Book', icon: BookOpen,
+    color: 'text-indigo-500', bg: 'bg-indigo-50',
+    support: 'full', group: 'core', inNav: true,
+    mobileNote: 'Read and update execution status',
+  },
+  {
+    type: 'assets-list', title: 'Assets', icon: TrendingUp,
+    color: 'text-blue-500', bg: 'bg-blue-50',
+    support: 'read-only', group: 'core', inNav: true,
+    mobileNote: 'Search and read — the grid stays on desktop',
+  },
+  {
+    type: 'asset', title: 'Asset', icon: TrendingUp,
+    color: 'text-blue-500', bg: 'bg-blue-50',
+    support: 'full', group: 'core',
+    mobileNote: 'Read and edit case narrative',
+  },
+  {
+    type: 'notes-list', title: 'Notes', icon: StickyNote,
+    color: 'text-yellow-600', bg: 'bg-yellow-50',
+    support: 'full', group: 'core', inNav: true,
+  },
+  { type: 'note', title: 'Note', icon: StickyNote, color: 'text-yellow-600', bg: 'bg-yellow-50', support: 'full', group: 'core' },
+  {
+    type: 'priorities', title: 'Priorities', icon: Flag,
+    color: 'text-rose-500', bg: 'bg-rose-50',
+    support: 'read-only', group: 'core', inNav: true,
+  },
+  {
+    type: 'outcomes', title: 'Outcomes', icon: Target,
+    color: 'text-teal-500', bg: 'bg-teal-50',
+    support: 'read-only', group: 'core', inNav: true,
+  },
+  {
+    type: 'portfolios-list', title: 'Portfolios', icon: Briefcase,
+    color: 'text-emerald-500', bg: 'bg-emerald-50',
+    support: 'read-only', group: 'core', inNav: true,
+  },
+  { type: 'portfolio', title: 'Portfolio', icon: Briefcase, color: 'text-emerald-500', bg: 'bg-emerald-50', support: 'read-only', group: 'core' },
+  {
+    type: 'themes-list', title: 'Themes', icon: Tag,
+    color: 'text-fuchsia-500', bg: 'bg-fuchsia-50',
+    support: 'read-only', group: 'core', inNav: true,
+  },
+  { type: 'theme', title: 'Theme', icon: Tag, color: 'text-fuchsia-500', bg: 'bg-fuchsia-50', support: 'read-only', group: 'core' },
+
+  // ---- Work management ----------------------------------------------------
+  {
+    type: 'lists', title: 'Lists', icon: List,
+    color: 'text-violet-500', bg: 'bg-violet-50',
+    support: 'read-only', group: 'work', inNav: true,
+  },
+  { type: 'list', title: 'List', icon: List, color: 'text-violet-500', bg: 'bg-violet-50', support: 'read-only', group: 'work' },
+  {
+    type: 'projects-list', title: 'Projects', icon: FolderKanban,
+    color: 'text-indigo-500', bg: 'bg-indigo-50',
+    support: 'read-only', group: 'work', inNav: true,
+  },
+  { type: 'project', title: 'Project', icon: FolderKanban, color: 'text-indigo-500', bg: 'bg-indigo-50', support: 'read-only', group: 'work' },
+  {
+    type: 'calendar', title: 'Calendar', icon: Calendar,
+    color: 'text-sky-500', bg: 'bg-sky-50',
+    support: 'read-only', group: 'work', inNav: true,
+  },
+  {
+    type: 'files', title: 'Files', icon: FolderOpen,
+    color: 'text-slate-500', bg: 'bg-slate-100',
+    support: 'read-only', group: 'work', inNav: true,
+  },
+  {
+    type: 'workflows', title: 'Process', icon: Repeat,
+    color: 'text-cyan-500', bg: 'bg-cyan-50',
+    support: 'desktop-only', group: 'work', inNav: true,
+    desktopReason: 'Building and running a workflow needs the multi-step wizard and side-by-side run views, which assume a wide screen.',
+  },
+  {
+    type: 'templates', title: 'Templates', icon: FileText,
+    color: 'text-amber-600', bg: 'bg-amber-50',
+    support: 'desktop-only', group: 'work', inNav: true,
+    desktopReason: 'The template editors are drag-and-drop field builders with spreadsheet-style grids.',
+  },
+  {
+    type: 'coverage', title: 'Coverage', icon: Users,
+    color: 'text-sky-500', bg: 'bg-sky-50',
+    support: 'desktop-only', group: 'work', inNav: true,
+    desktopReason: 'The coverage matrix is an analyst-by-asset grid that has no meaningful phone layout.',
+  },
+
+  // ---- Admin / analysis ---------------------------------------------------
+  {
+    type: 'organization', title: 'Organization', icon: Building2,
+    color: 'text-gray-500', bg: 'bg-gray-100',
+    support: 'desktop-only', group: 'admin', inNav: true,
+    desktopReason: 'Member, team, and permission management involves dense tables and bulk edits.',
+  },
+  {
+    type: 'asset-allocation', title: 'Allocation', icon: Briefcase,
+    color: 'text-emerald-600', bg: 'bg-emerald-50',
+    support: 'desktop-only', group: 'admin', inNav: true,
+    desktopReason: 'The allocation grid needs at least 900px to stay readable.',
+  },
+  {
+    type: 'charting', title: 'Charting', icon: LineChart,
+    color: 'text-blue-600', bg: 'bg-blue-50',
+    support: 'desktop-only', group: 'admin', inNav: true,
+    desktopReason: 'Multi-series charting depends on a large canvas and pointer-precise interaction.',
+  },
+  {
+    type: 'audit', title: 'Audit', icon: Shield,
+    color: 'text-gray-600', bg: 'bg-gray-100',
+    support: 'desktop-only', group: 'admin', inNav: true,
+    desktopReason: 'The audit explorer is a wide event table with column-level filtering.',
+  },
+  {
+    type: 'tdf-list', title: 'Target Date', icon: Target,
+    color: 'text-teal-600', bg: 'bg-teal-50',
+    support: 'desktop-only', group: 'admin', inNav: true,
+    desktopReason: 'Glide-path modelling is a wide numeric grid.',
+  },
+  {
+    type: 'tdf', title: 'Target Date Fund', icon: Target, color: 'text-teal-600', bg: 'bg-teal-50',
+    support: 'desktop-only', group: 'admin',
+    desktopReason: 'Glide-path modelling is a wide numeric grid.',
+  },
+]
+
+const BY_TYPE = new Map(MOBILE_SURFACES.map(surface => [surface.type, surface]))
+
+export function getMobileSurface(type: string | undefined): MobileSurface | undefined {
+  if (!type) return undefined
+  return BY_TYPE.get(type)
+}
+
+/**
+ * Unregistered surfaces default to `desktop-only` on purpose: a new tab type
+ * added without a mobile decision should show an honest card, not a broken
+ * desktop layout squeezed into 390px.
+ */
+export function getMobileSupport(type: string | undefined): MobileSupportLevel {
+  return getMobileSurface(type)?.support ?? 'desktop-only'
+}
+
+export function isDesktopOnly(type: string | undefined): boolean {
+  return getMobileSupport(type) === 'desktop-only'
+}
+
+/** Surfaces usable on a phone, for the nav drawer's primary sections. */
+export function getMobileNavSurfaces(group: MobileSurfaceGroup): MobileSurface[] {
+  return MOBILE_SURFACES.filter(s => s.inNav && s.group === group && s.support !== 'desktop-only')
+}
+
+/** Nav entries that will render a DesktopOnlyCard — listed but de-emphasised. */
+export function getDesktopOnlyNavSurfaces(): MobileSurface[] {
+  return MOBILE_SURFACES.filter(s => s.inNav && s.support === 'desktop-only')
+}

--- a/src/lib/mobile/popover-position.ts
+++ b/src/lib/mobile/popover-position.ts
@@ -1,0 +1,103 @@
+import type { CSSProperties } from 'react'
+
+/**
+ * Viewport-safe positioning for popovers, dropdowns and context menus.
+ *
+ * The pattern this replaces is scattered across ~30 components:
+ *
+ *     left: Math.min(x, window.innerWidth - 320)
+ *
+ * On a 390px-wide phone that evaluates to `min(x, 70)`, and for any popover
+ * wider than the viewport it goes negative — the panel hangs off the left edge
+ * and drags the page into horizontal scroll. These helpers clamp on both axes
+ * and fall back to a full-width sheet when the preferred width simply does not
+ * fit.
+ */
+
+export interface PopoverPlacementInput {
+  /** Anchor point in viewport coordinates (e.g. from getBoundingClientRect). */
+  x: number
+  y: number
+  /** Preferred width in px. */
+  width: number
+  /** Estimated height in px. Enables vertical flipping when known. */
+  height?: number
+  /** Minimum gap from the viewport edge. */
+  margin?: number
+  /** Gap between the anchor and the panel when flipping vertically. */
+  offset?: number
+}
+
+export interface PopoverPlacement {
+  left: number
+  top: number
+  /** Apply as `maxWidth` — narrower than `width` when the viewport is small. */
+  maxWidth: number
+  /** Apply as `maxHeight` so long menus scroll instead of overflowing. */
+  maxHeight: number
+  /** True when the panel was flipped above the anchor. */
+  flipped: boolean
+}
+
+const DEFAULT_MARGIN = 8
+const DEFAULT_OFFSET = 4
+
+export function placePopover({
+  x,
+  y,
+  width,
+  height,
+  margin = DEFAULT_MARGIN,
+  offset = DEFAULT_OFFSET,
+}: PopoverPlacementInput): PopoverPlacement {
+  const viewportWidth = typeof window === 'undefined' ? 1024 : window.innerWidth
+  const viewportHeight =
+    typeof window === 'undefined'
+      ? 768
+      : window.visualViewport?.height ?? window.innerHeight
+
+  const available = Math.max(0, viewportWidth - margin * 2)
+  // Never promise more width than exists — this is the case the old
+  // `innerWidth - 320` arithmetic got wrong.
+  const maxWidth = Math.min(width, available)
+
+  // Clamp low bound last so a too-wide panel pins to the left margin rather
+  // than to a negative offset.
+  const left = Math.max(margin, Math.min(x, viewportWidth - maxWidth - margin))
+
+  let top = y
+  let flipped = false
+  let maxHeight = Math.max(0, viewportHeight - y - margin)
+
+  if (height != null) {
+    const spaceBelow = viewportHeight - y - margin
+    const spaceAbove = y - margin
+
+    if (height > spaceBelow && spaceAbove > spaceBelow) {
+      flipped = true
+      top = Math.max(margin, y - height - offset)
+      maxHeight = Math.max(0, y - offset - margin)
+    } else {
+      maxHeight = Math.max(0, spaceBelow)
+    }
+  }
+
+  top = Math.max(margin, Math.min(top, viewportHeight - margin))
+
+  return { left, top, maxWidth, maxHeight, flipped }
+}
+
+/**
+ * True when a popover of this width cannot sit comfortably in the viewport and
+ * should be presented as a bottom sheet instead of an anchored panel.
+ */
+export function shouldUseSheet(width: number, margin = DEFAULT_MARGIN): boolean {
+  const viewportWidth = typeof window === 'undefined' ? 1024 : window.innerWidth
+  return width > viewportWidth - margin * 2
+}
+
+/** Convenience for the common `style={{ ... }}` spread on an absolute panel. */
+export function popoverStyle(input: PopoverPlacementInput): CSSProperties {
+  const { left, top, maxWidth, maxHeight } = placePopover(input)
+  return { left, top, maxWidth, maxHeight, overflowY: 'auto' }
+}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -19,6 +19,9 @@ import { ThemeTab } from '../components/tabs/ThemeTab'
 import { PortfolioTab } from '../components/tabs/PortfolioTab'
 import { ListTab } from '../components/tabs/ListTab'
 import { BlankTab } from '../components/tabs/BlankTab.tsx'
+import { DesktopOnlyCard } from '../components/mobile/DesktopOnlyCard'
+import { isDesktopOnly } from '../lib/mobile/mobile-surfaces'
+import { useIsMobile } from '../hooks/useMediaQuery'
 const IdeaGeneratorPage = lazy(() => import('./IdeaGeneratorPage').then(m => ({ default: m.IdeaGeneratorPage })))
 const WorkflowsPage = lazy(() => import('./WorkflowsPage').then(m => ({ default: m.WorkflowsPage })))
 import { ProjectsPage } from './ProjectsPage'
@@ -206,6 +209,9 @@ export function DashboardPage() {
 
   // Session tracking (heartbeat-based)
   useSessionTracking()
+
+  // Gates the desktop-only fallback in renderTabContent.
+  const isMobile = useIsMobile()
 
   // ─── Pilot Mode gating ───────────────────────────────────────────────
   const pilotMode = usePilotMode()
@@ -912,6 +918,19 @@ export function DashboardPage() {
 
     if (activeTab.isBlank) {
       return <BlankTab onSearchResult={handleSearchResult} />
+    }
+
+    // Surfaces with no phone treatment get an honest explanation rather than a
+    // desktop layout crushed into 390px. What is and isn't supported lives in
+    // lib/mobile/mobile-surfaces.ts — unregistered types default to desktop-only.
+    if (isMobile && isDesktopOnly(activeTab.type)) {
+      return (
+        <DesktopOnlyCard
+          type={activeTab.type}
+          title={activeTab.title}
+          onOpenSurface={handleSearchResult}
+        />
+      )
     }
 
     // Pilot mode substitution: render read-only preview components for

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -98,9 +98,16 @@ export default {
           900: '#581c87',
         },
       },
+      screens: {
+        // Narrow-phone breakpoint below Tailwind's `sm`. Stock breakpoints are
+        // otherwise unchanged so `useIsMobile()` and `md:` stay in agreement.
+        'xs': '480px',
+      },
       spacing: {
         '18': '4.5rem',
         '88': '22rem',
+        'safe-top': 'env(safe-area-inset-top, 0px)',
+        'safe-bottom': 'env(safe-area-inset-bottom, 0px)',
       },
       animation: {
         'fade-in': 'fadeIn 0.5s ease-in-out',


### PR DESCRIPTION
Phase 0 of mobile support. Adds the primitives every later phase depends on, without changing any product surface.

The app was desktop-only: a Chrome-tab workspace with a fixed 384px right rail and pixel-width tables. Only 109 of ~620 .tsx files contained a single responsive breakpoint, there was no media-query hook at all, and matchMedia was used exactly once (for dark mode).

Foundation:
- useMediaQuery / useIsMobile / useIsTouch / useKeyboardInset. Breakpoints match Tailwind's stock scale so a JS branch and a `md:` prefix cannot disagree.
- lib/mobile/mobile-surfaces.ts — one registry deciding full / read-only / desktop-only per tab type. Unregistered types default to desktop-only so a new surface cannot accidentally ship a broken phone layout.
- BottomSheet — snap points, drag-to-dismiss with velocity, and visualViewport keyboard avoidance. Built to host the Trade Lab sizing editor, where an input hidden behind the keyboard makes it unusable.
- MobileNavDrawer — the Tesseract mark opens this instead of the app launcher dropdown, which is wider than a phone viewport. Open tabs become a "Recent" list.
- DesktopOnlyCard — honest fallback naming the constraint.
- lib/mobile/popover-position.ts — replaces the Math.min(x, innerWidth - 320) pattern, which goes negative at 390px and forces horizontal scroll. Not yet adopted by the ~30 call sites.

Shell:
- TabManager hidden below md; the tab metaphor assumes juggling several surfaces at once.
- mr-96 no longer applies on mobile — it reserved 384px of a 390px viewport. Comm pane becomes a bottom sheet.
- Desktop-only guard in DashboardPage.renderTabContent.

Global CSS (phone widths only, desktop rendering untouched):
- overflow-x containment on html/body/#root; one overflowing child otherwise makes the whole page pannable and breaks fixed elements.
- 16px minimum input font-size — iOS zooms on focus below that and never zooms back out.
- 44px minimum hit areas on coarse pointers, with a .no-touch-target opt-out. Deliberately blunt: there are ~540 p-1 wrappers and ~2,000 12-14px icons, so per-component fixes do not scale.

Not yet validated on a physical device.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
