### PR TITLE
fix(mobile): steady first paint, readable panels, and capture from th…

### DIFF
--- a/src/components/feed/PairTradeChartCarousel.tsx
+++ b/src/components/feed/PairTradeChartCarousel.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { clsx } from 'clsx'
-import { TrendingDown, TrendingUp } from 'lucide-react'
+import { ChevronLeft, ChevronRight, TrendingDown, TrendingUp } from 'lucide-react'
 import { ReelsChartPanel } from './ReelsChartPanel'
 import type { PairTradeLeg } from '../../hooks/ideas/types'
 
@@ -27,19 +27,21 @@ const NEIGHBOUR_WINDOW = 1
  * A pair is a relationship between positions, so one chart misrepresents it,
  * and stacking legs vertically leaves each too short to read on a phone.
  *
- * Two things matter for this to feel right:
+ * Legs are changed with the arrows or the dots, not by swiping. Swiping and
+ * inspecting the price are the same gesture — press and drag horizontally —
+ * so a swipe-paged carousel makes it impossible to read a price history
+ * without changing chart. Explicit controls give the drag back to the chart,
+ * which is the more valuable of the two.
+ *
+ * Two further things matter for this to feel right:
  *
  * - Only the visible chart and its immediate neighbours are mounted. Each
  *   panel is a Recharts instance with its own quote request, so rendering four
  *   at once made the first swipe stall while they all laid out — the main
  *   cause of the swipe feeling heavy.
