### PR TITLE
fix(mobile): move ticker and price into the header; label the weight

### DIFF
--- a/src/components/feed/ReelsChartPanel.tsx
+++ b/src/components/feed/ReelsChartPanel.tsx
@@ -25,6 +25,10 @@ interface ReelsChartPanelProps {
   symbol: string
   companyName?: string
   onOpenFullChart?: (symbol: string) => void
+  /** Suppresses the panel's own symbol/price row. Set when the surrounding
+   *  tile already shows that information, so the chart gets the height back
+   *  instead of the card carrying two headers. */
+  hideHeader?: boolean
   eventDate?: string  // ISO date string for when an event occurred (e.g., trade idea created)
   eventLabel?: string // Label for the event
 }
@@ -33,6 +37,7 @@ export function ReelsChartPanel({
   symbol,
   companyName,
   onOpenFullChart,
+  hideHeader = false,
   eventDate,
   eventLabel
 }: ReelsChartPanelProps) {
@@ -115,6 +120,7 @@ export function ReelsChartPanel({
   return (
     <div className="w-full h-full flex flex-col">
       {/* Header with symbol info */}
+      {!hideHeader && (
       <div className="flex items-center justify-between px-2 py-2 bg-white border-b border-gray-200 rounded-t-xl relative z-30 dark:border-gray-700 dark:bg-gray-800">
         <div className="flex items-center gap-3">
           <div>
@@ -159,9 +165,10 @@ export function ReelsChartPanel({
           </button>
         )}
       </div>
+      )}
 
       {/* Timeframe selector */}
-      <div className="flex items-center gap-0.5 px-2 py-1.5 bg-gray-50 border-b border-gray-200 relative z-30 overflow-x-auto dark:border-gray-700 dark:bg-gray-900">
+      <div className={clsx("flex items-center gap-0.5 px-2 py-1.5 bg-gray-50 border-b border-gray-200 relative z-30 overflow-x-auto dark:border-gray-700 dark:bg-gray-900", hideHeader && "rounded-t-xl border-t")}>
         {timeframes.map(tf => (
           <button
             key={tf.value}

--- a/src/components/feed/ReelsFeedItem.tsx
+++ b/src/components/feed/ReelsFeedItem.tsx
@@ -7,6 +7,7 @@ import {
 } from 'lucide-react'
 import { ReelsChartPanel } from './ReelsChartPanel'
 import { PairTradeChartCarousel } from './PairTradeChartCarousel'
+import { TickerQuoteBadge } from '../mobile/TickerQuoteBadge'
 import type { ScoredFeedItem, ItemType } from '../../hooks/ideas/types'
 
 // Strip HTML tags from content for clean display
@@ -215,6 +216,16 @@ export function ReelsFeedItem({
           </span>
         </div>
 
+        {/* Ticker and price fill what was an empty right-hand gap, and let the
+            chart below drop its own header row. */}
+        {hideHeaderActions && displaySymbol && !isPairTrade && (
+          <TickerQuoteBadge
+            symbol={displaySymbol}
+            companyName={asset?.company_name}
+            className="ml-auto"
+          />
+        )}
+
         {/* Action buttons */}
         <div className={clsx('items-center gap-2', hideHeaderActions ? 'hidden' : 'flex')}>
           {/* Share button */}
@@ -264,6 +275,7 @@ export function ReelsFeedItem({
             onOpenFullChart={onOpenFullChart}
             eventDate={eventDate}
             eventLabel={eventLabel}
+            hideHeader={hideHeaderActions}
           />
         ) : (
           <div className="w-full h-full flex items-center justify-center bg-gray-50 rounded-xl border border-gray-200 dark:border-gray-700 dark:bg-gray-900">

--- a/src/components/mobile/AttentionFeedCard.tsx
+++ b/src/components/mobile/AttentionFeedCard.tsx
@@ -5,6 +5,7 @@ import {
   AlertTriangle, ArrowRight, BellOff, Check, Gavel, Info, Users,
 } from 'lucide-react'
 import { ReelsChartPanel } from '../feed/ReelsChartPanel'
+import { TickerQuoteBadge } from './TickerQuoteBadge'
 import { useDecisionContext } from '../../hooks/mobile/useDecisionContext'
 import type { AttentionItem, AttentionType } from '../../types/attention'
 
@@ -176,9 +177,13 @@ export function AttentionFeedCard({
           <TypeIcon className="h-4 w-4" />
           {config.label}
         </span>
-        <span className="ml-auto text-xs text-gray-400 whitespace-nowrap">
-          {formatDistanceToNow(new Date(item.last_activity_at || item.created_at), { addSuffix: true })}
-        </span>
+        {symbol ? (
+          <TickerQuoteBadge symbol={symbol} companyName={companyName} className="ml-auto" />
+        ) : (
+          <span className="ml-auto text-xs text-gray-400 whitespace-nowrap">
+            {formatDistanceToNow(new Date(item.last_activity_at || item.created_at), { addSuffix: true })}
+          </span>
+        )}
       </div>
 
       {/* The instruction, first and unmissable. */}
@@ -194,7 +199,7 @@ export function AttentionFeedCard({
 
       {symbol && (
         <div className="flex-shrink-0 h-[50%] min-h-[250px] max-h-[400px] px-3">
-          <ReelsChartPanel symbol={symbol} companyName={companyName ?? undefined} />
+          <ReelsChartPanel symbol={symbol} hideHeader />
         </div>
       )}
 

--- a/src/components/mobile/DerivedInsightTile.tsx
+++ b/src/components/mobile/DerivedInsightTile.tsx
@@ -1,6 +1,7 @@
 import { clsx } from 'clsx'
 import { ArrowRight, FileQuestion, Scale, TimerReset } from 'lucide-react'
 import { ReelsChartPanel } from '../feed/ReelsChartPanel'
+import { TickerQuoteBadge } from './TickerQuoteBadge'
 import type { DerivedInsight, DerivedInsightKind } from '../../hooks/mobile/useDerivedInsights'
 
 interface DerivedInsightTileProps {
@@ -51,11 +52,14 @@ export function DerivedInsightTile({ insight, onAssetClick, onCapture }: Derived
           <Icon className="h-4 w-4" />
           {config.label}
         </span>
-        {insight.weightPct != null && (
-          <span className="ml-auto text-xs font-semibold text-gray-500 dark:text-gray-400 whitespace-nowrap">
-            {insight.weightPct.toFixed(2)}%
-          </span>
-        )}
+        {/* A bare "4.20%" in the corner said nothing — it could have been a
+            price move, a target, anything. Ticker and price go here instead;
+            the weight is stated in words in the body, where it has context. */}
+        <TickerQuoteBadge
+          symbol={insight.symbol}
+          companyName={insight.companyName}
+          className="ml-auto"
+        />
       </div>
 
       <div className="flex-shrink-0 px-3 pt-2 pb-1.5">
@@ -70,7 +74,7 @@ export function DerivedInsightTile({ insight, onAssetClick, onCapture }: Derived
       </div>
 
       <div className="flex-shrink-0 h-[50%] min-h-[250px] max-h-[400px] px-3">
-        <ReelsChartPanel symbol={insight.symbol} companyName={insight.companyName ?? undefined} />
+        <ReelsChartPanel symbol={insight.symbol} hideHeader />
       </div>
 
       <div className="flex-1 min-h-0 overflow-y-auto px-3 py-2">

--- a/src/components/mobile/SignalFeedTile.tsx
+++ b/src/components/mobile/SignalFeedTile.tsx
@@ -4,6 +4,7 @@ import {
   ArrowRight, CalendarClock, Radar, Split, TimerReset,
 } from 'lucide-react'
 import { ReelsChartPanel } from '../feed/ReelsChartPanel'
+import { TickerQuoteBadge } from './TickerQuoteBadge'
 import type { SignalCard, SignalType } from '../../hooks/ideas/useIdeasFeed'
 
 interface SignalFeedTileProps {
@@ -62,11 +63,13 @@ export function SignalFeedTile({ signal, onAssetClick }: SignalFeedTileProps) {
           <Icon className="h-4 w-4" />
           {config.label}
         </span>
-        {signal.createdAt && (
+        {primary ? (
+          <TickerQuoteBadge symbol={primary.symbol} className="ml-auto" />
+        ) : signal.createdAt ? (
           <span className="ml-auto text-xs text-gray-400 whitespace-nowrap">
             {formatDistanceToNow(new Date(signal.createdAt), { addSuffix: true })}
           </span>
-        )}
+        ) : null}
       </div>
 
       {/* Headline leads, matching the decision card's instruction-first shape. */}
@@ -78,7 +81,7 @@ export function SignalFeedTile({ signal, onAssetClick }: SignalFeedTileProps) {
 
       {primary && (
         <div className="flex-shrink-0 h-[50%] min-h-[250px] max-h-[400px] px-3">
-          <ReelsChartPanel symbol={primary.symbol} />
+          <ReelsChartPanel symbol={primary.symbol} hideHeader />
         </div>
       )}
 

--- a/src/components/mobile/TickerQuoteBadge.tsx
+++ b/src/components/mobile/TickerQuoteBadge.tsx
@@ -1,0 +1,67 @@
+import { useQuery } from '@tanstack/react-query'
+import { clsx } from 'clsx'
+import { financialDataService } from '../../lib/financial-data/browser-client'
+
+interface TickerQuoteBadgeProps {
+  symbol: string
+  companyName?: string | null
+  className?: string
+}
+
+/**
+ * Ticker, name and live price for the top-right of a feed tile.
+ *
+ * This information used to live inside ReelsChartPanel's own header, which
+ * meant every tile carried two header rows — a nearly empty one at the top of
+ * the card and a second one above the chart. Hoisting it here fills the space
+ * that was empty and lets the chart reclaim the row it was giving up.
+ *
+ * Shares React Query's cache key with the chart panel (`reels-chart-quote`),
+ * so displaying the price here costs no additional request.
+ */
+export function TickerQuoteBadge({ symbol, companyName, className }: TickerQuoteBadgeProps) {
+  const { data: quote } = useQuery({
+    queryKey: ['reels-chart-quote', symbol],
+    queryFn: async () => {
+      try {
+        return await financialDataService.getQuote(symbol)
+      } catch {
+        return null
+      }
+    },
+    staleTime: 60_000,
+  })
+
+  const price = (quote as any)?.price as number | undefined
+  const changePercent = (quote as any)?.changePercent as number | undefined
+  const isPositive = (changePercent ?? 0) >= 0
+
+  return (
+    <div className={clsx('flex flex-col items-end min-w-0 text-right', className)}>
+      <div className="flex items-baseline gap-1.5 min-w-0">
+        <span className="text-sm font-bold text-gray-900 dark:text-white">{symbol}</span>
+        {price != null && (
+          <span className="text-sm font-semibold tabular-nums text-gray-900 dark:text-white">
+            ${price.toFixed(2)}
+          </span>
+        )}
+        {changePercent != null && (
+          <span
+            className={clsx(
+              'text-xs font-semibold tabular-nums',
+              isPositive ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'
+            )}
+          >
+            {isPositive ? '+' : ''}
+            {changePercent.toFixed(2)}%
+          </span>
+        )}
+      </div>
+      {companyName && (
+        <span className="text-[11px] text-gray-500 dark:text-gray-400 truncate max-w-[11rem]">
+          {companyName}
+        </span>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Every tile carried two header rows: a nearly empty band at the top with a chip on the left and a timestamp adrift on the right, then a second row above the chart holding the symbol and price. The top-right space was wasted and the chart paid for the duplication.

Ticker, company name, price and day change now sit in the top-right of the tile, and the chart panel's own header is suppressed there via a new `hideHeader` prop — so the space that was empty is now informative and the chart reclaims the row it was giving up. TickerQuoteBadge shares the chart's React Query cache key, so showing the price costs no extra request.

The "going stale" card had a bare percentage in the corner — "4.20%" with no label, which could equally have been a price move, a target or a day change. It was the position weight. Replaced with the ticker and price badge; the weight is already stated in words in the card body, where it has the context to mean something.

Applied consistently across idea, decision, signal and derived-insight tiles, so the header reads the same everywhere. Pair trades keep the carousel's own per-leg labelling, since a single ticker in the corner would misrepresent a two-sided position.

Type errors unchanged (8950). 17 tests pass.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
