### PR TITLE
fix(mobile): full-screen search, header fit, and real overflow contai…

### DIFF
--- a/src/components/ideas/feed/IdeasFeedPage.tsx
+++ b/src/components/ideas/feed/IdeasFeedPage.tsx
@@ -229,10 +229,11 @@ export function IdeasFeedPage({ onItemSelect }: IdeasFeedPageProps) {
   return (
     <div className="h-full flex flex-col bg-gray-50/50">
       {/* ═══ HEADER ═══ */}
-      <div className="bg-white border-b border-gray-100 px-6 py-2.5 shrink-0 dark:border-gray-800 dark:bg-gray-800">
+      <div className="bg-white border-b border-gray-100 px-3 md:px-6 py-2.5 shrink-0 dark:border-gray-800 dark:bg-gray-800">
         <div className="max-w-[1060px] mx-auto">
-          {/* Title + mode + actions row */}
-          <div className="flex items-center justify-between mb-2">
+          {/* Title + mode + actions row. Wraps on phones — the mode toggle and
+              action buttons together exceed a 390px row. */}
+          <div className="flex flex-wrap items-center justify-between gap-y-2 mb-2 min-w-0">
             <div className="flex items-center gap-4">
               <h1 className="text-[16px] font-semibold text-gray-900 flex items-center gap-2 dark:text-white">
                 <Lightbulb className="w-4.5 h-4.5 text-primary-600" />
@@ -344,7 +345,7 @@ export function IdeasFeedPage({ onItemSelect }: IdeasFeedPageProps) {
 
       {/* ═══ FEED ═══ */}
       <div className="flex-1 overflow-y-auto">
-        <div className="max-w-[1060px] mx-auto px-4 py-3">
+        <div className="max-w-[1060px] mx-auto px-3 md:px-4 py-3">
           {/* Loading state */}
           {isLoading && <FeedSkeleton count={5} />}
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { useQuery } from '@tanstack/react-query'
-import { Bell, Mail, User, Users, Settings, LogOut, ChevronDown, Lightbulb, Building2, FileText, Target, Calendar, FolderKanban, TrendingUp, Briefcase, List, Repeat, LineChart, FolderOpen, ListTodo, BookOpen, Activity, Plus, Shield, Flag, Beaker, Lock, Sparkles, Tag, StickyNote } from 'lucide-react'
+import { Bell, Mail, User, Users, Settings, LogOut, ChevronDown, Lightbulb, Building2, FileText, Target, Calendar, FolderKanban, TrendingUp, Briefcase, List, Repeat, LineChart, FolderOpen, ListTodo, BookOpen, Activity, Plus, Shield, Flag, Beaker, Lock, Sparkles, Tag, StickyNote, Search } from 'lucide-react'
 import { clsx } from 'clsx'
 import { useAuth } from '../../hooks/useAuth'
 import { useNotifications } from '../../hooks/useNotifications'
@@ -16,6 +16,7 @@ import { SettingsPage } from '../../pages/SettingsPage'
 import { SetupWizard } from '../onboarding/SetupWizard'
 import { TesseractLogo } from '../ui/TesseractLogo'
 import { useIsMobile } from '../../hooks/useMediaQuery'
+import { MobileSearchOverlay } from '../mobile/MobileSearchOverlay'
 // SetupWizard removed — org creation disabled for normal users
 
 interface HeaderProps {
@@ -48,6 +49,7 @@ export function Header({
   onOpenMobileNav
 }: HeaderProps) {
   const isMobile = useIsMobile()
+  const [showMobileSearch, setShowMobileSearch] = useState(false)
   const [showUserMenu, setShowUserMenu] = useState(false)
   const [showAppMenu, setShowAppMenu] = useState(false)
   const [showOrgSwitcher, setShowOrgSwitcher] = useState(false)
@@ -168,6 +170,14 @@ export function Header({
     }
     window.addEventListener('openSettings', handleOpenSettings)
     return () => window.removeEventListener('openSettings', handleOpenSettings)
+  }, [])
+
+  // The mobile nav drawer's search row opens the same overlay. An event keeps
+  // the drawer (rendered by Layout) from having to thread state through Header.
+  useEffect(() => {
+    const handler = () => setShowMobileSearch(true)
+    window.addEventListener('open-mobile-search', handler)
+    return () => window.removeEventListener('open-mobile-search', handler)
   }, [])
 
   // Subscribe to real-time message updates
@@ -612,10 +622,12 @@ export function Header({
               </>
             )}
 
-            {/* Search — must be allowed to shrink on phones (min-w-0), or it
-                holds the row wider than the viewport and forces horizontal
-                scroll. Search stays visible on mobile; the icon buttons go. */}
-            <div className="flex-1 min-w-0 ml-2 md:max-w-lg md:ml-5">
+            {/* Search. Hidden on phones: an <input> has an intrinsic
+                min-content width from its default `size` (~20 chars), which
+                `min-w-0` on the wrapper cannot shrink past — it held the header
+                wider than the viewport and pushed the profile off-screen. Phones
+                get a search icon that opens MobileSearchOverlay instead. */}
+            <div className="hidden md:block flex-1 min-w-0 md:max-w-lg md:ml-5">
               <GlobalSearch onSelectResult={onSearchResult} onFocusSearch={onFocusSearch} />
             </div>
 
@@ -636,6 +648,16 @@ export function Header({
               390px viewport. Thoughts, AI and DMs are reachable from the nav
               drawer instead. */}
           <div className="flex items-center flex-shrink-0 space-x-0.5 md:space-x-4">
+            {/* Mobile search entry point — replaces the inline input below md */}
+            <button
+              onClick={() => setShowMobileSearch(true)}
+              className="md:hidden flex items-center justify-center h-11 w-11 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+              aria-label="Search"
+              title="Search"
+            >
+              <Search className="h-5 w-5" />
+            </button>
+
             {/* Capture Thought Button */}
             <button
               onClick={() => {
@@ -879,6 +901,11 @@ export function Header({
 
       {/* Org Setup Wizard — only manually triggered, never auto-opens */}
       {/* Org creation is disabled for normal users; provisioned by platform admin only */}
+      <MobileSearchOverlay
+        open={showMobileSearch}
+        onClose={() => setShowMobileSearch(false)}
+        onSelectResult={onSearchResult}
+      />
     </header>
   )
 }

--- a/src/components/mobile/MobileNavDrawer.tsx
+++ b/src/components/mobile/MobileNavDrawer.tsx
@@ -126,7 +126,8 @@ export function MobileNavDrawer({
                 type="button"
                 onClick={() => {
                   onClose()
-                  onOpenSearch()
+                  // Header owns the full-screen search overlay.
+                  window.dispatchEvent(new CustomEvent('open-mobile-search'))
                 }}
                 className="w-full flex items-center gap-3 h-12 px-3 rounded-xl bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400"
               >

--- a/src/components/mobile/MobileSearchOverlay.tsx
+++ b/src/components/mobile/MobileSearchOverlay.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useRef } from 'react'
+import { createPortal } from 'react-dom'
+import { clsx } from 'clsx'
+import { ArrowLeft } from 'lucide-react'
+import { GlobalSearch } from '../search/GlobalSearch'
+
+interface MobileSearchOverlayProps {
+  open: boolean
+  onClose: () => void
+  onSelectResult: (result: any) => void
+}
+
+/**
+ * Full-screen search for phones.
+ *
+ * The header cannot host a text input at this width: an `<input>` carries an
+ * intrinsic min-content width from its default `size` attribute (~20
+ * characters), which no amount of `flex-1 min-w-0` on the wrapper can shrink
+ * past. That single element was holding the header row wider than the
+ * viewport, truncating the placeholder and pushing the profile button
+ * off-screen. Promoting search to its own surface removes the constraint
+ * instead of fighting it, and gives results the full screen to render in.
+ */
+export function MobileSearchOverlay({ open, onClose, onSelectResult }: MobileSearchOverlayProps) {
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!open) return
+    const previous = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.body.style.overflow = previous
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [open, onClose])
+
+  // Focus the search field once the panel is on screen. GlobalSearch owns its
+  // own input ref, so reach for it through the DOM rather than threading a ref
+  // through a shared component used on desktop too.
+  useEffect(() => {
+    if (!open) return
+    const timer = setTimeout(() => {
+      panelRef.current?.querySelector('input')?.focus()
+    }, 60)
+    return () => clearTimeout(timer)
+  }, [open])
+
+  if (!open || typeof document === 'undefined') return null
+
+  return createPortal(
+    <div
+      ref={panelRef}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Search"
+      className={clsx(
+        'fixed inset-0 z-[80] flex flex-col',
+        'bg-white dark:bg-gray-900'
+      )}
+    >
+      <div className="flex items-center gap-2 px-2 h-16 pt-safe border-b border-gray-200 dark:border-gray-700">
+        <button
+          type="button"
+          onClick={onClose}
+          className="flex items-center justify-center h-11 w-11 flex-shrink-0 rounded-full text-gray-600 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-800"
+          aria-label="Close search"
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </button>
+        <div className="flex-1 min-w-0">
+          <GlobalSearch
+            placeholder="Search…"
+            onSelectResult={result => {
+              onClose()
+              onSelectResult(result)
+            }}
+          />
+        </div>
+      </div>
+
+      <div className="flex-1 overflow-y-auto overscroll-contain" />
+    </div>,
+    document.body
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -165,16 +165,40 @@
    --------------------------------------------------------------------------- */
 @media (max-width: 767px) {
   /* Horizontal scroll containment. Any single overflowing child otherwise
-     makes the entire page pannable, which breaks every fixed element. */
+     makes the entire page pannable, which breaks every fixed element.
+     `clip` rather than `hidden`: `hidden` still creates a scroll container
+     that can be panned by touch and scrolled programmatically, which is why
+     the page remained draggable into whitespace. `clip` genuinely clips.
+     Paired with a `hidden` fallback for browsers without overflow: clip. */
   html,
   body {
     overflow-x: hidden;
-    max-width: 100vw;
+    overflow-x: clip;
+    max-width: 100%;
   }
 
   #root {
     overflow-x: hidden;
-    max-width: 100vw;
+    overflow-x: clip;
+    max-width: 100%;
+  }
+
+  /* Inputs and textareas carry an intrinsic min-content width from their
+     `size`/`cols` attributes that `min-w-0` on a wrapper cannot override.
+     Inside a flex row this silently holds the row wider than the viewport. */
+  input,
+  textarea,
+  select {
+    min-width: 0;
+  }
+
+  /* Media should never be the thing that widens a row. */
+  img,
+  svg,
+  video,
+  canvas,
+  table {
+    max-width: 100%;
   }
 
   /* iOS zooms the viewport when a focused input's font-size is under 16px, and


### PR DESCRIPTION
…nment

Three reported defects on a phone: search placeholder truncated, profile button off-screen, and the page still draggable sideways into whitespace.

Root cause of the header overflow was the search input itself. An <input> carries an intrinsic min-content width from its default `size` (~20 characters) that `flex-1 min-w-0` on the wrapper cannot shrink past — and the 16px minimum font-size added for iOS made it wider still. The row therefore stayed wider than the viewport and pushed the profile off the right edge.

- Hide the inline search below md; add a search icon that opens a new MobileSearchOverlay (full-screen, autofocused, results get the whole screen). The nav drawer's search row opens the same overlay via an event so it needn't thread state through Header.
- input/textarea/select get `min-width: 0` on phones so no form control can silently hold a flex row open.

Overflow containment was also wrong: `overflow-x: hidden` still creates a scroll container that can be panned by touch, which is exactly what was happening. Switched to `overflow-x: clip` (with `hidden` as the fallback declaration), which genuinely clips. Added `max-width: 100%` for img, svg, video, canvas and table.

Ideas feed: header row now wraps instead of overflowing, and horizontal padding drops from px-6/px-4 to px-3 on phones.

Type errors unchanged from main (9178 pre-existing, none introduced).

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
