### PR TITLE
fix(theme): boot loader follows the app theme

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -17,6 +17,21 @@
     color-scheme: dark;
   }
 
+  /* Boot loader theming. index.html hardcodes the light palette because it
+     paints before any CSS or JS runs, and the CSP (script-src 'self') blocks
+     the usual inline theme-detection script. Once this stylesheet is in, the
+     loader tracks the theme — which matters most on re-shows (org switch),
+     where a full-screen white flash over a dark app is very visible. */
+  :root.dark #tesseract-boot-loader {
+    background: #111827;
+    color: #6b7280;
+  }
+
+  :root.dark #tesseract-boot-loader .ring {
+    border-color: #374151;
+    border-top-color: #6366f1;
+  }
+
   html {
     font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   }


### PR DESCRIPTION
index.html paints #tesseract-boot-loader with a hardcoded light palette (#f9fafb) because it renders before any CSS or JS runs. Now that dark mode is real, a dark-mode user gets a full-screen white flash on every cold boot, and again on every org switch where the loader is re-shown over an already-dark app.

The usual fix — an inline script that reads the stored theme and sets a class before first paint — is blocked by the CSP (script-src 'self'), so this is done in CSS. The initial cold-boot frame is still light (nothing can style it earlier without violating CSP), but every subsequent re-show tracks the theme.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
