### PR TITLE
feat(mobile): on-device overflow auditor behind ?overflow=1

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -12,6 +12,7 @@ import { useSidebarStore, type InspectableItemType } from '../../stores/sidebarS
 import { useOrganization } from '../../contexts/OrganizationContext'
 import { useIsMobile } from '../../hooks/useMediaQuery'
 import { MobileNavDrawer } from '../mobile/MobileNavDrawer'
+import { OverflowAuditOverlay } from '../mobile/OverflowAuditOverlay'
 
 interface LayoutProps {
   children: React.ReactNode
@@ -496,6 +497,9 @@ export function Layout({
           }
         }}
       />
+
+      {/* Inert unless the URL carries ?overflow=1 */}
+      <OverflowAuditOverlay />
 
       {isMobile && (
         <MobileNavDrawer

--- a/src/components/mobile/OverflowAuditOverlay.tsx
+++ b/src/components/mobile/OverflowAuditOverlay.tsx
@@ -1,0 +1,125 @@
+import { useCallback, useEffect, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { clsx } from 'clsx'
+import { RefreshCw, X } from 'lucide-react'
+import { auditOverflow, hasHorizontalScroll, type OverflowOffender } from '../../lib/mobile/overflow-audit'
+
+/**
+ * Opt-in on-device overflow reporter.
+ *
+ * Enabled by adding `?overflow=1` to the URL — it therefore works against the
+ * deployed build on a real phone, which is where these bugs actually show up.
+ * Nothing renders and nothing is measured unless the flag is present.
+ *
+ * Tap an entry to flash the offending element so you can see what it is.
+ */
+export function OverflowAuditOverlay() {
+  const [enabled, setEnabled] = useState(false)
+  const [offenders, setOffenders] = useState<OverflowOffender[]>([])
+  const [scrolls, setScrolls] = useState(false)
+  const [collapsed, setCollapsed] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return
+    const params = new URLSearchParams(window.location.search)
+    setEnabled(params.get('overflow') === '1')
+  }, [])
+
+  const run = useCallback(() => {
+    setOffenders(auditOverflow())
+    setScrolls(hasHorizontalScroll())
+  }, [])
+
+  useEffect(() => {
+    if (!enabled) return
+    // Let layout settle (fonts, images, async content) before measuring.
+    const timer = setTimeout(run, 600)
+    window.addEventListener('resize', run)
+    window.addEventListener('orientationchange', run)
+    return () => {
+      clearTimeout(timer)
+      window.removeEventListener('resize', run)
+      window.removeEventListener('orientationchange', run)
+    }
+  }, [enabled, run])
+
+  const flash = (el: Element) => {
+    const node = el as HTMLElement
+    const previous = node.style.outline
+    node.style.outline = '3px solid #ef4444'
+    node.scrollIntoView({ block: 'center', behavior: 'smooth' })
+    setTimeout(() => {
+      node.style.outline = previous
+    }, 1600)
+  }
+
+  if (!enabled || typeof document === 'undefined') return null
+
+  return createPortal(
+    <div
+      data-overflow-audit
+      className="fixed left-0 right-0 bottom-0 z-[999] pb-safe pointer-events-auto"
+    >
+      <div className="mx-2 mb-2 rounded-xl bg-gray-900/95 text-white shadow-2xl ring-1 ring-white/10">
+        <div className="flex items-center gap-2 px-3 py-2 border-b border-white/10">
+          <span
+            className={clsx(
+              'inline-block h-2 w-2 rounded-full',
+              scrolls || offenders.length ? 'bg-red-500' : 'bg-emerald-500'
+            )}
+          />
+          <span className="text-xs font-semibold">
+            {offenders.length} overflowing · {scrolls ? 'page scrolls sideways' : 'no page scroll'}
+          </span>
+          <div className="ml-auto flex items-center gap-1">
+            <button
+              onClick={run}
+              className="h-9 w-9 flex items-center justify-center rounded-lg hover:bg-white/10 no-touch-target"
+              aria-label="Re-scan"
+            >
+              <RefreshCw className="h-4 w-4" />
+            </button>
+            <button
+              onClick={() => setCollapsed(c => !c)}
+              className="h-9 px-2 flex items-center justify-center rounded-lg hover:bg-white/10 text-xs no-touch-target"
+            >
+              {collapsed ? 'Show' : 'Hide'}
+            </button>
+            <button
+              onClick={() => setEnabled(false)}
+              className="h-9 w-9 flex items-center justify-center rounded-lg hover:bg-white/10 no-touch-target"
+              aria-label="Dismiss"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+
+        {!collapsed && (
+          <div className="max-h-56 overflow-y-auto overscroll-contain">
+            {offenders.length === 0 ? (
+              <p className="px-3 py-3 text-xs text-white/60">
+                Nothing wider than the viewport. If the page still drags sideways, the
+                cause is a scroll container rather than an oversized element.
+              </p>
+            ) : (
+              offenders.map((o, i) => (
+                <button
+                  key={i}
+                  onClick={() => flash(o.element)}
+                  className="w-full text-left px-3 py-2 border-b border-white/5 hover:bg-white/5 no-touch-target"
+                >
+                  <div className="text-[11px] font-mono text-red-300">
+                    +{o.overhangRight}px{o.overhangLeft > 0 ? ` / left −${o.overhangLeft}px` : ''} · {o.width}px wide
+                  </div>
+                  <div className="text-[11px] font-mono text-white/70 break-all">{o.path}</div>
+                </button>
+              ))
+            )}
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/src/lib/mobile/overflow-audit.ts
+++ b/src/lib/mobile/overflow-audit.ts
@@ -1,0 +1,102 @@
+/**
+ * Finds the elements actually causing horizontal overflow.
+ *
+ * Static analysis has repeatedly pointed at the wrong culprit — a wide class
+ * name is not the same as a wide rendered box, and the real offenders have
+ * been things with no suspicious class at all (an <input>'s intrinsic
+ * min-content width, for instance). This measures the rendered layout instead.
+ *
+ * Only elements whose own box exceeds the viewport are reported, and a parent
+ * is suppressed when a child is equally guilty, so the output points at the
+ * leaf that needs fixing rather than every ancestor containing it.
+ */
+
+export interface OverflowOffender {
+  /** Readable path, e.g. `div.flex > header#app > input.block` */
+  path: string
+  tag: string
+  className: string
+  /** Rendered width in px. */
+  width: number
+  /** How far past the viewport's right edge, in px. */
+  overhangRight: number
+  /** How far past the left edge (negative left positions). */
+  overhangLeft: number
+  element: Element
+}
+
+function describe(el: Element): string {
+  const tag = el.tagName.toLowerCase()
+  const id = el.id ? `#${el.id}` : ''
+  const cls =
+    typeof el.className === 'string' && el.className.trim()
+      ? '.' + el.className.trim().split(/\s+/).slice(0, 3).join('.')
+      : ''
+  return `${tag}${id}${cls}`
+}
+
+function pathTo(el: Element, depth = 3): string {
+  const parts: string[] = []
+  let node: Element | null = el
+  while (node && parts.length < depth) {
+    parts.unshift(describe(node))
+    node = node.parentElement
+  }
+  return parts.join(' > ')
+}
+
+export function auditOverflow(tolerance = 1): OverflowOffender[] {
+  if (typeof document === 'undefined') return []
+
+  const viewportWidth = document.documentElement.clientWidth
+  const found: OverflowOffender[] = []
+
+  for (const el of Array.from(document.querySelectorAll<HTMLElement>('*'))) {
+    // Skip things that are not laid out, and our own audit UI.
+    if (el.closest('[data-overflow-audit]')) continue
+    const rect = el.getBoundingClientRect()
+    if (rect.width === 0 && rect.height === 0) continue
+
+    const style = window.getComputedStyle(el)
+    if (style.display === 'none' || style.visibility === 'hidden') continue
+    // Fixed/sticky overlays legitimately sit outside flow while animating off
+    // screen (drawers, sheets). A translated-off element is not an overflow bug.
+    if (style.transform !== 'none' && rect.left >= viewportWidth) continue
+
+    const overhangRight = Math.round(rect.right - viewportWidth)
+    const overhangLeft = Math.round(-rect.left)
+
+    if (overhangRight > tolerance || overhangLeft > tolerance) {
+      found.push({
+        path: pathTo(el),
+        tag: el.tagName.toLowerCase(),
+        className: typeof el.className === 'string' ? el.className : '',
+        width: Math.round(rect.width),
+        overhangRight: Math.max(0, overhangRight),
+        overhangLeft: Math.max(0, overhangLeft),
+        element: el,
+      })
+    }
+  }
+
+  // Drop ancestors whose overhang is fully explained by a reported descendant —
+  // fixing the leaf usually fixes the chain.
+  const leaves = found.filter(
+    candidate =>
+      !found.some(
+        other =>
+          other.element !== candidate.element &&
+          candidate.element.contains(other.element) &&
+          other.overhangRight >= candidate.overhangRight - 1
+      )
+  )
+
+  return leaves.sort((a, b) => b.overhangRight - a.overhangRight)
+}
+
+/** True when the document itself can be scrolled sideways. */
+export function hasHorizontalScroll(): boolean {
+  if (typeof document === 'undefined') return false
+  const doc = document.documentElement
+  return doc.scrollWidth > doc.clientWidth + 1
+}


### PR DESCRIPTION
Static analysis has pointed at the wrong culprit repeatedly this cycle. A wide class name is not a wide rendered box, and the actual offenders had no suspicious class at all — the header overflow turned out to be an <input>'s intrinsic min-content width. This measures rendered layout instead of guessing at it.

Append ?overflow=1 to any URL to get a panel listing every element whose box exceeds the viewport, sorted by overhang, with the rendered width and a DOM path. Tapping an entry outlines and scrolls to it. It also reports whether the document itself scrolls sideways, which distinguishes an oversized element from a stray scroll container — two different bugs that look identical from the outside.

Ancestors are suppressed when a descendant is equally guilty, so the list points at the leaf worth fixing rather than every parent containing it.

Works against the deployed build on a real phone, which is where these bugs actually appear. Renders nothing and measures nothing without the flag.

Type errors unchanged from main (9178 pre-existing, none introduced).

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
