### PR TITLE
fix(mobile): pair labelling, header fit, gesture and timeframe polish

### DIFF
--- a/src/components/feed/PairTradeChartCarousel.tsx
+++ b/src/components/feed/PairTradeChartCarousel.tsx
@@ -12,6 +12,8 @@ interface PairTradeChartCarouselProps {
 interface CarouselLeg {
   key: string
   side: 'long' | 'short'
+  /** The instruction, in the words used everywhere else: BUY / SELL / ADD / TRIM. */
+  action: string
   symbol: string
   companyName?: string
 }
@@ -49,6 +51,7 @@ export function PairTradeChartCarousel({ longLegs, shortLegs }: PairTradeChartCa
         .map(l => ({
           key: `${side}-${l.id}`,
           side,
+          action: (l.action || (side === 'long' ? 'buy' : 'sell')).toUpperCase(),
           symbol: l.asset.symbol,
           companyName: l.asset.company_name,
         }))
@@ -102,7 +105,7 @@ export function PairTradeChartCarousel({ longLegs, shortLegs }: PairTradeChartCa
                 )}
               >
                 {leg.side === 'long' ? <TrendingUp className="h-3 w-3" /> : <TrendingDown className="h-3 w-3" />}
-                {leg.symbol}
+                {leg.action} {leg.symbol}
               </span>
 
               {near ? (

--- a/src/components/feed/ReelsChartPanel.tsx
+++ b/src/components/feed/ReelsChartPanel.tsx
@@ -168,7 +168,7 @@ export function ReelsChartPanel({
       )}
 
       {/* Timeframe selector */}
-      <div className={clsx("flex items-center gap-0.5 px-2 py-1.5 bg-gray-50 border-b border-gray-200 relative z-30 overflow-x-auto dark:border-gray-700 dark:bg-gray-900", hideHeader && "rounded-t-xl border-t")}>
+      <div className={clsx("flex items-center justify-between gap-0.5 px-2 py-1.5 bg-gray-50 border-b border-gray-200 relative z-30 dark:border-gray-700 dark:bg-gray-900", hideHeader && "rounded-t-xl border-t")}>
         {timeframes.map(tf => (
           <button
             key={tf.value}

--- a/src/components/feed/ReelsFeedItem.tsx
+++ b/src/components/feed/ReelsFeedItem.tsx
@@ -160,14 +160,16 @@ export function ReelsFeedItem({
       config.bgColor
     )}>
       {/* Header */}
-      <div className="flex-shrink-0 z-30 flex items-center justify-between px-3 py-2 bg-white border-b border-gray-100 dark:border-gray-800 dark:bg-gray-800">
-        <div className="flex items-center gap-3">
+      <div className="flex-shrink-0 z-30 flex items-center gap-2 px-3 py-2 bg-white border-b border-gray-100 dark:border-gray-800 dark:bg-gray-800">
+        <div className="flex items-center gap-2 min-w-0">
           {/* Type badge */}
+          {/* shrink-0 + nowrap: "Trade Idea" was wrapping onto a second line
+              and pushing the row taller than the header. */}
           <span className={clsx(
-            'flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium border',
+            'flex shrink-0 items-center gap-1 px-2 py-1 rounded-full text-[11px] sm:text-sm font-medium border whitespace-nowrap',
             config.badgeColor
           )}>
-            <TypeIcon className={clsx('h-4 w-4', config.iconColor)} />
+            <TypeIcon className={clsx('h-3.5 w-3.5 shrink-0', config.iconColor)} />
             {config.label}
           </span>
 
@@ -177,23 +179,23 @@ export function ReelsFeedItem({
               e.stopPropagation()
               onAuthorClick?.(item.author.id)
             }}
-            className="flex items-center gap-2 text-gray-700 hover:text-gray-900 transition-colors dark:hover:text-white dark:text-gray-300"
+            className="flex items-center gap-1.5 min-w-0 text-gray-700 hover:text-gray-900 transition-colors dark:hover:text-white dark:text-gray-300"
           >
             {item.author.avatar_url ? (
               <img
                 src={item.author.avatar_url}
-                alt={item.author.full_name || ''}
-                className="w-7 h-7 rounded-full object-cover border border-gray-200 dark:border-gray-700"
+                alt=""
+                className="hidden sm:block w-7 h-7 rounded-full object-cover border border-gray-200 dark:border-gray-700"
               />
             ) : (
-              <div className="w-7 h-7 rounded-full bg-gray-100 flex items-center justify-center border border-gray-200 dark:border-gray-700 dark:bg-gray-800">
+              <div className="hidden sm:flex w-7 h-7 rounded-full bg-gray-100 items-center justify-center border border-gray-200 dark:border-gray-700 dark:bg-gray-800">
                 <User className="h-4 w-4 text-gray-500 dark:text-gray-400" />
               </div>
             )}
             {/* Always show the name. A bare avatar glyph with no label tells
                 the reader nothing about who wrote the post — which is the
                 single most useful piece of context on a research feed. */}
-            <span className="text-sm font-medium truncate max-w-[9rem] sm:max-w-none">
+            <span className="text-[13px] sm:text-sm font-medium truncate max-w-[7rem] sm:max-w-none">
               {item.author.full_name ||
                 (item.author.first_name && item.author.last_name
                   ? `${item.author.first_name} ${item.author.last_name}`
@@ -203,7 +205,7 @@ export function ReelsFeedItem({
 
           {/* Time */}
           {/* Recency matters on a research feed — keep it on phones too. */}
-          <span className="text-gray-400 text-xs md:text-sm whitespace-nowrap">
+          <span className="hidden sm:inline text-gray-400 text-xs md:text-sm whitespace-nowrap">
             {formatDistanceToNow(new Date(item.created_at), { addSuffix: true })}
           </span>
         </div>

--- a/src/components/mobile/AttentionFeedCard.tsx
+++ b/src/components/mobile/AttentionFeedCard.tsx
@@ -206,10 +206,22 @@ export function AttentionFeedCard({
             {isPair ? (
               // Name the whole trade. Showing only the leg that raised the
               // alert would misdescribe a decision about both sides.
-              <span className="text-gray-900 dark:text-white">
-                {longLegs.map(l => l.asset?.symbol).filter(Boolean).join(' / ') || 'Long'}
-                <span className="text-gray-400"> vs </span>
-                {shortLegs.map(l => l.asset?.symbol).filter(Boolean).join(' / ') || 'Short'}
+              // Both sides named and coloured. A plain black "A / B vs C / D"
+              // left the reader guessing which side was being bought.
+              <span className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5 text-xl">
+                {longLegs.length > 0 && (
+                  <span className="text-emerald-600 dark:text-emerald-400">
+                    BUY {longLegs.map(l => l.asset?.symbol).filter(Boolean).join(' / ')}
+                  </span>
+                )}
+                {longLegs.length > 0 && shortLegs.length > 0 && (
+                  <span className="text-gray-400 text-base font-medium">vs</span>
+                )}
+                {shortLegs.length > 0 && (
+                  <span className="text-red-600 dark:text-red-400">
+                    SELL {shortLegs.map(l => l.asset?.symbol).filter(Boolean).join(' / ')}
+                  </span>
+                )}
               </span>
             ) : (
               <>

--- a/src/components/mobile/MobileDashboard.tsx
+++ b/src/components/mobile/MobileDashboard.tsx
@@ -153,7 +153,7 @@ export function MobileDashboard({
       .filter(Boolean) as string[],
     [attentionItems]
   )
-  const { data: pairInfo } = useQuery({
+  const { data: pairInfo, isLoading: pairInfoLoading } = useQuery({
     queryKey: ['attention-pair-membership', attentionSourceIds],
     queryFn: async () => {
       const empty = { keyBySource: {} as Record<string, string>, legsByPair: {} as Record<string, any[]> }
@@ -237,6 +237,10 @@ export function MobileDashboard({
   // ordered by attention priority — and the rest are dropped rather than
   // rendered as separate screens for what is one decision.
   const dedupedAttention = useMemo(() => {
+    // Until pair membership resolves, every leg still looks like its own
+    // decision. Rendering them would show "SELL CLOV" for a beat and then
+    // replace it with the pair, so hold the attention cards back instead.
+    if (attentionSourceIds.length && pairInfoLoading) return []
     if (!pairKeyBySource || !Object.keys(pairKeyBySource).length) return attentionItems
     const seenPairs = new Set<string>()
     return attentionItems.filter(a => {
@@ -246,7 +250,7 @@ export function MobileDashboard({
       seenPairs.add(key)
       return true
     })
-  }, [attentionItems, pairKeyBySource])
+  }, [attentionItems, pairKeyBySource, attentionSourceIds.length, pairInfoLoading])
 
   // Interleave so consecutive screens are not all one kind. Scores are
   // position-derived rather than raw: each source ranks on its own scale, and

--- a/src/hooks/mobile/usePullToRefresh.ts
+++ b/src/hooks/mobile/usePullToRefresh.ts
@@ -17,8 +17,12 @@ interface UsePullToRefreshOptions {
 const RESISTANCE = 0.45
 /** Indicator never travels further than this, regardless of drag. */
 const MAX_PULL = 96
-/** Ignore the first pixels so a slightly-imperfect vertical scroll is not a pull. */
-const START_SLOP = 8
+/** Vertical travel before a pull begins. Deliberately generous: a pull is a
+ *  deliberate gesture, and starting one by accident mid-scroll is worse than
+ *  needing a slightly longer drag. */
+const START_SLOP = 16
+/** Movement needed before the gesture's axis is decided. */
+const AXIS_SLOP = 6
 const RELEASE_EASE = 'transform 220ms cubic-bezier(0.22, 1, 0.36, 1)'
 
 /**
@@ -46,6 +50,9 @@ export function usePullToRefresh({
 
   const indicatorRef = useRef<HTMLElement | null>(null)
   const startY = useRef<number | null>(null)
+  const startX = useRef(0)
+  /** Set once a gesture is judged horizontal; it can then never become a pull. */
+  const horizontal = useRef(false)
   const distance = useRef(0)
   const dragging = useRef(false)
   const refreshing = useRef(false)
@@ -110,6 +117,8 @@ export function usePullToRefresh({
         return
       }
       startY.current = e.touches[0].clientY
+      startX.current = e.touches[0].clientX
+      horizontal.current = false
       dragging.current = false
     }
 
@@ -117,6 +126,15 @@ export function usePullToRefresh({
       if (startY.current == null || refreshing.current) return
 
       const raw = e.touches[0].clientY - startY.current
+      const dx = Math.abs(e.touches[0].clientX - startX.current)
+
+      // Decide the axis once, and stick to it. Swiping a pair-trade carousel
+      // drifts vertically by a few pixels, which was enough to start a pull.
+      if (!dragging.current && !horizontal.current && (dx > AXIS_SLOP || raw > AXIS_SLOP)) {
+        horizontal.current = dx > raw
+      }
+      if (horizontal.current) return
+
       if (raw <= START_SLOP) {
         if (dragging.current) {
           dragging.current = false


### PR DESCRIPTION
A pair briefly rendered as one leg on load. The collapse depends on a pair-membership lookup, and until it resolved every leg still looked like its own decision — so "SELL CLOV" appeared for a beat before being replaced by the pair. Attention cards are now held back until membership is known.

Pull-to-refresh fired while swiping the carousel. A horizontal swipe drifts a few pixels vertically, which was enough to start a pull. The gesture's axis is now decided once, after 6px of movement, and a horizontal verdict can never become a pull. The vertical slop before a pull begins also rose from 8px to 16px: a pull is deliberate, and starting one by accident mid-scroll is worse than needing a longer drag.

Chart timeframes read as a scrolling strip, which looked like content that had moved when swiping between legs. The options now divide the row evenly and cannot overflow, so a different timeframe on another leg shows simply as a different selection.

Pair sides were unlabelled and black, leaving no way to tell which name was being bought. Both the carousel badge and the card title now state the instruction and colour it — "BUY LLY / PFE" in green against "SELL CLOV / GH" in red.

The trade-idea header overflowed: "Trade Idea" wrapped to two lines and the pieces collided. The badge no longer wraps or shrinks, and the author avatar is dropped on phones while the name is kept — a bare glyph says nothing, the name is the useful context, and removing it reclaims the width that caused the collision.

Type errors unchanged (8916). Full unit suite passes.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
