### PR TITLE
fix(mobile): tap-paged carousels, identified pair charts, AI and DM o…

### DIFF
--- a/src/components/feed/PairTradeChartCarousel.tsx
+++ b/src/components/feed/PairTradeChartCarousel.tsx
@@ -1,7 +1,9 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 import { clsx } from 'clsx'
-import { ChevronLeft, ChevronRight, TrendingDown, TrendingUp } from 'lucide-react'
+import { TrendingDown, TrendingUp } from 'lucide-react'
 import { ReelsChartPanel } from './ReelsChartPanel'
+import { CarouselControls } from '../mobile/CarouselControls'
+import { TickerQuoteBadge } from '../mobile/TickerQuoteBadge'
 import type { PairTradeLeg } from '../../hooks/ideas/types'
 
 interface PairTradeChartCarouselProps {
@@ -62,13 +64,6 @@ export function PairTradeChartCarousel({ longLegs, shortLegs }: PairTradeChartCa
 
   const [active, setActive] = useState(0)
   const clamped = Math.min(active, Math.max(0, legs.length - 1))
-  const go = useCallback((delta: number) => {
-    setActive(prev => {
-      const next = prev + delta
-      if (next < 0 || next > legs.length - 1) return prev
-      return next
-    })
-  }, [legs.length])
 
   if (!legs.length) {
     return (
@@ -95,72 +90,43 @@ export function PairTradeChartCarousel({ longLegs, shortLegs }: PairTradeChartCa
                 isActive ? 'opacity-100' : 'opacity-0 pointer-events-none'
               )}
             >
-              <span
-                className={clsx(
-                  'absolute top-1 left-1 z-10 inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-bold uppercase tracking-wide',
-                  leg.side === 'long'
-                    ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300'
-                    : 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300'
-                )}
-              >
-                {leg.side === 'long' ? <TrendingUp className="h-3 w-3" /> : <TrendingDown className="h-3 w-3" />}
-                {leg.action} {leg.symbol}
-              </span>
+              <div className="h-full flex flex-col min-h-0">
+                {/* Which leg, and what it is doing. Without the quote the two
+                    charts were indistinguishable — a line with no ticker. */}
+                <div className="flex-shrink-0 flex items-start justify-between gap-2 px-0.5 pb-1">
+                  <span
+                    className={clsx(
+                      'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-bold uppercase tracking-wide shrink-0',
+                      leg.side === 'long'
+                        ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300'
+                        : 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300'
+                    )}
+                  >
+                    {leg.side === 'long' ? <TrendingUp className="h-3 w-3" /> : <TrendingDown className="h-3 w-3" />}
+                    {leg.action}
+                  </span>
+                  <TickerQuoteBadge symbol={leg.symbol} companyName={leg.companyName} className="min-w-0" />
+                </div>
 
-              {/* Horizontal drag is the crosshair's; vertical still pages the feed. */}
-              <div className="w-full h-full" style={{ touchAction: 'pan-y' }}>
-                <ReelsChartPanel symbol={leg.symbol} companyName={leg.companyName} hideHeader />
+                {/* Horizontal drag is the crosshair's; vertical still pages the feed. */}
+                <div className="flex-1 min-h-0" style={{ touchAction: 'pan-y' }}>
+                  <ReelsChartPanel symbol={leg.symbol} companyName={leg.companyName} hideHeader />
+                </div>
               </div>
             </div>
           )
         })}
       </div>
 
