### PR TITLE
fix(mobile): dashboard fit, input zoom, and launcher affordance

### DIFF
--- a/src/components/dashboard/DashboardFilters.tsx
+++ b/src/components/dashboard/DashboardFilters.tsx
@@ -261,7 +261,10 @@ export function DashboardFilters({
   portfolios,
 }: DashboardFiltersProps) {
   return (
-    <div className="flex items-center gap-2.5 px-3 py-2 rounded-lg border border-gray-200/80 dark:border-gray-700/60 bg-white dark:bg-gray-800/60 shadow-sm">
+    // Wraps on narrow screens. This row holds a segmented control, two
+    // labelled selects and a reset button — well over a phone's width — and
+    // as a single non-wrapping flex row it pushed the whole page sideways.
+    <div className="flex flex-wrap items-center gap-2 md:gap-2.5 px-3 py-2 rounded-lg border border-gray-200/80 dark:border-gray-700/60 bg-white dark:bg-gray-800/60 shadow-sm">
       {/* Mode selector */}
       <div className="flex items-center rounded-lg bg-gray-100 dark:bg-gray-700/50 p-[3px] gap-[2px]">
         {MODE_OPTIONS.map(({ value, label, icon: Icon }) => (

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -321,11 +321,21 @@ export function Header({
                   }
                   setShowAppMenu(!showAppMenu)
                 }}
-                className="flex items-center justify-center w-11 h-11 -ml-2 md:w-9 md:h-9 md:-ml-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-                aria-label={isMobile ? 'Open navigation' : 'App launcher'}
+                className={clsx(
+                  'flex items-center justify-center gap-0.5 h-11 px-1.5 -ml-1 rounded-lg transition-colors',
+                  // On phones the mark is the only way into navigation, so it
+                  // needs to read as a control rather than as a logo: visible
+                  // button chrome plus a disclosure chevron. Desktop keeps the
+                  // bare mark, where the app-launcher convention is familiar.
+                  'bg-gray-100 dark:bg-gray-800 hover:bg-gray-200 dark:hover:bg-gray-700',
+                  'md:w-9 md:h-9 md:px-0 md:bg-transparent md:dark:bg-transparent md:hover:bg-gray-100 md:dark:hover:bg-gray-800'
+                )}
+                aria-label={isMobile ? 'Open menu' : 'App launcher'}
+                aria-haspopup="menu"
                 title={isMobile ? 'Menu' : 'App launcher'}
               >
-                <TesseractLogo size={28} />
+                <TesseractLogo size={24} />
+                <ChevronDown className="md:hidden h-3.5 w-3.5 text-gray-500 dark:text-gray-400" />
               </button>
 
               {/* App Launcher Panel */}

--- a/src/components/mobile/MobileSearchOverlay.tsx
+++ b/src/components/mobile/MobileSearchOverlay.tsx
@@ -86,7 +86,11 @@ export function MobileSearchOverlay({ open, onClose, onSelectResult }: MobileSea
         </div>
       </div>
 
-      <div className="flex-1 overflow-y-auto overscroll-contain" />
+      {/* GlobalSearch renders its own absolutely-positioned results panel just
+          below the field, so this area is intentionally empty — it exists to
+          paint the rest of the screen in the surface colour rather than
+          letting the app show through behind the results. */}
+      <div className="flex-1 bg-white dark:bg-gray-900" />
     </div>,
     document.body
   )

--- a/src/components/pilot/PilotActionDashboard.tsx
+++ b/src/components/pilot/PilotActionDashboard.tsx
@@ -762,7 +762,10 @@ function SystemLoopCard({
 
       {/* Stage strip */}
       <div className="px-4 py-3 border-b border-gray-100 dark:border-gray-700">
-        <div className="grid grid-cols-5 gap-1.5 items-stretch">
+        {/* Five stages across is ~70px per card on a phone. Wrap instead —
+            two per row still reads as a loop, and stops the strip forcing
+            the page wider than the screen. */}
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-1.5 items-stretch">
           {stages.map((s, i) => {
             const Icon = s.icon
             // During the cold-load window, force every stage to render

--- a/src/index.css
+++ b/src/index.css
@@ -218,13 +218,17 @@
     max-width: 100%;
   }
 
-  /* iOS zooms the viewport when a focused input's font-size is under 16px, and
-     never zooms back out. This is the single most common "my app feels broken
-     on iPhone" bug. */
-  input,
+  /* iOS zooms the viewport when a focused input's font-size is under 16px and
+     never zooms back out — it also shifts the page, hiding whatever sat below
+     the field. `!important` is deliberate: almost every input here carries a
+     Tailwind size class (`text-sm`, `text-xs`), and a class beats a bare
+     element selector on specificity no matter the source order, so without it
+     this rule silently loses and the zoom still happens.
+     Checkboxes and radios are excluded — font-size changes their box metrics. */
+  input:not([type='checkbox']):not([type='radio']):not([type='range']),
   select,
   textarea {
-    font-size: 16px;
+    font-size: 16px !important;
   }
 
   /* Kill the grey flash on tap; we render our own active states. */


### PR DESCRIPTION
Dashboard
- PilotActionDashboard's system-loop strip was `grid-cols-5` with no breakpoint: five cards across a 390px screen is ~70px each, which both looked broken and pushed the page wider than the viewport. Now 2 / 3 / 5 across by breakpoint.
- DashboardFilters was a single non-wrapping flex row holding a segmented control, two labelled selects and a reset button — far wider than a phone. It now wraps.

Input zoom
The 16px minimum added earlier never took effect. Nearly every input carries a Tailwind size class (`text-sm`, `text-xs`), and a class beats a bare element selector on specificity regardless of source order — so the rule silently lost and iOS kept zooming on focus, shifting the page and hiding the search results underneath. Marked `!important`, with checkbox/radio/range excluded since font-size alters their box metrics.

Launcher affordance
On phones the Tesseract mark is the only route into navigation, so it now reads as a control: visible button chrome, a disclosure chevron, and aria-haspopup. Desktop keeps the bare mark.

Search overlay no longer leaves a transparent gap below the field.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