- * - The active index is derived from scroll position inside a rAF, so it
- *   cannot disagree with what is on screen and does not re-render per event.
- *
- * `touch-action` is deliberately left alone. Pinning it to `pan-x` would make
- * the carousel swipe crisper, but the chart is half the tile and a vertical
- * drag there would then do nothing — paging the feed from the chart area
- * matters more. The browser's own axis locking handles the rest.
+ * - The chart area declares `touch-action: pan-y`, so a horizontal drag there
+ *   belongs to the chart's crosshair and never scrolls anything, while a
+ *   vertical drag still pages the feed.
  */
 export function PairTradeChartCarousel({ longLegs, shortLegs }: PairTradeChartCarouselProps) {
   const legs: CarouselLeg[] = useMemo(() => {
@@ -58,24 +60,15 @@ export function PairTradeChartCarousel({ longLegs, shortLegs }: PairTradeChartCa
     return [...build(longLegs, 'long'), ...build(shortLegs, 'short')]
   }, [longLegs, shortLegs])
 
-  const scrollerRef = useRef<HTMLDivElement>(null)
-  const frame = useRef<number | null>(null)
   const [active, setActive] = useState(0)
-
-  const onScroll = useCallback(() => {
-    if (frame.current != null) return
-    frame.current = requestAnimationFrame(() => {
-      frame.current = null
-      const el = scrollerRef.current
-      if (!el || el.clientWidth === 0) return
-      const index = Math.round(el.scrollLeft / el.clientWidth)
-      setActive(prev => (prev === index ? prev : index))
+  const clamped = Math.min(active, Math.max(0, legs.length - 1))
+  const go = useCallback((delta: number) => {
+    setActive(prev => {
+      const next = prev + delta
+      if (next < 0 || next > legs.length - 1) return prev
+      return next
     })
-  }, [])
-
-  useEffect(() => () => {
-    if (frame.current != null) cancelAnimationFrame(frame.current)
-  }, [])
+  }, [legs.length])
 
   if (!legs.length) {
     return (
@@ -87,15 +80,21 @@ export function PairTradeChartCarousel({ longLegs, shortLegs }: PairTradeChartCa
 
   return (
     <div className="w-full h-full flex flex-col">
-      <div
-        ref={scrollerRef}
-        onScroll={onScroll}
-        className="flex-1 min-h-0 flex overflow-x-auto overflow-y-hidden snap-x snap-mandatory overscroll-x-contain scrollbar-hide"
-      >
+      <div className="flex-1 min-h-0 relative">
         {legs.map((leg, i) => {
-          const near = Math.abs(i - active) <= NEIGHBOUR_WINDOW
+          const isActive = i === clamped
+          // Neighbours stay mounted so switching legs is instant, but only the
+          // active one is visible or reachable.
+          if (Math.abs(i - clamped) > NEIGHBOUR_WINDOW) return null
           return (
-            <div key={leg.key} className="w-full h-full flex-shrink-0 snap-start snap-always relative">
+            <div
+              key={leg.key}
+              aria-hidden={!isActive}
+              className={clsx(
+                'absolute inset-0',
+                isActive ? 'opacity-100' : 'opacity-0 pointer-events-none'
+              )}
+            >
               <span
                 className={clsx(
                   'absolute top-1 left-1 z-10 inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-bold uppercase tracking-wide',
@@ -108,32 +107,57 @@ export function PairTradeChartCarousel({ longLegs, shortLegs }: PairTradeChartCa
                 {leg.action} {leg.symbol}
               </span>
 
-              {near ? (
+              {/* Horizontal drag is the crosshair's; vertical still pages the feed. */}
+              <div className="w-full h-full" style={{ touchAction: 'pan-y' }}>
                 <ReelsChartPanel symbol={leg.symbol} companyName={leg.companyName} hideHeader />
-              ) : (
-                // Placeholder keeps the scroll width correct so snap points and
-                // the derived index stay accurate while the chart is unmounted.
-                <div className="w-full h-full rounded-xl border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900" />
-              )}
+              </div>
             </div>
           )
         })}
       </div>
 
       {legs.length > 1 && (
-        <div className="flex-shrink-0 flex items-center justify-center gap-1.5 pt-1.5">
+        <div className="flex-shrink-0 flex items-center justify-center gap-2 pt-1.5">
+          <button
+            type="button"
+            onClick={() => go(-1)}
+            disabled={clamped === 0}
+            className="flex items-center justify-center h-8 w-8 rounded-full text-gray-500 dark:text-gray-400 disabled:opacity-30 active:bg-gray-100 dark:active:bg-gray-800 no-touch-target"
+            aria-label="Previous leg"
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </button>
+
           {legs.map((leg, i) => (
-            <span
+            <button
               key={leg.key}
-              aria-hidden="true"
-              className={clsx(
-                'h-1.5 rounded-full transition-all',
-                i === active ? 'w-4 bg-gray-500 dark:bg-gray-300' : 'w-1.5 bg-gray-300 dark:bg-gray-600'
-              )}
-            />
+              type="button"
+              onClick={() => setActive(i)}
+              className="flex items-center justify-center h-8 px-1 no-touch-target"
+              aria-label={`Show ${leg.action} ${leg.symbol}`}
+              aria-current={i === clamped}
+            >
+              <span
+                className={clsx(
+                  'h-1.5 rounded-full transition-all block',
+                  i === clamped ? 'w-4 bg-gray-500 dark:bg-gray-300' : 'w-1.5 bg-gray-300 dark:bg-gray-600'
+                )}
+              />
+            </button>
           ))}
+
+          <button
+            type="button"
+            onClick={() => go(1)}
+            disabled={clamped === legs.length - 1}
+            className="flex items-center justify-center h-8 w-8 rounded-full text-gray-500 dark:text-gray-400 disabled:opacity-30 active:bg-gray-100 dark:active:bg-gray-800 no-touch-target"
+            aria-label="Next leg"
+          >
+            <ChevronRight className="h-5 w-5" />
+          </button>
+
           <span className="sr-only" role="status">
-            {legs[active]?.symbol} — chart {active + 1} of {legs.length}
+            {legs[clamped]?.symbol} — chart {clamped + 1} of {legs.length}
           </span>
         </div>
       )}

--- a/src/components/mobile/AttentionFeedCard.tsx
+++ b/src/components/mobile/AttentionFeedCard.tsx
@@ -2,12 +2,12 @@ import { useRef, useState } from 'react'
 import { clsx } from 'clsx'
 import { formatDistanceToNow } from 'date-fns'
 import {
-  AlertTriangle, ArrowRight, BellOff, Check, Gavel, Info, Users,
+  AlertTriangle, ArrowRight, BellOff, Check, Gavel, Info, PenLine, Share2, Users,
 } from 'lucide-react'
 import { ReelsChartPanel } from '../feed/ReelsChartPanel'
 import { PairTradeChartCarousel } from '../feed/PairTradeChartCarousel'
 import { TickerQuoteBadge } from './TickerQuoteBadge'
-import { ExpandableText } from './ExpandableText'
+import { ExpandablePanel } from './ExpandablePanel'
 import { useDecisionContext } from '../../hooks/mobile/useDecisionContext'
 import type { AttentionItem, AttentionType } from '../../types/attention'
 
@@ -23,6 +23,9 @@ interface AttentionFeedCardProps {
   onOpen?: (item: AttentionItem) => void
   onSnooze?: (item: AttentionItem) => void
   onAcknowledge?: (item: AttentionItem) => void
+  onShare?: (item: AttentionItem) => void
+  /** Log a thought, idea, recommendation or prompt against this item. */
+  onCapture?: (item: AttentionItem) => void
 }
 
 const TYPE_CONFIG: Record<AttentionType, { icon: typeof Info; label: string; chip: string }> = {
@@ -75,6 +78,8 @@ export function AttentionFeedCard({
   onOpen,
   onSnooze,
   onAcknowledge,
+  onShare,
+  onCapture,
 }: AttentionFeedCardProps) {
   const config = TYPE_CONFIG[item.attention_type] ?? TYPE_CONFIG.informational
   const TypeIcon = config.icon
@@ -152,7 +157,7 @@ export function AttentionFeedCard({
     panels.push({
       key: 'rationale',
       label: 'Rationale',
-      body: <ExpandableText text={rationale} lines={5} />,
+      body: <p className="text-sm text-gray-600 dark:text-gray-300 whitespace-pre-wrap">{rationale}</p>,
     })
   }
 
@@ -245,7 +250,7 @@ export function AttentionFeedCard({
       </div>
 
       {(isPair || symbol) && (
-        <div className="flex-shrink-0 h-[50%] min-h-[250px] max-h-[400px] px-3">
+        <div className="flex-shrink-0 h-[50%] min-h-[220px] max-h-[400px] px-3">
           {isPair ? (
             <PairTradeChartCarousel longLegs={longLegs as any} shortLegs={shortLegs as any} />
           ) : (
@@ -262,11 +267,11 @@ export function AttentionFeedCard({
           className="flex-1 min-h-0 flex overflow-x-auto overflow-y-hidden snap-x snap-mandatory overscroll-x-contain scrollbar-hide"
         >
           {panels.map(p => (
-            <div key={p.key} className="w-full flex-shrink-0 snap-start snap-always px-3 overflow-hidden">
-              <div className="text-[11px] font-semibold uppercase tracking-wider text-gray-400 mb-2">
+            <div key={p.key} className="w-full h-full flex-shrink-0 snap-start snap-always px-3 flex flex-col min-h-0">
+              <div className="flex-shrink-0 text-[11px] font-semibold uppercase tracking-wider text-gray-400 mb-2">
                 {p.label}
               </div>
-              {p.body}
+              <ExpandablePanel resetKey={panel}>{p.body}</ExpandablePanel>
             </div>
           ))}
         </div>
@@ -308,6 +313,28 @@ export function AttentionFeedCard({
           >
             <Check className="h-5 w-5" />
             <span className="text-[10px] font-medium leading-none">Got it</span>
+          </button>
+        )}
+        {onShare && (
+          <button
+            type="button"
+            onClick={() => onShare(item)}
+            className="flex flex-col items-center justify-center gap-0.5 w-14 rounded-xl text-gray-500 dark:text-gray-400 active:bg-gray-100 dark:active:bg-gray-800 no-touch-target"
+            aria-label="Share"
+          >
+            <Share2 className="h-5 w-5" />
+            <span className="text-[10px] font-medium leading-none">Share</span>
+          </button>
+        )}
+        {onCapture && (
+          <button
+            type="button"
+            onClick={() => onCapture(item)}
+            className="flex flex-col items-center justify-center gap-0.5 w-14 rounded-xl text-gray-500 dark:text-gray-400 active:bg-gray-100 dark:active:bg-gray-800 no-touch-target"
+            aria-label="Capture a thought"
+          >
+            <PenLine className="h-5 w-5" />
+            <span className="text-[10px] font-medium leading-none">Capture</span>
           </button>
         )}
         <button

--- a/src/components/mobile/DerivedInsightTile.tsx
+++ b/src/components/mobile/DerivedInsightTile.tsx
@@ -1,5 +1,5 @@
 import { clsx } from 'clsx'
-import { ArrowRight, FileQuestion, Scale, TimerReset } from 'lucide-react'
+import { ArrowRight, FileQuestion, PenLine, Scale, TimerReset } from 'lucide-react'
 import { ReelsChartPanel } from '../feed/ReelsChartPanel'
 import { TickerQuoteBadge } from './TickerQuoteBadge'
 import { ExpandableText } from './ExpandableText'
@@ -8,6 +8,7 @@ import type { DerivedInsight, DerivedInsightKind } from '../../hooks/mobile/useD
 interface DerivedInsightTileProps {
   insight: DerivedInsight
   onAssetClick?: (assetId: string, symbol: string) => void
+  /** Log a thought, idea, recommendation or prompt from this tile. */
   onCapture?: (insight: DerivedInsight) => void
 }
 
@@ -83,15 +84,7 @@ export function DerivedInsightTile({ insight, onAssetClick, onCapture }: Derived
       </div>
 
       <div className="flex-shrink-0 flex items-stretch gap-2 px-3 py-3 pb-safe border-t border-gray-200 dark:border-gray-700">
-        {onCapture && (
-          <button
-            type="button"
-            onClick={() => onCapture(insight)}
-            className="flex-1 flex items-center justify-center h-12 rounded-xl border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 font-semibold no-touch-target"
-          >
-            Add a note
-          </button>
-        )}
+        <CaptureButton onCapture={onCapture ? () => onCapture(insight) : undefined} />
         <button
           type="button"
           onClick={() => onAssetClick?.(insight.assetId, insight.symbol)}
@@ -102,5 +95,22 @@ export function DerivedInsightTile({ insight, onAssetClick, onCapture }: Derived
         </button>
       </div>
     </div>
+  )
+}
+
+/** Capture sits on every tile type, in the same place, so logging a thought
+ *  never depends on which kind of post happens to be on screen. */
+function CaptureButton({ onCapture }: { onCapture?: () => void }) {
+  if (!onCapture) return null
+  return (
+    <button
+      type="button"
+      onClick={onCapture}
+      className="flex flex-col items-center justify-center gap-0.5 w-14 rounded-xl text-gray-500 dark:text-gray-400 active:bg-gray-100 dark:active:bg-gray-800 no-touch-target"
+      aria-label="Capture a thought"
+    >
+      <PenLine className="h-5 w-5" />
+      <span className="text-[10px] font-medium leading-none">Capture</span>
+    </button>
   )
 }

--- a/src/components/mobile/ExpandablePanel.tsx
+++ b/src/components/mobile/ExpandablePanel.tsx
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { clsx } from 'clsx'
+import { ChevronDown, ChevronUp } from 'lucide-react'
+
+interface ExpandablePanelProps {
+  children: React.ReactNode
+  /** Reset back to collapsed when this changes — e.g. the visible panel index. */
+  resetKey?: string | number
+}
+
+/**
+ * A fixed-height region that reveals the rest of its content on request.
+ *
+ * The feed gives each tile exactly one screen, so the space under the chart is
+ * whatever is left — and it shrinks further when a pair trade's title wraps to
+ * two lines. Content simply overflowed and was unreachable: the region did not
+ * scroll, because a scrollable box inside a vertically-paged feed steals the
+ * paging gesture.
+ *
+ * Scrolling is therefore off until the reader asks for it. Collapsed, the
+ * region clips and vertical drags page the feed as normal. Expanded, it grows
+ * and scrolls internally — the reader has said this is what they want the
+ * gesture to do.
+ *
+ * "Show more" only appears when something is actually clipped, so a short
+ * rationale carries no control at all.
+ */
+export function ExpandablePanel({ children, resetKey }: ExpandablePanelProps) {
+  const [expanded, setExpanded] = useState(false)
+  const [overflows, setOverflows] = useState(false)
+  const contentRef = useRef<HTMLDivElement>(null)
+
+  const measure = useCallback(() => {
+    const el = contentRef.current
+    if (!el) return
+    // A pixel of tolerance: sub-pixel layout rounding otherwise reports
+    // overflow on content that visibly fits.
+    setOverflows(el.scrollHeight > el.clientHeight + 1)
+  }, [])
+
+  useEffect(() => {
+    setExpanded(false)
+  }, [resetKey])
+
+  useEffect(() => {
+    measure()
+    const el = contentRef.current
+    if (!el || typeof ResizeObserver === 'undefined') return
+    // Content arrives asynchronously (quotes, rationale) and the tile itself
+    // resizes with the keyboard, so a one-off measurement goes stale.
+    const observer = new ResizeObserver(measure)
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [measure, children])
+
+  return (
+    <div className="h-full flex flex-col min-h-0">
+      <div
+        ref={contentRef}
+        className={clsx(
+          'flex-1 min-h-0',
+          expanded
+            ? 'overflow-y-auto overscroll-contain'
+            : 'overflow-hidden'
+        )}
+        // Once expanded the region owns vertical drags; collapsed it must not
+        // capture them, or the feed cannot be paged from this part of the tile.
+        style={{ touchAction: expanded ? 'pan-y' : 'none' }}
+      >
+        {children}
+      </div>
+
+      {(overflows || expanded) && (
+        <button
+          type="button"
+          onClick={() => setExpanded(v => !v)}
+          className="flex-shrink-0 self-start inline-flex items-center gap-1 pt-1 text-xs font-semibold text-primary-600 dark:text-primary-400 no-touch-target"
+        >
+          {expanded ? (
+            <>
+              Show less <ChevronUp className="h-3.5 w-3.5" />
+            </>
+          ) : (
+            <>
+              Show more <ChevronDown className="h-3.5 w-3.5" />
+            </>
+          )}
+        </button>
+      )}
+    </div>
+  )
+}

--- a/src/components/mobile/FeedCaptureSheet.tsx
+++ b/src/components/mobile/FeedCaptureSheet.tsx
@@ -1,0 +1,207 @@
+import { useState } from 'react'
+import { clsx } from 'clsx'
+import { ArrowLeft, Lightbulb, MessageSquareQuote, Target, TrendingUp } from 'lucide-react'
+import { BottomSheet } from './BottomSheet'
+import { QuickThoughtCapture } from '../thoughts/QuickThoughtCapture'
+import { QuickTradeIdeaCapture } from '../thoughts/QuickTradeIdeaCapture'
+import { RecommendationQuickModal } from '../thoughts/RecommendationQuickModal'
+import { PromptModal } from '../thoughts/PromptModal'
+import type { CapturedContext } from '../thoughts/ContextSelector'
+
+type CaptureKind = 'thought' | 'trade-idea' | 'recommendation' | 'prompt'
+
+interface FeedCaptureSheetProps {
+  open: boolean
+  onClose: () => void
+  /** Asset of the tile the reader was looking at, so capture starts in context. */
+  assetId?: string | null
+  assetSymbol?: string | null
+  assetName?: string | null
+  /** What was on screen, recorded as the thought's provenance. */
+  context?: CapturedContext | null
+  onCaptured?: (kind: CaptureKind) => void
+}
+
+const OPTIONS: {
+  kind: CaptureKind
+  label: string
+  hint: string
+  icon: typeof Lightbulb
+  tone: string
+}[] = [
+  {
+    kind: 'thought',
+    label: 'Quick thought',
+    hint: 'Something worth remembering. Structure it later.',
+    icon: Lightbulb,
+    tone: 'text-amber-500 bg-amber-50 dark:bg-amber-900/30',
+  },
+  {
+    kind: 'trade-idea',
+    label: 'Trade idea',
+    hint: 'A position to put on, with a direction.',
+    icon: TrendingUp,
+    tone: 'text-emerald-600 bg-emerald-50 dark:bg-emerald-900/30',
+  },
+  {
+    kind: 'recommendation',
+    label: 'Recommendation',
+    hint: 'Ask a PM to act. Goes to the decision queue.',
+    icon: Target,
+    tone: 'text-primary-600 bg-primary-50 dark:bg-primary-900/30',
+  },
+  {
+    kind: 'prompt',
+    label: 'Prompt',
+    hint: 'Ask someone for work or an answer.',
+    icon: MessageSquareQuote,
+    tone: 'text-purple-600 bg-purple-50 dark:bg-purple-900/30',
+  },
+]
+
+/**
+ * Capture from inside the feed.
+ *
+ * Reading is what prompts a thought, and until now acting on one meant leaving
+ * the feed, losing your place and the thing that prompted it. The sheet opens
+ * over the tile with that tile's asset already attached.
+ *
+ * Each option routes to the surface that already owns it —
+ * QuickThoughtCapture, QuickTradeIdeaCapture, RecommendationQuickModal,
+ * PromptModal — rather than reimplementing capture for phones. They carry
+ * validation, provenance and org stamping that a mobile-only form would drift
+ * from immediately.
+ */
+export function FeedCaptureSheet({
+  open,
+  onClose,
+  assetId,
+  assetSymbol,
+  assetName,
+  context,
+  onCaptured,
+}: FeedCaptureSheetProps) {
+  const [kind, setKind] = useState<CaptureKind | null>(null)
+
+  const close = () => {
+    setKind(null)
+    onClose()
+  }
+
+  const done = (k: CaptureKind) => {
+    onCaptured?.(k)
+    close()
+  }
+
+  // These two own their overlay, so they render outside the sheet rather than
+  // inside it — nesting them would put a modal inside a drag-dismissable panel.
+  if (open && kind === 'recommendation') {
+    return (
+      <RecommendationQuickModal
+        isOpen
+        onClose={close}
+        context={context ?? contextFromAsset(assetId, assetSymbol)}
+      />
+    )
+  }
+
+  if (open && kind === 'prompt') {
+    return (
+      <PromptModal
+        isOpen
+        onClose={close}
+        context={context ?? contextFromAsset(assetId, assetSymbol)}
+      />
+    )
+  }
+
+  return (
+    <BottomSheet
+      open={open}
+      onClose={close}
+      title={kind ? undefined : 'Capture'}
+      snapPoints={kind ? [0.92] : [0.5]}
+    >
+      {kind === null ? (
+        <div className="px-3 pb-4">
+          {assetSymbol && (
+            <p className="px-1 pb-2 text-xs text-gray-500 dark:text-gray-400">
+              Attached to <span className="font-semibold text-gray-700 dark:text-gray-200">{assetSymbol}</span>
+            </p>
+          )}
+          <div className="space-y-1">
+            {OPTIONS.map(opt => {
+              const Icon = opt.icon
+              return (
+                <button
+                  key={opt.kind}
+                  type="button"
+                  onClick={() => setKind(opt.kind)}
+                  className="w-full flex items-center gap-3 min-h-[60px] px-2 rounded-xl text-left active:bg-gray-100 dark:active:bg-gray-800 transition-colors"
+                >
+                  <span className={clsx('h-10 w-10 rounded-xl flex items-center justify-center flex-shrink-0', opt.tone)}>
+                    <Icon className="h-5 w-5" />
+                  </span>
+                  <span className="flex-1 min-w-0">
+                    <span className="block text-sm font-semibold text-gray-900 dark:text-gray-100">
+                      {opt.label}
+                    </span>
+                    <span className="block text-xs text-gray-500 dark:text-gray-400">{opt.hint}</span>
+                  </span>
+                </button>
+              )
+            })}
+          </div>
+        </div>
+      ) : (
+        <div className="flex flex-col min-h-0">
+          <div className="flex-shrink-0 flex items-center gap-2 px-3 pb-2">
+            <button
+              type="button"
+              onClick={() => setKind(null)}
+              className="flex items-center justify-center h-9 w-9 -ml-1 rounded-full text-gray-500 dark:text-gray-400 active:bg-gray-100 dark:active:bg-gray-800 no-touch-target"
+              aria-label="Back to capture options"
+            >
+              <ArrowLeft className="h-5 w-5" />
+            </button>
+            <span className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+              {OPTIONS.find(o => o.kind === kind)?.label}
+            </span>
+          </div>
+
+          <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain px-3 pb-4">
+            {kind === 'thought' && (
+              <QuickThoughtCapture
+                autoFocus
+                compact
+                initialAssetId={assetId ?? undefined}
+                capturedContext={context ?? contextFromAsset(assetId, assetSymbol)}
+                onSuccess={() => done('thought')}
+                onCancel={() => setKind(null)}
+              />
+            )}
+            {kind === 'trade-idea' && (
+              <QuickTradeIdeaCapture
+                autoFocus
+                compact
+                assetId={assetId ?? undefined}
+                assetSymbol={assetSymbol ?? undefined}
+                assetName={assetName ?? undefined}
+                onSuccess={() => done('trade-idea')}
+                onCancel={() => setKind(null)}
+              />
+            )}
+          </div>
+        </div>
+      )}
+    </BottomSheet>
+  )
+}
+
+function contextFromAsset(
+  assetId?: string | null,
+  assetSymbol?: string | null
+): CapturedContext | null {
+  if (!assetId || !assetSymbol) return null
+  return { type: 'asset', id: assetId, title: assetSymbol }
+}

--- a/src/components/mobile/MobileDashboard.tsx
+++ b/src/components/mobile/MobileDashboard.tsx
@@ -20,6 +20,7 @@ import { SignalFeedTile } from './SignalFeedTile'
 import { DerivedInsightTile } from './DerivedInsightTile'
 import { useDerivedInsights } from '../../hooks/mobile/useDerivedInsights'
 import { ShareToUserModal } from '../feed/ShareToUserModal'
+import { FeedCaptureSheet } from './FeedCaptureSheet'
 import { PromoteToTradeIdeaModal } from '../ideas/PromoteToTradeIdeaModal'
 import { PromptModal } from '../thoughts/PromptModal'
 import { useFeedDwell } from '../../hooks/mobile/useFeedDwell'
@@ -82,8 +83,8 @@ export function MobileDashboard({
   // catalyst proximity. These are the real "what should I be thinking about"
   // cards; the `prompt` type is excluded because those are canned questions
   // with no finding behind them, which is precisely the filler complained of.
-  const { data: derivedInsights = [] } = useDerivedInsights()
-  const { signals } = useSignalCards()
+  const { data: derivedInsights = [], isLoading: insightsLoading } = useDerivedInsights()
+  const { signals, isLoading: signalsLoading } = useSignalCards()
   const realSignals = useMemo(
     () => (signals ?? []).filter(sig => sig.signalType !== 'prompt'),
     [signals]
@@ -92,6 +93,11 @@ export function MobileDashboard({
   const [shareItem, setShareItem] = useState<ScoredFeedItem | null>(null)
   const [promoteItem, setPromoteItem] = useState<ScoredFeedItem | null>(null)
   const [askItem, setAskItem] = useState<ScoredFeedItem | null>(null)
+  /** Asset the reader was looking at when they tapped Capture, so a thought
+   *  logged from the feed arrives already attached to its subject. */
+  const [captureCtx, setCaptureCtx] = useState<
+    { assetId: string | null; symbol: string | null; name: string | null } | null
+  >(null)
 
   const { track } = useFeedDwell(userId)
 
@@ -385,7 +391,14 @@ export function MobileDashboard({
     [onNavigate]
   )
 
-  if (isLoading || attentionLoading) {
+  // Every source gates the first paint. The feed's order is composed from all
+  // of them, so rendering before they have arrived shows one tile and then
+  // swaps it for another as each source lands.
+  const composing =
+    isLoading || attentionLoading || signalsLoading || insightsLoading ||
+    (attentionSourceIds.length > 0 && pairInfoLoading)
+
+  if (composing) {
     return (
       <div className="h-full flex items-center justify-center">
         <div className="flex flex-col items-center gap-3 text-gray-400">
@@ -436,6 +449,11 @@ export function MobileDashboard({
                   onOpen={target ? () => { markRead(a.attention_id); onNavigate?.(target) } : undefined}
                   onSnooze={() => snoozeFor(a.attention_id, 24)}
                   onAcknowledge={() => acknowledge(a.attention_id)}
+                  onCapture={() => setCaptureCtx({
+                    assetId: linked?.id ?? null,
+                    symbol: linked?.symbol ?? null,
+                    name: linked?.company_name ?? null,
+                  })}
                 />
               </section>
             )
@@ -447,7 +465,15 @@ export function MobileDashboard({
                 key={`${entry.insight.id}-r${entry.round}`}
                 className="relative h-full w-full snap-start snap-always"
               >
-                <DerivedInsightTile insight={entry.insight} onAssetClick={openAsset} />
+                <DerivedInsightTile
+                  insight={entry.insight}
+                  onAssetClick={openAsset}
+                  onCapture={() => setCaptureCtx({
+                    assetId: entry.insight.assetId ?? null,
+                    symbol: entry.insight.symbol ?? null,
+                    name: null,
+                  })}
+                />
               </section>
             )
           }
@@ -455,7 +481,15 @@ export function MobileDashboard({
           if (entry.kind === 'signal') {
             return (
               <section key={entry.signal.id} className="relative h-full w-full snap-start snap-always">
-                <SignalFeedTile signal={entry.signal} onAssetClick={openAsset} />
+                <SignalFeedTile
+                  signal={entry.signal}
+                  onAssetClick={openAsset}
+                  onCapture={() => setCaptureCtx({
+                    assetId: entry.signal.asset?.id ?? null,
+                    symbol: entry.signal.asset?.symbol ?? null,
+                    name: entry.signal.asset?.company_name ?? null,
+                  })}
+                />
               </section>
             )
           }
@@ -491,6 +525,11 @@ export function MobileDashboard({
                 onPromote={item.type === 'quick_thought' ? () => setPromoteItem(item) : undefined}
                 onAsk={() => setAskItem(item)}
                 onReadthrough={source ? () => { note('readthrough'); setReadthroughFor(item) } : undefined}
+                onCapture={() => setCaptureCtx({
+                  assetId: itemAssetId,
+                  symbol: ('asset' in item && item.asset ? item.asset.symbol : null) as string | null,
+                  name: ('asset' in item && item.asset ? item.asset.company_name : null) as string | null,
+                })}
               />
             </section>
           )
@@ -498,6 +537,14 @@ export function MobileDashboard({
 
         <div ref={sentinelRef} className="h-px" />
       </div>
+
+      <FeedCaptureSheet
+        open={captureCtx !== null}
+        onClose={() => setCaptureCtx(null)}
+        assetId={captureCtx?.assetId}
+        assetSymbol={captureCtx?.symbol}
+        assetName={captureCtx?.name}
+      />
 
       {shareItem && (
         <ShareToUserModal isOpen onClose={() => setShareItem(null)} item={shareItem} />

--- a/src/components/mobile/MobileFeedActionRail.tsx
+++ b/src/components/mobile/MobileFeedActionRail.tsx
@@ -1,5 +1,5 @@
 import { clsx } from 'clsx'
-import { GitCompareArrows, MessageSquarePlus, PlusCircle, Share2, TrendingDown, TrendingUp } from 'lucide-react'
+import { GitCompareArrows, MessageSquarePlus, PenLine, PlusCircle, Share2, TrendingDown, TrendingUp } from 'lucide-react'
 import { useIdeaReactions } from '../../hooks/ideas/useIdeaReactions'
 import type { ItemType } from '../../hooks/ideas/types'
 
@@ -19,6 +19,8 @@ interface MobileFeedActionRailProps {
   onAsk?: () => void
   /** Fired on any reaction, so interest telemetry can record it. */
   onReact?: () => void
+  /** Log a thought, idea, recommendation or prompt against this post. */
+  onCapture?: () => void
 }
 
 /**
@@ -41,6 +43,7 @@ export function MobileFeedActionRail({
   onPromote,
   onAsk,
   onReact,
+  onCapture,
 }: MobileFeedActionRailProps) {
   const { reactionCounts, toggleReaction, isToggling } = useIdeaReactions(itemId, itemType)
 
@@ -75,6 +78,7 @@ export function MobileFeedActionRail({
       )}
       {onAsk && <BarButton icon={MessageSquarePlus} label="Ask" onClick={onAsk} />}
       {onShare && <BarButton icon={Share2} label="Share" onClick={onShare} />}
+      {onCapture && <BarButton icon={PenLine} label="Capture" onClick={onCapture} />}
       {/* Promote is the strongest "move this forward" verb available, so it
           carries the accent when offered. */}
       {onPromote && (

--- a/src/components/mobile/SignalFeedTile.tsx
+++ b/src/components/mobile/SignalFeedTile.tsx
@@ -1,8 +1,6 @@
 import { clsx } from 'clsx'
 import { formatDistanceToNow } from 'date-fns'
-import {
-  ArrowRight, CalendarClock, Radar, Split, TimerReset,
-} from 'lucide-react'
+import { ArrowRight, CalendarClock, PenLine, Radar, Split, TimerReset } from 'lucide-react'
 import { ReelsChartPanel } from '../feed/ReelsChartPanel'
 import { TickerQuoteBadge } from './TickerQuoteBadge'
 import { ExpandableText } from './ExpandableText'
@@ -11,6 +9,8 @@ import type { SignalCard, SignalType } from '../../hooks/ideas/useIdeasFeed'
 interface SignalFeedTileProps {
   signal: SignalCard
   onAssetClick?: (assetId: string, symbol: string) => void
+  /** Log a thought, idea, recommendation or prompt from this tile. */
+  onCapture?: () => void
 }
 
 const SIGNAL_CONFIG: Record<SignalType, { icon: typeof Radar; label: string; chip: string }> = {
@@ -52,7 +52,7 @@ const SIGNAL_CONFIG: Record<SignalType, { icon: typeof Radar; label: string; chi
  * Signals are observations rather than requests, so the action is navigation
  * to the asset rather than an accept/dismiss verb.
  */
-export function SignalFeedTile({ signal, onAssetClick }: SignalFeedTileProps) {
+export function SignalFeedTile({ signal, onAssetClick, onCapture }: SignalFeedTileProps) {
   const config = SIGNAL_CONFIG[signal.signalType] ?? SIGNAL_CONFIG.prompt
   const Icon = config.icon
   const primary = signal.relatedAssets?.[0]
@@ -114,7 +114,8 @@ export function SignalFeedTile({ signal, onAssetClick }: SignalFeedTileProps) {
         )}
       </div>
 
-      <div className="flex-shrink-0 flex items-stretch px-3 py-3 pb-safe border-t border-gray-200 dark:border-gray-700">
+      <div className="flex-shrink-0 flex items-stretch gap-2 px-3 py-3 pb-safe border-t border-gray-200 dark:border-gray-700">
+        <CaptureButton onCapture={onCapture} />
         <button
           type="button"
           onClick={() => primary && onAssetClick?.(primary.id, primary.symbol)}
@@ -126,5 +127,22 @@ export function SignalFeedTile({ signal, onAssetClick }: SignalFeedTileProps) {
         </button>
       </div>
     </div>
+  )
+}
+
+/** Capture sits on every tile type, in the same place, so logging a thought
+ *  never depends on which kind of post happens to be on screen. */
+function CaptureButton({ onCapture }: { onCapture?: () => void }) {
+  if (!onCapture) return null
+  return (
+    <button
+      type="button"
+      onClick={onCapture}
+      className="flex flex-col items-center justify-center gap-0.5 w-14 rounded-xl text-gray-500 dark:text-gray-400 active:bg-gray-100 dark:active:bg-gray-800 no-touch-target"
+      aria-label="Capture a thought"
+    >
+      <PenLine className="h-5 w-5" />
+      <span className="text-[10px] font-medium leading-none">Capture</span>
+    </button>
   )
 }


### PR DESCRIPTION
…e feed

Five reports from device testing.

Hard refresh settled on one tile then swapped to another. The feed's order is composed from four sources that resolve at different times, but only two of them gated the first paint, so the reader saw a tile chosen from partial data. All four now gate it.

Text under the chart was unreachable. The region clipped and did not scroll — a scrollable box inside a vertically-paged feed steals the paging gesture — and a pair trade's two-line title made the clipping worse. ExpandablePanel keeps the region clipped and unscrollable by default, and offers "Show more" only when something is genuinely cut off; expanded, it grows and scrolls, because the reader has said that is what the gesture should do.

Swiping between a pair's legs and dragging the chart to read prices are the same gesture, so the carousel made price history impossible to inspect. Legs now change via arrows and dots, and the chart area declares touch-action: pan-y — horizontal drag belongs to the crosshair, vertical still pages the feed. The drag is the more valuable of the two, so the carousel gives it up.

Bullish/bearish/share existed only on idea tiles, so on a feed weighted to decisions they appeared to be missing entirely. Attention, signal and insight tiles now carry actions too, in the bar each already had rather than a floating control that would cover the content.

Capture is available from every tile: quick thought, trade idea, recommendation or prompt, opening over the post with its asset attached so the feed keeps your place. Each option routes to the surface that already owns it rather than reimplementing capture for phones.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
