### PR TITLE
fix(mobile): repair pull-to-refresh; refresh reorders; pairs on one tile

### DIFF
--- a/src/components/mobile/AttentionFeedCard.tsx
+++ b/src/components/mobile/AttentionFeedCard.tsx
@@ -5,6 +5,7 @@ import {
   AlertTriangle, ArrowRight, BellOff, Check, Gavel, Info, Users,
 } from 'lucide-react'
 import { ReelsChartPanel } from '../feed/ReelsChartPanel'
+import { PairTradeChartCarousel } from '../feed/PairTradeChartCarousel'
 import { TickerQuoteBadge } from './TickerQuoteBadge'
 import { ExpandableText } from './ExpandableText'
 import { useDecisionContext } from '../../hooks/mobile/useDecisionContext'
@@ -15,6 +16,10 @@ interface AttentionFeedCardProps {
   /** Ticker for the linked asset, resolved by the caller in one batched query. */
   symbol?: string | null
   companyName?: string | null
+  /** Every leg of the pair this item belongs to. Supplied when the feed has
+   *  collapsed a multi-leg pair into a single card, so the tile can show the
+   *  whole trade rather than the one leg that happened to raise the alert. */
+  pairLegs?: Array<{ id: string; action?: string; pair_leg_type?: string | null; assets?: any }>
   onOpen?: (item: AttentionItem) => void
   onSnooze?: (item: AttentionItem) => void
   onAcknowledge?: (item: AttentionItem) => void
@@ -66,6 +71,7 @@ export function AttentionFeedCard({
   item,
   symbol,
   companyName,
+  pairLegs,
   onOpen,
   onSnooze,
   onAcknowledge,
@@ -74,6 +80,13 @@ export function AttentionFeedCard({
   const TypeIcon = config.icon
   const isOverdue = !!item.due_at && new Date(item.due_at).getTime() < Date.now()
   const { data: decision } = useDecisionContext(item)
+
+  // A pair is a relationship between names, so one chart misrepresents it.
+  const isPair = (pairLegs?.length ?? 0) > 1
+  const isLongLeg = (l: any) =>
+    l.pair_leg_type === 'long' || (l.pair_leg_type == null && (l.action === 'buy' || l.action === 'add'))
+  const longLegs = (pairLegs ?? []).filter(isLongLeg).map(l => ({ id: l.id, action: l.action, asset: l.assets }))
+  const shortLegs = (pairLegs ?? []).filter(l => !isLongLeg(l)).map(l => ({ id: l.id, action: l.action, asset: l.assets }))
 
   const scrollerRef = useRef<HTMLDivElement>(null)
   const [panel, setPanel] = useState(0)
@@ -175,7 +188,7 @@ export function AttentionFeedCard({
           <TypeIcon className="h-4 w-4" />
           {config.label}
         </span>
-        {symbol ? (
+        {symbol && !isPair ? (
           <TickerQuoteBadge symbol={symbol} companyName={companyName} className="ml-auto" />
         ) : (
           <span className="ml-auto text-xs text-gray-400 whitespace-nowrap">
@@ -188,8 +201,20 @@ export function AttentionFeedCard({
       <div className="flex-shrink-0 px-3 pt-2 pb-1.5">
         <div className="flex items-baseline gap-2">
           <h2 className="text-2xl font-bold leading-tight min-w-0">
-            <span className={tone}>{(decision?.action || verb || '').toUpperCase()}</span>{' '}
-            <span className="text-gray-900 dark:text-white">{ticker}</span>
+            {isPair ? (
+              // Name the whole trade. Showing only the leg that raised the
+              // alert would misdescribe a decision about both sides.
+              <span className="text-gray-900 dark:text-white">
+                {longLegs.map(l => l.asset?.symbol).filter(Boolean).join(' / ') || 'Long'}
+                <span className="text-gray-400"> vs </span>
+                {shortLegs.map(l => l.asset?.symbol).filter(Boolean).join(' / ') || 'Short'}
+              </span>
+            ) : (
+              <>
+                <span className={tone}>{(decision?.action || verb || '').toUpperCase()}</span>{' '}
+                <span className="text-gray-900 dark:text-white">{ticker}</span>
+              </>
+            )}
           </h2>
           {/* Attribution sits with the instruction it attributes — as its own
               labelled row inside a panel called "Recommendation" it read as
@@ -205,9 +230,13 @@ export function AttentionFeedCard({
         )}
       </div>
 
-      {symbol && (
+      {(isPair || symbol) && (
         <div className="flex-shrink-0 h-[50%] min-h-[250px] max-h-[400px] px-3">
-          <ReelsChartPanel symbol={symbol} hideHeader />
+          {isPair ? (
+            <PairTradeChartCarousel longLegs={longLegs as any} shortLegs={shortLegs as any} />
+          ) : (
+            <ReelsChartPanel symbol={symbol!} hideHeader />
+          )}
         </div>
       )}
 

--- a/src/components/mobile/MobileDashboard.tsx
+++ b/src/components/mobile/MobileDashboard.tsx
@@ -114,7 +114,11 @@ export function MobileDashboard({
   const [interestAtMount] = useState(() => loadInterest(userId ?? ''))
   const [readthroughFor, setReadthroughFor] = useState<ScoredFeedItem | null>(null)
   const sentinelRef = useRef<HTMLDivElement>(null)
-  const scrollerRef = useRef<HTMLDivElement>(null)
+  // State, not a ref. The component returns early while loading, so the
+  // scroller does not exist on first render — effects keyed on a ref bound to
+  // nothing and never re-ran, which is why pull-to-refresh did nothing and the
+  // scroll position was never saved.
+  const [scroller, setScroller] = useState<HTMLDivElement | null>(null)
   const restoredRef = useRef(false)
 
   // One query for every asset referenced by an attention item, rather than a
@@ -137,6 +141,62 @@ export function MobileDashboard({
     enabled: attentionAssetIds.length > 0,
     staleTime: 5 * 60 * 1000,
   })
+
+  // Attention items are raised per trade-queue row, so a four-leg pair
+  // produces four near-identical decision cards. Look up pair membership for
+  // the sources on screen so legs of one pair can be collapsed into a single
+  // tile.
+  const attentionSourceIds = useMemo(
+    () => attentionItems
+      .filter(a => a.source_type === 'trade_queue_item')
+      .map(a => a.source_id)
+      .filter(Boolean) as string[],
+    [attentionItems]
+  )
+  const { data: pairInfo } = useQuery({
+    queryKey: ['attention-pair-membership', attentionSourceIds],
+    queryFn: async () => {
+      const empty = { keyBySource: {} as Record<string, string>, legsByPair: {} as Record<string, any[]> }
+      if (!attentionSourceIds.length) return empty
+
+      const { data: sources, error } = await supabase
+        .from('trade_queue_items')
+        .select('id, pair_id, pair_trade_id')
+        .in('id', attentionSourceIds)
+      if (error) throw error
+
+      const keyBySource: Record<string, string> = {}
+      const pairKeys = new Set<string>()
+      for (const row of (sources ?? []) as any[]) {
+        const key = row.pair_trade_id || row.pair_id
+        if (!key) continue
+        keyBySource[row.id] = key
+        pairKeys.add(key)
+      }
+      if (!pairKeys.size) return { keyBySource, legsByPair: {} }
+
+      // Every leg of those pairs, so the surviving card can show the whole
+      // trade rather than the one leg that happened to raise the alert.
+      const keys = [...pairKeys]
+      const { data: legs } = await supabase
+        .from('trade_queue_items')
+        .select('id, action, pair_id, pair_trade_id, pair_leg_type, assets:asset_id(id, symbol, company_name)')
+        .or(`pair_id.in.(${keys.join(',')}),pair_trade_id.in.(${keys.join(',')})`)
+        .eq('visibility_tier', 'active')
+        .neq('status', 'deleted')
+
+      const legsByPair: Record<string, any[]> = {}
+      for (const leg of (legs ?? []) as any[]) {
+        const key = leg.pair_trade_id || leg.pair_id
+        if (!key) continue
+        ;(legsByPair[key] ||= []).push(leg)
+      }
+      return { keyBySource, legsByPair }
+    },
+    enabled: attentionSourceIds.length > 0,
+    staleTime: 60_000,
+  })
+  const pairKeyBySource = pairInfo?.keyBySource
 
   // Drop only genuinely empty cards. An earlier 24-character threshold was
   // hiding real posts — short reasoning is still reasoning. This now catches
@@ -173,15 +233,30 @@ export function MobileDashboard({
     return () => clearTimeout(timer)
   }, [userId, visibleItems])
 
+  // One card per pair. The highest-priority leg is kept — the list is already
+  // ordered by attention priority — and the rest are dropped rather than
+  // rendered as separate screens for what is one decision.
+  const dedupedAttention = useMemo(() => {
+    if (!pairKeyBySource || !Object.keys(pairKeyBySource).length) return attentionItems
+    const seenPairs = new Set<string>()
+    return attentionItems.filter(a => {
+      const key = a.source_id ? pairKeyBySource[a.source_id] : undefined
+      if (!key) return true
+      if (seenPairs.has(key)) return false
+      seenPairs.add(key)
+      return true
+    })
+  }, [attentionItems, pairKeyBySource])
+
   // Interleave so consecutive screens are not all one kind. Scores are
   // position-derived rather than raw: each source ranks on its own scale, and
   // using position preserves the ordering each source already decided
   // (including the seen-rotation applied to ideas) while making the two
   // comparable. `leadWith` keeps the single most pressing decision first.
   const feedEntries = useMemo(() => {
-    const attentionEntries = attentionItems.map((a, idx) => ({
+    const attentionEntries = dedupedAttention.map((a, idx) => ({
       kind: 'attention' as const,
-      score: attentionItems.length - idx,
+      score: dedupedAttention.length - idx,
       attention: a,
     }))
     // Learned interest nudges rank rather than dictating it: a strong
@@ -221,7 +296,7 @@ export function MobileDashboard({
       leadWith: 'attention',
       seed: shuffleSeed,
     })
-  }, [attentionItems, visibleItems, realSignals, derivedInsights, cycle, interestAtMount, shuffleSeed])
+  }, [dedupedAttention, visibleItems, realSignals, derivedInsights, cycle, interestAtMount, shuffleSeed])
 
   useEffect(() => {
     const sentinel = sentinelRef.current
@@ -247,19 +322,19 @@ export function MobileDashboard({
   // Attempting it before render leaves scrollTop clamped to zero.
   useEffect(() => {
     if (restoredRef.current || !resumed?.scrollTop) return
-    const el = scrollerRef.current
-    if (!el || !feedEntries.length) return
+    if (!scroller || !feedEntries.length) return
+    const el = scroller
     restoredRef.current = true
     // Two frames: one for the list to lay out, one for snap to settle.
     requestAnimationFrame(() => requestAnimationFrame(() => {
       el.scrollTop = resumed.scrollTop
     }))
-  }, [resumed, feedEntries.length])
+  }, [resumed, scroller, feedEntries.length])
 
   // Persist position as the user scrolls, and once more on unmount so a fast
   // navigation away is not lost to the throttle window.
   useEffect(() => {
-    const el = scrollerRef.current
+    const el = scroller
     if (!el) return
     let timer: ReturnType<typeof setTimeout> | null = null
     const persist = () => saveFeedSession({ seed: shuffleSeed, cycle, scrollTop: el.scrollTop })
@@ -273,7 +348,7 @@ export function MobileDashboard({
       if (timer) clearTimeout(timer)
       persist()
     }
-  }, [shuffleSeed, cycle])
+  }, [scroller, shuffleSeed, cycle])
 
   // A deliberate refresh: refetch every source, re-deal the order, drop the
   // saved position and return to the top. The browser's own pull-to-refresh
@@ -291,11 +366,11 @@ export function MobileDashboard({
       queryClient.invalidateQueries({ queryKey: ['signal-cards'] }),
       queryClient.invalidateQueries({ queryKey: ['derived-insights'] }),
     ].filter(Boolean) as Promise<unknown>[])
-    scrollerRef.current?.scrollTo({ top: 0 })
-  }, [refetch, refetchAttention, queryClient])
+    scroller?.scrollTo({ top: 0 })
+  }, [refetch, refetchAttention, queryClient, scroller])
 
   const { pullDistance, isRefreshing, threshold } = usePullToRefresh({
-    scrollerRef,
+    scroller,
     onRefresh: handleRefresh,
   })
 
@@ -340,7 +415,7 @@ export function MobileDashboard({
       />
 
       <div
-        ref={scrollerRef}
+        ref={setScroller}
         className="h-full overflow-y-auto snap-y snap-mandatory overscroll-contain"
         style={{
           transform: pullDistance > 0 ? `translateY(${pullDistance}px)` : undefined,
@@ -358,6 +433,10 @@ export function MobileDashboard({
                   item={a}
                   symbol={linked?.symbol}
                   companyName={linked?.company_name}
+                  pairLegs={(() => {
+                    const key = a.source_id ? pairInfo?.keyBySource?.[a.source_id] : undefined
+                    return key ? pairInfo?.legsByPair?.[key] : undefined
+                  })()}
                   onOpen={target ? () => { markRead(a.attention_id); onNavigate?.(target) } : undefined}
                   onSnooze={() => snoozeFor(a.attention_id, 24)}
                   onAcknowledge={() => acknowledge(a.attention_id)}

--- a/src/hooks/mobile/usePullToRefresh.ts
+++ b/src/hooks/mobile/usePullToRefresh.ts
@@ -1,8 +1,13 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 interface UsePullToRefreshOptions {
-  /** The scrolling element. Pull only engages when it is already at the top. */
-  scrollerRef: React.RefObject<HTMLElement>
+  /**
+   * The scrolling element itself, not a ref. Passing a ref meant the binding
+   * effect ran once on mount — before the feed had loaded and the scroller
+   * existed — bound to nothing, and never re-ran, so the gesture was dead.
+   * Taking the element makes its arrival a dependency.
+   */
+  scroller: HTMLElement | null
   onRefresh: () => Promise<void> | void
   /** Drag distance, after resistance, that commits the refresh. */
   threshold?: number
@@ -30,7 +35,7 @@ const MAX_PULL = 96
  * pass through untouched.
  */
 export function usePullToRefresh({
-  scrollerRef,
+  scroller,
   onRefresh,
   threshold = 72,
   enabled = true,
@@ -66,7 +71,7 @@ export function usePullToRefresh({
   }, [onRefresh, threshold])
 
   useEffect(() => {
-    const el = scrollerRef.current
+    const el = scroller
     if (!el || !enabled) return
 
     const onTouchStart = (e: TouchEvent) => {
@@ -130,7 +135,7 @@ export function usePullToRefresh({
       el.removeEventListener('touchend', onTouchEnd)
       el.removeEventListener('touchcancel', onTouchEnd)
     }
-  }, [scrollerRef, enabled, finish])
+  }, [scroller, enabled, finish])
 
   // Mirror into a ref so touchend reads the current distance without the
   // listener having to be re-bound on every pixel of travel.

--- a/src/lib/mobile/feed-session.ts
+++ b/src/lib/mobile/feed-session.ts
@@ -27,8 +27,30 @@ export interface FeedSession {
   savedAt: number
 }
 
+/**
+ * True when this page load was an explicit reload rather than an in-app
+ * navigation. A reload is the user asking for a fresh feed; restoring the
+ * previous order and position in that case makes refreshing look broken.
+ */
+function isPageReload(): boolean {
+  if (typeof performance === 'undefined') return false
+  try {
+    const nav = performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming | undefined
+    return nav?.type === 'reload'
+  } catch {
+    return false
+  }
+}
+
 export function loadFeedSession(): FeedSession | null {
   if (typeof sessionStorage === 'undefined') return null
+  // Resume only for in-app navigation. Without this a browser refresh looked
+  // identical to returning from an asset page, so it restored the same seed
+  // and offset — the feed appeared not to change at all.
+  if (isPageReload()) {
+    clearFeedSession()
+    return null
+  }
   try {
     const raw = sessionStorage.getItem(KEY)
     if (!raw) return null


### PR DESCRIPTION
Pull-to-refresh never worked. The binding effect keyed on a ref, and MobileDashboard returns early while loading — so on first render the scroller did not exist, the effect bound to nothing, and it never re-ran once the feed arrived. The hook now takes the element itself, making its arrival a dependency. The session-save effect had the same latent bug and is fixed the same way, so scroll position was also never being persisted on first load.

Refreshing appeared to change nothing because session resume could not tell a browser reload from an in-app navigation: both are a fresh mount reading sessionStorage, so a reload restored the same seed and offset. Resume is now skipped when the Navigation Timing API reports a reload — returning from an asset still lands where you left, while an explicit refresh genuinely re-deals.

Pair trades now occupy one tile. Attention items are raised per trade-queue row, so a four-leg pair produced four near-identical decision cards. Legs of the same pair are collapsed to the highest-priority one, and that card receives every leg: the chart becomes the swipeable carousel, and the title names the whole trade ("LLY / PFE vs CLOV / GH") rather than the single leg that happened to raise the alert. The header quote badge is suppressed for pairs, since one ticker would misrepresent a two-sided position.

Type errors unchanged (8949). 17 tests pass.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
