### PR TITLE
fix(mobile): lock page scroll so the header cannot drift

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -170,17 +170,34 @@
      that can be panned by touch and scrolled programmatically, which is why
      the page remained draggable into whitespace. `clip` genuinely clips.
      Paired with a `hidden` fallback for browsers without overflow: clip. */
+  /* The app shell owns all scrolling on phones; the page itself must not
+     scroll. If it can, two things go wrong: the header scrolls out of view,
+     and the browser shows/hides its URL bar during the scroll, which resizes
+     the viewport and reflows the whole shell mid-gesture. Locking html/body
+     means only inner containers scroll and the header becomes structurally
+     immovable. `overscroll-behavior: none` also kills rubber-banding and
+     pull-to-refresh, which visibly displace the header. */
   html,
   body {
-    overflow-x: hidden;
+    height: 100%;
+    overflow: hidden;
+    overscroll-behavior: none;
     overflow-x: clip;
     max-width: 100%;
   }
 
   #root {
-    overflow-x: hidden;
+    height: 100%;
+    overflow: hidden;
     overflow-x: clip;
     max-width: 100%;
+  }
+
+  /* With a definite height on the html/body chain, percentage height is stable
+     where 100dvh is not — dvh tracks the URL bar and resizes the shell while
+     you scroll, which is what made the header appear to drift. */
+  .h-viewport {
+    height: 100%;
   }
 
   /* Inputs and textareas carry an intrinsic min-content width from their


### PR DESCRIPTION
The header disappeared while scrolling. Two causes, both at the page level.

The shell was sized with 100dvh. dvh tracks the *visible* viewport, so when a mobile browser hides its URL bar mid-scroll the value changes and the entire shell reflows during the gesture — the header visibly shifts.

Separately, nothing stopped the page itself from scrolling or rubber- banding, so the sticky header could simply be scrolled out of view.

Give html/body a definite height and lock their overflow: only inner containers scroll, which is what the layout already assumed. `.h-viewport` then resolves against that definite height instead of dvh, so it no longer moves with the URL bar. `overscroll-behavior: none` removes rubber-banding and pull-to-refresh, which displace the header the same way.

Phone widths only; desktop is untouched.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
