### PR TITLE
feat(mobile): interleave feed sources and chart attention items

### DIFF
--- a/src/components/mobile/AttentionFeedCard.tsx
+++ b/src/components/mobile/AttentionFeedCard.tsx
@@ -3,10 +3,16 @@ import { formatDistanceToNow } from 'date-fns'
 import {
   AlertTriangle, ArrowRight, BellOff, Check, Gavel, Info, Users,
 } from 'lucide-react'
+import { ReelsChartPanel } from '../feed/ReelsChartPanel'
 import type { AttentionItem, AttentionType } from '../../types/attention'
 
 interface AttentionFeedCardProps {
   item: AttentionItem
+  /** Ticker for the linked asset, resolved by the caller in one batched query
+   *  rather than a lookup per card. Absent for non-asset items (projects,
+   *  lists), which correctly render without a chart. */
+  symbol?: string | null
+  companyName?: string | null
   onOpen?: (item: AttentionItem) => void
   onSnooze?: (item: AttentionItem) => void
   onAcknowledge?: (item: AttentionItem) => void
@@ -50,7 +56,14 @@ const TYPE_CONFIG: Record<AttentionType, { icon: typeof Info; label: string; chi
  * nicety — "the algorithm deprioritised it" is not an acceptable explanation
  * for a missed approval.
  */
-export function AttentionFeedCard({ item, onOpen, onSnooze, onAcknowledge }: AttentionFeedCardProps) {
+export function AttentionFeedCard({
+  item,
+  symbol,
+  companyName,
+  onOpen,
+  onSnooze,
+  onAcknowledge,
+}: AttentionFeedCardProps) {
   const config = TYPE_CONFIG[item.attention_type] ?? TYPE_CONFIG.informational
   const TypeIcon = config.icon
   const isOverdue = !!item.due_at && new Date(item.due_at).getTime() < Date.now()
@@ -66,6 +79,15 @@ export function AttentionFeedCard({ item, onOpen, onSnooze, onAcknowledge }: Att
           {formatDistanceToNow(new Date(item.last_activity_at || item.created_at), { addSuffix: true })}
         </span>
       </div>
+
+      {/* A decision about a position is hard to judge without seeing the
+          price. Same chart component as the idea cards, so the two read as
+          one feed rather than two systems. */}
+      {symbol && (
+        <div className="flex-shrink-0 h-[30%] px-4 pt-3">
+          <ReelsChartPanel symbol={symbol} companyName={companyName ?? undefined} />
+        </div>
+      )}
 
       <div className="flex-1 overflow-y-auto px-4 py-4">
         <div className={clsx('border-l-4 pl-3', config.accent)}>

--- a/src/components/mobile/MobileDashboard.tsx
+++ b/src/components/mobile/MobileDashboard.tsx
@@ -11,6 +11,9 @@ import { useAuth } from '../../hooks/useAuth'
 import { useAttention } from '../../hooks/useAttention'
 import { AttentionFeedCard } from './AttentionFeedCard'
 import { attentionTarget } from '../../lib/mobile/attention-navigation'
+import { interleaveByKind } from '../../lib/mobile/feed-interleave'
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../../lib/supabase'
 
 interface MobileDashboardProps {
   onNavigate?: (result: any) => void
@@ -62,6 +65,27 @@ export function MobileDashboard({
   const [readthroughFor, setReadthroughFor] = useState<ScoredFeedItem | null>(null)
   const sentinelRef = useRef<HTMLDivElement>(null)
 
+  // One query for every asset referenced by an attention item, rather than a
+  // lookup inside each card.
+  const attentionAssetIds = useMemo(
+    () => Array.from(new Set(attentionItems.map(a => a.context?.asset_id).filter(Boolean) as string[])),
+    [attentionItems]
+  )
+  const { data: attentionAssets } = useQuery({
+    queryKey: ['attention-feed-assets', attentionAssetIds],
+    queryFn: async () => {
+      if (!attentionAssetIds.length) return {} as Record<string, { symbol: string; company_name: string | null }>
+      const { data, error } = await supabase
+        .from('assets')
+        .select('id, symbol, company_name')
+        .in('id', attentionAssetIds)
+      if (error) throw error
+      return Object.fromEntries((data ?? []).map((a: any) => [a.id, a]))
+    },
+    enabled: attentionAssetIds.length > 0,
+    staleTime: 5 * 60 * 1000,
+  })
+
   // Drop only genuinely empty cards. An earlier 24-character threshold was
   // hiding real posts — short reasoning is still reasoning. This now catches
   // just the AI insights that arrive as a call to action with no finding.
@@ -88,6 +112,28 @@ export function MobileDashboard({
     const timer = setTimeout(() => markSeen(userId, visibleItems.slice(0, 10).map(i => i.id)), 1500)
     return () => clearTimeout(timer)
   }, [userId, visibleItems])
+
+  // Interleave so consecutive screens are not all one kind. Scores are
+  // position-derived rather than raw: each source ranks on its own scale, and
+  // using position preserves the ordering each source already decided
+  // (including the seen-rotation applied to ideas) while making the two
+  // comparable. `leadWith` keeps the single most pressing decision first.
+  const feedEntries = useMemo(() => {
+    const attentionEntries = attentionItems.map((a, idx) => ({
+      kind: 'attention' as const,
+      score: attentionItems.length - idx,
+      attention: a,
+    }))
+    const ideaEntries = visibleItems.map((i, idx) => ({
+      kind: 'idea' as const,
+      score: visibleItems.length - idx,
+      idea: i,
+    }))
+    return interleaveByKind<any>([...attentionEntries, ...ideaEntries], {
+      maxRun: 1,
+      leadWith: 'attention',
+    })
+  }, [attentionItems, visibleItems])
 
   useEffect(() => {
     const sentinel = sentinelRef.current
@@ -137,25 +183,26 @@ export function MobileDashboard({
   return (
     <>
       <div className="h-full overflow-y-auto snap-y snap-mandatory overscroll-contain">
-        {/* Things awaiting the user lead the feed. A pending decision is
-            time-sensitive in a way an idea is not, and burying it below ranked
-            content is how approvals get missed. Ordered by the attention
-            system's own score so the most pressing comes first. */}
-        {attentionItems.map(item => (
-          <section key={item.attention_id} className="relative h-full w-full snap-start snap-always">
-            <AttentionFeedCard
-              item={item}
-              onOpen={attentionTarget(item) ? (it) => {
-                markRead(it.attention_id)
-                onNavigate?.(attentionTarget(it))
-              } : undefined}
-              onSnooze={(it) => snoozeFor(it.attention_id, 24)}
-              onAcknowledge={(it) => acknowledge(it.attention_id)}
-            />
-          </section>
-        ))}
+        {feedEntries.map(entry => {
+          if (entry.kind === 'attention') {
+            const a = entry.attention
+            const linked = a.context?.asset_id ? attentionAssets?.[a.context.asset_id] : null
+            const target = attentionTarget(a)
+            return (
+              <section key={a.attention_id} className="relative h-full w-full snap-start snap-always">
+                <AttentionFeedCard
+                  item={a}
+                  symbol={linked?.symbol}
+                  companyName={linked?.company_name}
+                  onOpen={target ? () => { markRead(a.attention_id); onNavigate?.(target) } : undefined}
+                  onSnooze={() => snoozeFor(a.attention_id, 24)}
+                  onAcknowledge={() => acknowledge(a.attention_id)}
+                />
+              </section>
+            )
+          }
 
-        {visibleItems.map(item => {
+          const item = entry.idea
           const source = readthroughSourceType(item.type)
           return (
             <section key={item.id} className="relative h-full w-full snap-start snap-always">
@@ -180,6 +227,7 @@ export function MobileDashboard({
             </section>
           )
         })}
+
         <div ref={sentinelRef} className="h-px" />
       </div>
 

--- a/src/lib/mobile/__tests__/feed-interleave.test.ts
+++ b/src/lib/mobile/__tests__/feed-interleave.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import { interleaveByKind } from '../feed-interleave'
+
+type Entry = { kind: string; score: number; id: string }
+
+const entry = (kind: string, score: number, id = `${kind}-${score}`): Entry => ({ kind, score, id })
+
+/** Longest run of consecutive entries sharing a kind. */
+function longestRun(entries: Entry[]): number {
+  let best = 0
+  let run = 0
+  let prev: string | null = null
+  for (const e of entries) {
+    run = e.kind === prev ? run + 1 : 1
+    prev = e.kind
+    if (run > best) best = run
+  }
+  return best
+}
+
+describe('interleaveByKind', () => {
+  it('alternates kinds rather than emitting them in blocks', () => {
+    const input = [
+      ...[5, 4, 3, 2, 1].map(s => entry('idea', s)),
+      ...[5, 4, 3].map(s => entry('attention', s)),
+    ]
+    const out = interleaveByKind(input, { maxRun: 1 })
+
+    expect(out).toHaveLength(8)
+    // With both buckets non-empty, no two neighbours share a kind.
+    const firstSix = out.slice(0, 6)
+    expect(longestRun(firstSix)).toBe(1)
+  })
+
+  it('falls back to the remaining kind once others are exhausted', () => {
+    const input = [
+      ...[9, 8, 7, 6].map(s => entry('idea', s)),
+      entry('attention', 5),
+    ]
+    const out = interleaveByKind(input, { maxRun: 1 })
+
+    expect(out).toHaveLength(5)
+    // The tail is unavoidably all ideas — the constraint must relax, not drop.
+    expect(out.filter(e => e.kind === 'idea')).toHaveLength(4)
+    expect(out.filter(e => e.kind === 'attention')).toHaveLength(1)
+  })
+
+  it('preserves relative order within a kind', () => {
+    const input = [
+      entry('idea', 3, 'a'),
+      entry('idea', 2, 'b'),
+      entry('idea', 1, 'c'),
+      entry('attention', 3, 'x'),
+      entry('attention', 2, 'y'),
+    ]
+    const out = interleaveByKind(input, { maxRun: 1 })
+    const ideaOrder = out.filter(e => e.kind === 'idea').map(e => e.id)
+    const attentionOrder = out.filter(e => e.kind === 'attention').map(e => e.id)
+
+    expect(ideaOrder).toEqual(['a', 'b', 'c'])
+    expect(attentionOrder).toEqual(['x', 'y'])
+  })
+
+  it('leads with the requested kind even when another scores higher', () => {
+    const input = [entry('idea', 100, 'big-idea'), entry('attention', 1, 'small-attention')]
+    const out = interleaveByKind(input, { maxRun: 1, leadWith: 'attention' })
+
+    expect(out[0].id).toBe('small-attention')
+  })
+
+  it('loses nothing and is deterministic', () => {
+    const input = [
+      ...Array.from({ length: 7 }, (_, i) => entry('idea', 7 - i)),
+      ...Array.from({ length: 4 }, (_, i) => entry('attention', 4 - i)),
+      ...Array.from({ length: 2 }, (_, i) => entry('news', 2 - i)),
+    ]
+    const first = interleaveByKind(input, { maxRun: 1, leadWith: 'attention' })
+    const second = interleaveByKind(input, { maxRun: 1, leadWith: 'attention' })
+
+    expect(first).toHaveLength(input.length)
+    expect(first.map(e => e.id)).toEqual(second.map(e => e.id))
+  })
+
+  it('handles an empty input and a single kind', () => {
+    expect(interleaveByKind<Entry>([], { maxRun: 1 })).toEqual([])
+    const only = [entry('idea', 2), entry('idea', 1)]
+    expect(interleaveByKind(only, { maxRun: 1 })).toHaveLength(2)
+  })
+})

--- a/src/lib/mobile/feed-interleave.ts
+++ b/src/lib/mobile/feed-interleave.ts
@@ -1,0 +1,90 @@
+/**
+ * Mixes feed sources so consecutive screens are not all the same kind.
+ *
+ * Concatenating sources produces "all decisions, then all projects, then all
+ * ideas" — every block feels like a different app, and whichever source is
+ * longest buries the rest. Sorting everything by score alone does not fix it
+ * either, because scores are computed per-source on different scales and one
+ * source reliably wins.
+ *
+ * The rule here: never emit more than `maxRun` consecutive entries of the same
+ * kind while any other kind still has items. Within that constraint, always
+ * take the highest-scoring available entry, so relevance still drives order —
+ * diversity is a tie-breaker, not a shuffle. Deliberately deterministic:
+ * randomising would make the feed feel arbitrary and make bug reports
+ * impossible to reproduce.
+ */
+
+export interface InterleavableEntry {
+  /** Source bucket — 'attention', 'idea', 'news'… */
+  kind: string
+  /** Higher is more relevant. Only compared within a kind. */
+  score: number
+}
+
+export interface InterleaveOptions {
+  /** Max consecutive entries of one kind before another must be emitted. */
+  maxRun?: number
+  /**
+   * Kinds that may lead regardless of score. Used so the single most pressing
+   * decision opens the feed even when an idea outranks it on its own scale.
+   */
+  leadWith?: string
+}
+
+export function interleaveByKind<T extends InterleavableEntry>(
+  entries: T[],
+  { maxRun = 1, leadWith }: InterleaveOptions = {}
+): T[] {
+  // Bucket, preserving each source's own ordering by score.
+  const buckets = new Map<string, T[]>()
+  for (const entry of entries) {
+    const bucket = buckets.get(entry.kind)
+    if (bucket) bucket.push(entry)
+    else buckets.set(entry.kind, [entry])
+  }
+  for (const bucket of buckets.values()) bucket.sort((a, b) => b.score - a.score)
+
+  const out: T[] = []
+
+  // Optional lead item: the most pressing entry of one kind opens the feed, so
+  // something urgent is never pushed below content that merely scores well.
+  if (leadWith) {
+    const lead = buckets.get(leadWith)
+    if (lead?.length) out.push(lead.shift() as T)
+  }
+
+  let runKind: string | null = out.length ? out[out.length - 1].kind : null
+  let runLength = out.length ? 1 : 0
+
+  while (true) {
+    const available = [...buckets.entries()].filter(([, items]) => items.length > 0)
+    if (!available.length) break
+
+    // Prefer a kind that would not extend the current run.
+    const eligible = available.filter(([kind]) => !(kind === runKind && runLength >= maxRun))
+    const pool = eligible.length ? eligible : available
+
+    // Highest-scoring head among the permitted kinds.
+    let bestKind = pool[0][0]
+    let bestScore = pool[0][1][0].score
+    for (const [kind, items] of pool) {
+      if (items[0].score > bestScore) {
+        bestScore = items[0].score
+        bestKind = kind
+      }
+    }
+
+    const chosen = buckets.get(bestKind)!.shift() as T
+    out.push(chosen)
+
+    if (bestKind === runKind) {
+      runLength += 1
+    } else {
+      runKind = bestKind
+      runLength = 1
+    }
+  }
+
+  return out
+}


### PR DESCRIPTION
Diversification
Sources were concatenated, so the feed read as "all decisions, then all projects, then all ideas" — each block felt like a different app and the longest source buried the rest. Sorting everything by score does not fix it either: each source scores on its own scale and one reliably wins.

interleaveByKind never emits more than `maxRun` consecutive entries of a kind while another kind still has items, and takes the highest-scoring available entry within that constraint — so relevance still drives order and diversity is the tie-breaker, not a shuffle. Deliberately deterministic; randomising would make the feed feel arbitrary and bug reports impossible to reproduce.

Entry scores are position-derived rather than raw, which keeps each source's own ordering (including the seen-rotation applied to ideas) while making the two comparable. `leadWith` keeps the single most pressing decision first, so nothing urgent is displaced by diversity.

Covered by unit tests: alternation, graceful fallback when one source is exhausted, order preservation within a kind, lead-kind override, determinism, and no dropped entries.

Charts on attention cards
A decision about a position is hard to judge without the price. Attention cards now render the same ReelsChartPanel as idea cards when the item links an asset, so the two read as one feed. Symbols are resolved in a single batched query keyed on the asset ids present, not per card.

Type errors unchanged (8950).

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