-      {legs.length > 1 && (
-        <div className="flex-shrink-0 flex items-center justify-center gap-2 pt-1.5">
-          <button
-            type="button"
-            onClick={() => go(-1)}
-            disabled={clamped === 0}
-            className="flex items-center justify-center h-8 w-8 rounded-full text-gray-500 dark:text-gray-400 disabled:opacity-30 active:bg-gray-100 dark:active:bg-gray-800 no-touch-target"
-            aria-label="Previous leg"
-          >
-            <ChevronLeft className="h-5 w-5" />
-          </button>
+      <CarouselControls
+        className="flex-shrink-0 pt-1.5"
+        count={legs.length}
+        index={clamped}
+        onChange={setActive}
+        dotLabel={i => `Show ${legs[i].action} ${legs[i].symbol}`}
+        label={`${legs[clamped]?.symbol} — chart ${clamped + 1} of ${legs.length}`}
+      />
 
-          {legs.map((leg, i) => (
-            <button
-              key={leg.key}
-              type="button"
-              onClick={() => setActive(i)}
-              className="flex items-center justify-center h-8 px-1 no-touch-target"
-              aria-label={`Show ${leg.action} ${leg.symbol}`}
-              aria-current={i === clamped}
-            >
-              <span
-                className={clsx(
-                  'h-1.5 rounded-full transition-all block',
-                  i === clamped ? 'w-4 bg-gray-500 dark:bg-gray-300' : 'w-1.5 bg-gray-300 dark:bg-gray-600'
-                )}
-              />
-            </button>
-          ))}
-
-          <button
-            type="button"
-            onClick={() => go(1)}
-            disabled={clamped === legs.length - 1}
-            className="flex items-center justify-center h-8 w-8 rounded-full text-gray-500 dark:text-gray-400 disabled:opacity-30 active:bg-gray-100 dark:active:bg-gray-800 no-touch-target"
-            aria-label="Next leg"
-          >
-            <ChevronRight className="h-5 w-5" />
-          </button>
-
-          <span className="sr-only" role="status">
-            {legs[clamped]?.symbol} — chart {clamped + 1} of {legs.length}
-          </span>
-        </div>
-      )}
     </div>
   )
 }

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -662,7 +662,7 @@ export function Header({
             {/* Mobile search entry point — replaces the inline input below md */}
             <button
               onClick={() => setShowMobileSearch(true)}
-              className="md:hidden inline-flex items-center justify-center h-10 w-10 rounded-full text-gray-400 hover:text-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+              className="md:hidden inline-flex items-center justify-center h-9 w-9 rounded-full no-touch-target text-gray-400 hover:text-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
               aria-label="Search"
               title="Search"
             >
@@ -679,7 +679,7 @@ export function Header({
                 // the point of the mobile app, so it must be reachable from
                 // every screen. Amber on mobile so it reads as the one
                 // create action rather than another grey utility icon.
-                "inline-flex items-center justify-center h-10 w-10 md:h-9 md:w-9 rounded-full transition-colors relative hover:bg-gray-100 dark:hover:bg-gray-800",
+                "inline-flex items-center justify-center h-9 w-9 rounded-full transition-colors relative no-touch-target hover:bg-gray-100 dark:hover:bg-gray-800",
                 isCommPaneOpen && commPaneView === 'thoughts'
                   ? "text-amber-600 bg-amber-100 dark:bg-amber-900/40"
                   : "text-amber-500 md:text-gray-400 md:hover:text-gray-600 dark:hover:text-gray-300"
@@ -695,7 +695,7 @@ export function Header({
                 onShowAI()
               }}
               className={clsx(
-                "hidden md:inline-flex items-center justify-center h-9 w-9 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors relative",
+                "inline-flex items-center justify-center h-9 w-9 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors relative no-touch-target",
                 isCommPaneOpen && commPaneView === 'ai'
                   ? "text-primary-600 bg-primary-100 dark:bg-primary-900/40 dark:text-primary-300"
                   : "text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
@@ -713,7 +713,7 @@ export function Header({
                 onShowDirectMessages?.()
               }}
               className={clsx(
-                "hidden md:inline-flex items-center justify-center h-9 w-9 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors relative",
+                "inline-flex items-center justify-center h-9 w-9 rounded-full hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors relative no-touch-target",
                 isCommPaneOpen && commPaneView === 'direct-messages'
                   ? "text-primary-600 bg-primary-100 dark:bg-primary-900/40 dark:text-primary-300"
                   : "text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
@@ -732,7 +732,7 @@ export function Header({
                 onShowNotifications?.()
               }}
               className={clsx(
-                "inline-flex items-center justify-center h-10 w-10 md:h-9 md:w-9 rounded-full transition-colors relative hover:bg-gray-100 dark:hover:bg-gray-800",
+                "inline-flex items-center justify-center h-9 w-9 rounded-full transition-colors relative no-touch-target hover:bg-gray-100 dark:hover:bg-gray-800",
                 isCommPaneOpen && commPaneView === 'notifications'
                   ? "text-primary-600 bg-primary-100 dark:bg-primary-900/40 dark:text-primary-300"
                   : "text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
@@ -751,10 +751,10 @@ export function Header({
             <div className="relative" ref={userMenuRef}>
               <button
                 onClick={() => setShowUserMenu(!showUserMenu)}
-                className="flex items-center justify-center gap-0 md:gap-3 h-10 w-10 md:h-auto md:w-auto md:px-2 md:py-1.5 text-gray-700 hover:text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full md:rounded-lg transition-colors dark:hover:text-white dark:text-gray-300"
+                className="flex items-center justify-center gap-0 md:gap-3 h-9 w-9 md:h-auto md:w-auto md:px-2 md:py-1.5 no-touch-target text-gray-700 hover:text-gray-900 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full md:rounded-lg transition-colors dark:hover:text-white dark:text-gray-300"
                 title="Account menu"
               >
-                <div className="w-8 h-8 shrink-0 rounded-full bg-primary-600 flex items-center justify-center">
+                <div className="w-7 h-7 md:w-8 md:h-8 shrink-0 rounded-full bg-primary-600 flex items-center justify-center">
                   <span className="text-white text-sm font-semibold">
                     {getUserInitials()}
                   </span>

--- a/src/components/mobile/AttentionFeedCard.tsx
+++ b/src/components/mobile/AttentionFeedCard.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 import { clsx } from 'clsx'
 import { formatDistanceToNow } from 'date-fns'
 import {
@@ -8,6 +8,7 @@ import { ReelsChartPanel } from '../feed/ReelsChartPanel'
 import { PairTradeChartCarousel } from '../feed/PairTradeChartCarousel'
 import { TickerQuoteBadge } from './TickerQuoteBadge'
 import { ExpandablePanel } from './ExpandablePanel'
+import { CarouselControls } from './CarouselControls'
 import { useDecisionContext } from '../../hooks/mobile/useDecisionContext'
 import type { AttentionItem, AttentionType } from '../../types/attention'
 
@@ -95,7 +96,6 @@ export function AttentionFeedCard({
   const longLegs = chartableLegs.filter(isLongLeg).map(l => ({ id: l.id, action: l.action, asset: l.assets }))
   const shortLegs = chartableLegs.filter(l => !isLongLeg(l)).map(l => ({ id: l.id, action: l.action, asset: l.assets }))
 
-  const scrollerRef = useRef<HTMLDivElement>(null)
   const [panel, setPanel] = useState(0)
 
   // `title` arrives as "SELL DASH" — split so the verb can carry the tone
@@ -180,12 +180,7 @@ export function AttentionFeedCard({
     ),
   })
 
-  const onScroll = () => {
-    const el = scrollerRef.current
-    if (!el) return
-    const i = Math.round(el.scrollLeft / el.clientWidth)
-    if (i !== panel) setPanel(i)
-  }
+  const activePanel = Math.min(panel, Math.max(0, panels.length - 1))
 
   return (
     <div className="relative w-full h-full flex flex-col bg-white dark:bg-gray-900">
@@ -259,37 +254,26 @@ export function AttentionFeedCard({
         </div>
       )}
 
-      {/* Supporting detail, swipeable so the chart above keeps its height. */}
+      {/* Supporting detail, paged so the chart above keeps its height.
+          Tap-driven like the chart carousel: a horizontal scroll container
+          here absorbed the vertical drags meant to page the feed, which is
+          why swiping up over this area did nothing. */}
       <div className="flex-1 min-h-0 flex flex-col pt-3">
-        <div
-          ref={scrollerRef}
-          onScroll={onScroll}
-          className="flex-1 min-h-0 flex overflow-x-auto overflow-y-hidden snap-x snap-mandatory overscroll-x-contain scrollbar-hide"
-        >
-          {panels.map(p => (
-            <div key={p.key} className="w-full h-full flex-shrink-0 snap-start snap-always px-3 flex flex-col min-h-0">
-              <div className="flex-shrink-0 text-[11px] font-semibold uppercase tracking-wider text-gray-400 mb-2">
-                {p.label}
-              </div>
-              <ExpandablePanel resetKey={panel}>{p.body}</ExpandablePanel>
-            </div>
-          ))}
+        <div className="flex-1 min-h-0 px-3 flex flex-col">
+          <div className="flex-shrink-0 text-[11px] font-semibold uppercase tracking-wider text-gray-400 mb-2">
+            {panels[activePanel]?.label}
+          </div>
+          <ExpandablePanel resetKey={activePanel}>{panels[activePanel]?.body}</ExpandablePanel>
         </div>
 
-        {panels.length > 1 && (
-          <div className="flex-shrink-0 flex items-center justify-center gap-1.5 py-2">
-            {panels.map((p, i) => (
-              <span
-                key={p.key}
-                aria-hidden="true"
-                className={clsx(
-                  'h-1.5 rounded-full transition-all',
-                  i === panel ? 'w-4 bg-gray-500 dark:bg-gray-300' : 'w-1.5 bg-gray-300 dark:bg-gray-600'
-                )}
-              />
-            ))}
-          </div>
-        )}
+        <CarouselControls
+          className="flex-shrink-0 py-1"
+          count={panels.length}
+          index={activePanel}
+          onChange={setPanel}
+          dotLabel={i => `Show ${panels[i].label}`}
+          label={`${panels[activePanel]?.label} — ${activePanel + 1} of ${panels.length}`}
+        />
       </div>
 
       <div className="flex-shrink-0 flex items-stretch gap-2 px-3 py-3 pb-safe border-t border-gray-200 dark:border-gray-700">

--- a/src/components/mobile/CarouselControls.tsx
+++ b/src/components/mobile/CarouselControls.tsx
@@ -1,0 +1,85 @@
+import { clsx } from 'clsx'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
+
+interface CarouselControlsProps {
+  count: number
+  index: number
+  onChange: (index: number) => void
+  /** Announced to screen readers, e.g. "LLY — chart 1 of 2". */
+  label?: string
+  /** Accessible name for each dot, e.g. i => `Show ${panels[i].label}`. */
+  dotLabel?: (index: number) => string
+  className?: string
+}
+
+/**
+ * Arrows and dots for paging a carousel.
+ *
+ * Shared because the tile has two carousels — the pair-trade charts and the
+ * supporting-detail panels — and they must page identically; two carousels on
+ * one screen that respond to different gestures is worse than either choice
+ * made consistently.
+ *
+ * Both are driven by taps rather than swipes. On the charts a horizontal drag
+ * belongs to the crosshair, and on the panels it competed with the feed's own
+ * vertical paging: a horizontal scroll-snap container is a scroll container,
+ * so vertical drags starting inside it were absorbed rather than passed up.
+ */
+export function CarouselControls({
+  count,
+  index,
+  onChange,
+  label,
+  dotLabel,
+  className,
+}: CarouselControlsProps) {
+  if (count <= 1) return null
+
+  return (
+    <div className={clsx('flex items-center justify-center gap-2', className)}>
+      <button
+        type="button"
+        onClick={() => onChange(Math.max(0, index - 1))}
+        disabled={index === 0}
+        className="flex items-center justify-center h-8 w-8 rounded-full text-gray-500 dark:text-gray-400 disabled:opacity-30 active:bg-gray-100 dark:active:bg-gray-800 no-touch-target"
+        aria-label="Previous"
+      >
+        <ChevronLeft className="h-5 w-5" />
+      </button>
+
+      {Array.from({ length: count }, (_, i) => (
+        <button
+          key={i}
+          type="button"
+          onClick={() => onChange(i)}
+          className="flex items-center justify-center h-8 px-1 no-touch-target"
+          aria-label={dotLabel?.(i) ?? `Go to ${i + 1}`}
+          aria-current={i === index}
+        >
+          <span
+            className={clsx(
+              'block h-1.5 rounded-full transition-all',
+              i === index ? 'w-4 bg-gray-500 dark:bg-gray-300' : 'w-1.5 bg-gray-300 dark:bg-gray-600'
+            )}
+          />
+        </button>
+      ))}
+
+      <button
+        type="button"
+        onClick={() => onChange(Math.min(count - 1, index + 1))}
+        disabled={index === count - 1}
+        className="flex items-center justify-center h-8 w-8 rounded-full text-gray-500 dark:text-gray-400 disabled:opacity-30 active:bg-gray-100 dark:active:bg-gray-800 no-touch-target"
+        aria-label="Next"
+      >
+        <ChevronRight className="h-5 w-5" />
+      </button>
+
+      {label && (
+        <span className="sr-only" role="status">
+          {label}
+        </span>
+      )}
+    </div>
+  )
+}

--- a/src/components/mobile/ExpandablePanel.tsx
+++ b/src/components/mobile/ExpandablePanel.tsx
@@ -63,9 +63,12 @@ export function ExpandablePanel({ children, resetKey }: ExpandablePanelProps) {
             ? 'overflow-y-auto overscroll-contain'
             : 'overflow-hidden'
         )}
-        // Once expanded the region owns vertical drags; collapsed it must not
-        // capture them, or the feed cannot be paged from this part of the tile.
-        style={{ touchAction: expanded ? 'pan-y' : 'none' }}
+        // Collapsed, the region has nothing to scroll and must stay out of the
+        // way: `touch-action: none` here swallowed the drag entirely, so
+        // swiping up over the text did not page the feed. Left at the default,
+        // the browser passes the pan to the feed's own scroller. Expanded, the
+        // region scrolls itself.
+        style={expanded ? { touchAction: 'pan-y' } : undefined}
       >
         {children}
       </div>


### PR DESCRIPTION
…n phones

Swiping up over the supporting text did nothing. A horizontal scroll-snap container is a scroll container, so vertical drags starting inside it were absorbed rather than passed to the feed. The panels now page by tap, sharing CarouselControls with the chart carousel — two carousels on one screen that answer to different gestures is worse than either choice made consistently.

The collapsed ExpandablePanel made this worse: it declared touch-action: none, which swallowed the drag outright. Collapsed it has nothing to scroll and now stays out of the way entirely.

Pair charts were unidentifiable — a line with a BUY badge and no ticker. Each leg now carries ticker, name, price and change, reusing TickerQuoteBadge, which shares the chart's query key and so costs no extra request.

AI and direct messages were hidden below md, leaving both surfaces with no entry point on a phone. Showing them makes six controls in the header, which the global 44px minimum would have widened into each other — the overlap reported earlier. The toolbar opts out and sizes itself, which is what .no-touch-target is for.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
