### PR TITLE
refactor(mobile): one shared header for every feed tile type

### DIFF
--- a/src/components/feed/PairTradeChartCarousel.tsx
+++ b/src/components/feed/PairTradeChartCarousel.tsx
@@ -93,7 +93,7 @@ export function PairTradeChartCarousel({ longLegs, shortLegs }: PairTradeChartCa
               <div className="h-full flex flex-col min-h-0">
                 {/* Which leg, and what it is doing. Without the quote the two
                     charts were indistinguishable — a line with no ticker. */}
-                <div className="flex-shrink-0 flex items-start justify-between gap-2 px-0.5 pb-1">
+                <div className="flex-shrink-0 flex items-start justify-between gap-2 px-0.5 pb-0.5">
                   <span
                     className={clsx(
                       'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-bold uppercase tracking-wide shrink-0',
@@ -119,7 +119,7 @@ export function PairTradeChartCarousel({ longLegs, shortLegs }: PairTradeChartCa
       </div>
 
       <CarouselControls
-        className="flex-shrink-0 pt-1.5"
+        className="flex-shrink-0"
         count={legs.length}
         index={clamped}
         onChange={setActive}

--- a/src/components/feed/ReelsChartPanel.tsx
+++ b/src/components/feed/ReelsChartPanel.tsx
@@ -168,7 +168,7 @@ export function ReelsChartPanel({
       )}
 
       {/* Timeframe selector */}
-      <div className={clsx("flex items-center justify-between gap-0.5 px-2 py-1.5 bg-gray-50 border-b border-gray-200 relative z-30 dark:border-gray-700 dark:bg-gray-900", hideHeader && "rounded-t-xl border-t")}>
+      <div className={clsx("flex items-center justify-between gap-0.5 px-2 py-0.5 bg-gray-50 border-b border-gray-200 relative z-30 dark:border-gray-700 dark:bg-gray-900", hideHeader && "rounded-t-xl border-t")}>
         {timeframes.map(tf => (
           <button
             key={tf.value}
@@ -177,9 +177,9 @@ export function ReelsChartPanel({
               setSelectedTimeframe(tf.value)
             }}
             className={clsx(
-              'px-2.5 py-1 rounded-md text-xs font-medium transition-colors whitespace-nowrap',
+              'px-1.5 py-0.5 rounded text-[11px] font-medium transition-colors whitespace-nowrap no-touch-target',
               selectedTimeframe === tf.value
-                ? 'bg-primary-100 text-primary-700'
+                ? 'bg-primary-100 text-primary-700 dark:bg-primary-900/40 dark:text-primary-300'
                 : 'text-gray-500 hover:text-gray-700 hover:bg-gray-100 dark:hover:text-gray-200 dark:hover:bg-gray-700 dark:text-gray-400'
             )}
           >

--- a/src/components/feed/ReelsFeedItem.tsx
+++ b/src/components/feed/ReelsFeedItem.tsx
@@ -1,12 +1,8 @@
 import { clsx } from 'clsx'
-import { formatDistanceToNow } from 'date-fns'
-import {
-  TrendingUp, TrendingDown, Lightbulb, FileText, GitBranch, Sparkles,
-  MessageSquare, User, ChevronRight, Share2, PlusCircle, GitCompareArrows
-} from 'lucide-react'
+import { TrendingUp, TrendingDown, Lightbulb, FileText, GitBranch, Sparkles, MessageSquare, ChevronRight, Share2, PlusCircle, GitCompareArrows } from 'lucide-react'
 import { ReelsChartPanel } from './ReelsChartPanel'
 import { PairTradeChartCarousel } from './PairTradeChartCarousel'
-import { TickerQuoteBadge } from '../mobile/TickerQuoteBadge'
+import { FeedTileHeader } from '../mobile/FeedTileHeader'
 import { ExpandableText } from '../mobile/ExpandableText'
 import type { ScoredFeedItem, ItemType } from '../../hooks/ideas/types'
 
@@ -159,12 +155,9 @@ export function ReelsFeedItem({
       'relative w-full h-full overflow-hidden flex flex-col',
       config.bgColor
     )}>
-      {/* Header */}
-      <div className="flex-shrink-0 z-30 flex items-center gap-2 px-3 py-2 bg-white border-b border-gray-100 dark:border-gray-800 dark:bg-gray-800">
-        <div className="flex items-center gap-2 min-w-0">
-          {/* Type badge */}
-          {/* shrink-0 + nowrap: "Trade Idea" was wrapping onto a second line
-              and pushing the row taller than the header. */}
+      <FeedTileHeader
+        className="bg-white dark:bg-gray-800"
+        badge={
           <span className={clsx(
             'flex shrink-0 items-center gap-1 px-2 py-1 rounded-full text-[11px] sm:text-sm font-medium border whitespace-nowrap',
             config.badgeColor
@@ -172,56 +165,17 @@ export function ReelsFeedItem({
             <TypeIcon className={clsx('h-3.5 w-3.5 shrink-0', config.iconColor)} />
             {config.label}
           </span>
-
-          {/* Author */}
-          <button
-            onClick={(e) => {
-              e.stopPropagation()
-              onAuthorClick?.(item.author.id)
-            }}
-            className="flex items-center gap-1.5 min-w-0 text-gray-700 hover:text-gray-900 transition-colors dark:hover:text-white dark:text-gray-300"
-          >
-            {item.author.avatar_url ? (
-              <img
-                src={item.author.avatar_url}
-                alt=""
-                className="hidden sm:block w-7 h-7 rounded-full object-cover border border-gray-200 dark:border-gray-700"
-              />
-            ) : (
-              <div className="hidden sm:flex w-7 h-7 rounded-full bg-gray-100 items-center justify-center border border-gray-200 dark:border-gray-700 dark:bg-gray-800">
-                <User className="h-4 w-4 text-gray-500 dark:text-gray-400" />
-              </div>
-            )}
-            {/* Always show the name. A bare avatar glyph with no label tells
-                the reader nothing about who wrote the post — which is the
-                single most useful piece of context on a research feed. */}
-            <span className="text-[13px] sm:text-sm font-medium truncate max-w-[7rem] sm:max-w-none">
-              {item.author.full_name ||
-                (item.author.first_name && item.author.last_name
-                  ? `${item.author.first_name} ${item.author.last_name}`
-                  : item.author.email?.split('@')[0] || 'Unknown')}
-            </span>
-          </button>
-
-          {/* Time */}
-          {/* Recency matters on a research feed — keep it on phones too. */}
-          <span className="hidden sm:inline text-gray-400 text-xs md:text-sm whitespace-nowrap">
-            {formatDistanceToNow(new Date(item.created_at), { addSuffix: true })}
-          </span>
-        </div>
-
-        {/* Ticker and price fill what was an empty right-hand gap, and let the
-            chart below drop its own header row. */}
-        {hideHeaderActions && displaySymbol && !isPairTrade && (
-          <TickerQuoteBadge
-            symbol={displaySymbol}
-            companyName={asset?.company_name}
-            className="ml-auto"
-          />
-        )}
-
-        {/* Action buttons */}
-        <div className={clsx('items-center gap-2', hideHeaderActions ? 'hidden' : 'flex')}>
+        }
+        authorName={item.author.full_name ||
+          (item.author.first_name && item.author.last_name
+            ? `${item.author.first_name} ${item.author.last_name}`
+            : item.author.email?.split('@')[0] || 'Unknown')}
+        onAuthorClick={onAuthorClick ? () => onAuthorClick(item.author.id) : undefined}
+        timestamp={item.created_at}
+        symbol={hideHeaderActions && !isPairTrade ? displaySymbol : null}
+        companyName={asset?.company_name}
+        actions={hideHeaderActions ? undefined : (
+          <>
           {/* Share button */}
           <button
             onClick={(e) => {
@@ -247,8 +201,9 @@ export function ReelsFeedItem({
             <PlusCircle className="h-4 w-4" />
             <span className="hidden sm:inline">Create Idea</span>
           </button>
-        </div>
-      </div>
+          </>
+        )}
+      />
 
       {/* Chart area */}
       {/* Chart takes less of a phone screen than a desktop one — the written

--- a/src/components/mobile/AttentionFeedCard.tsx
+++ b/src/components/mobile/AttentionFeedCard.tsx
@@ -6,7 +6,7 @@ import {
 } from 'lucide-react'
 import { ReelsChartPanel } from '../feed/ReelsChartPanel'
 import { PairTradeChartCarousel } from '../feed/PairTradeChartCarousel'
-import { TickerQuoteBadge } from './TickerQuoteBadge'
+import { FeedTileHeader } from './FeedTileHeader'
 import { ExpandablePanel } from './ExpandablePanel'
 import { CarouselControls } from './CarouselControls'
 import { useDecisionContext } from '../../hooks/mobile/useDecisionContext'
@@ -184,23 +184,23 @@ export function AttentionFeedCard({
 
   return (
     <div className="relative w-full h-full flex flex-col bg-white dark:bg-gray-900">
-      {/* Header band — mirrors the idea card's, so the two read as one feed. */}
-      <div className="flex-shrink-0 flex items-center gap-2 px-3 py-2 border-b border-gray-100 dark:border-gray-800">
-        <span className={clsx('flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium border', config.chip)}>
-          <TypeIcon className="h-4 w-4" />
-          {config.label}
-        </span>
-        {symbol && !isPair ? (
-          <TickerQuoteBadge symbol={symbol} companyName={companyName} className="ml-auto" />
-        ) : (
-          <span className="ml-auto text-xs text-gray-400 whitespace-nowrap">
-            {formatDistanceToNow(new Date(item.last_activity_at || item.created_at), { addSuffix: true })}
+      <FeedTileHeader
+        badge={
+          <span className={clsx('flex shrink-0 items-center gap-1 px-2 py-1 rounded-full text-[11px] font-medium border whitespace-nowrap', config.chip)}>
+            <TypeIcon className="h-3.5 w-3.5 shrink-0" />
+            {config.label}
           </span>
-        )}
-      </div>
+        }
+        authorName={decision?.recommendedBy}
+        timestamp={item.last_activity_at || item.created_at}
+        // A pair's legs each carry their own quote in the carousel; one in the
+        // header could only describe half the trade.
+        symbol={isPair ? null : symbol}
+        companyName={companyName}
+      />
 
       {/* The instruction, first and unmissable. */}
-      <div className="flex-shrink-0 px-3 pt-2 pb-1.5">
+      <div className="flex-shrink-0 px-3 pt-1.5 pb-1">
         <div className="flex items-baseline gap-2">
           <h2 className="text-2xl font-bold leading-tight min-w-0">
             {isPair ? (
@@ -230,14 +230,6 @@ export function AttentionFeedCard({
               </>
             )}
           </h2>
-          {/* Attribution sits with the instruction it attributes — as its own
-              labelled row inside a panel called "Recommendation" it read as
-              the same word twice. */}
-          {decision?.recommendedBy && (
-            <span className="ml-auto shrink-0 text-xs text-gray-500 dark:text-gray-400 truncate max-w-[9rem]">
-              by {decision.recommendedBy}
-            </span>
-          )}
         </div>
         {item.subtitle && (
           <p className="mt-0.5 text-sm font-medium text-gray-600 dark:text-gray-300">{item.subtitle}</p>
@@ -258,9 +250,9 @@ export function AttentionFeedCard({
           Tap-driven like the chart carousel: a horizontal scroll container
           here absorbed the vertical drags meant to page the feed, which is
           why swiping up over this area did nothing. */}
-      <div className="flex-1 min-h-0 flex flex-col pt-3">
+      <div className="flex-1 min-h-0 flex flex-col pt-2">
         <div className="flex-1 min-h-0 px-3 flex flex-col">
-          <div className="flex-shrink-0 text-[11px] font-semibold uppercase tracking-wider text-gray-400 mb-2">
+          <div className="flex-shrink-0 text-[10px] font-semibold uppercase tracking-wider text-gray-400 mb-1">
             {panels[activePanel]?.label}
           </div>
           <ExpandablePanel resetKey={activePanel}>{panels[activePanel]?.body}</ExpandablePanel>

--- a/src/components/mobile/CarouselControls.tsx
+++ b/src/components/mobile/CarouselControls.tsx
@@ -41,7 +41,7 @@ export function CarouselControls({
         type="button"
         onClick={() => onChange(Math.max(0, index - 1))}
         disabled={index === 0}
-        className="flex items-center justify-center h-8 w-8 rounded-full text-gray-500 dark:text-gray-400 disabled:opacity-30 active:bg-gray-100 dark:active:bg-gray-800 no-touch-target"
+        className="flex items-center justify-center h-7 w-7 rounded-full text-gray-500 dark:text-gray-400 disabled:opacity-30 active:bg-gray-100 dark:active:bg-gray-800 no-touch-target"
         aria-label="Previous"
       >
         <ChevronLeft className="h-5 w-5" />
@@ -52,7 +52,7 @@ export function CarouselControls({
           key={i}
           type="button"
           onClick={() => onChange(i)}
-          className="flex items-center justify-center h-8 px-1 no-touch-target"
+          className="flex items-center justify-center h-7 px-1 no-touch-target"
           aria-label={dotLabel?.(i) ?? `Go to ${i + 1}`}
           aria-current={i === index}
         >
@@ -69,7 +69,7 @@ export function CarouselControls({
         type="button"
         onClick={() => onChange(Math.min(count - 1, index + 1))}
         disabled={index === count - 1}
-        className="flex items-center justify-center h-8 w-8 rounded-full text-gray-500 dark:text-gray-400 disabled:opacity-30 active:bg-gray-100 dark:active:bg-gray-800 no-touch-target"
+        className="flex items-center justify-center h-7 w-7 rounded-full text-gray-500 dark:text-gray-400 disabled:opacity-30 active:bg-gray-100 dark:active:bg-gray-800 no-touch-target"
         aria-label="Next"
       >
         <ChevronRight className="h-5 w-5" />

--- a/src/components/mobile/DerivedInsightTile.tsx
+++ b/src/components/mobile/DerivedInsightTile.tsx
@@ -1,7 +1,7 @@
 import { clsx } from 'clsx'
 import { ArrowRight, FileQuestion, PenLine, Scale, TimerReset } from 'lucide-react'
 import { ReelsChartPanel } from '../feed/ReelsChartPanel'
-import { TickerQuoteBadge } from './TickerQuoteBadge'
+import { FeedTileHeader } from './FeedTileHeader'
 import { ExpandableText } from './ExpandableText'
 import type { DerivedInsight, DerivedInsightKind } from '../../hooks/mobile/useDerivedInsights'
 
@@ -49,22 +49,21 @@ export function DerivedInsightTile({ insight, onAssetClick, onCapture }: Derived
 
   return (
     <div className="relative w-full h-full flex flex-col bg-white dark:bg-gray-900">
-      <div className="flex-shrink-0 flex items-center gap-2 px-3 py-2 border-b border-gray-100 dark:border-gray-800">
-        <span className={clsx('flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium border', config.chip)}>
-          <Icon className="h-4 w-4" />
-          {config.label}
-        </span>
-        {/* A bare "4.20%" in the corner said nothing — it could have been a
-            price move, a target, anything. Ticker and price go here instead;
-            the weight is stated in words in the body, where it has context. */}
-        <TickerQuoteBadge
-          symbol={insight.symbol}
-          companyName={insight.companyName}
-          className="ml-auto"
-        />
-      </div>
+      {/* A bare "4.20%" in the corner said nothing — it could have been a price
+          move, a target, anything. Ticker and price go there instead; the
+          weight is stated in words in the body, where it has context. */}
+      <FeedTileHeader
+        badge={
+          <span className={clsx('flex shrink-0 items-center gap-1 px-2 py-1 rounded-full text-[11px] font-medium border whitespace-nowrap', config.chip)}>
+            <Icon className="h-3.5 w-3.5 shrink-0" />
+            {config.label}
+          </span>
+        }
+        symbol={insight.symbol}
+        companyName={insight.companyName}
+      />
 
-      <div className="flex-shrink-0 px-3 pt-2 pb-1.5">
+      <div className="flex-shrink-0 px-3 pt-1.5 pb-1">
         <h2 className="text-xl font-bold leading-tight text-gray-900 dark:text-white">
           {insight.headline}
         </h2>

--- a/src/components/mobile/FeedTileHeader.tsx
+++ b/src/components/mobile/FeedTileHeader.tsx
@@ -1,0 +1,89 @@
+import { clsx } from 'clsx'
+import { formatDistanceToNow } from 'date-fns'
+import { TickerQuoteBadge } from './TickerQuoteBadge'
+
+interface FeedTileHeaderProps {
+  /** Type chip: "Trade Idea", "Decision needed", "Going stale". */
+  badge: React.ReactNode
+  /** Who is responsible for the post — author, or recommender on a decision. */
+  authorName?: string | null
+  onAuthorClick?: () => void
+  timestamp?: string | null
+  /** Quote block on the right. Omitted for pair trades, whose legs each need
+   *  their own and so carry it inside the carousel instead. */
+  symbol?: string | null
+  companyName?: string | null
+  /** Desktop-only controls; the phone puts these in the bottom bar. */
+  actions?: React.ReactNode
+  className?: string
+}
+
+/**
+ * The top band of every feed tile.
+ *
+ * Shared so attribution lands in the same place whatever kind of post it is.
+ * Each tile type previously built its own header, and they drifted: the author
+ * sat inline beside the badge on ideas, inside the title row on decisions, and
+ * nowhere at all on signals and insights.
+ *
+ * Attribution stacks — name above time — rather than running along the row.
+ * Inline, the two competed with the badge for the same horizontal space and
+ * forced the ticker out of the header entirely; stacked they occupy one column
+ * and hand the whole right-hand side to the quote.
+ */
+export function FeedTileHeader({
+  badge,
+  authorName,
+  onAuthorClick,
+  timestamp,
+  symbol,
+  companyName,
+  actions,
+  className,
+}: FeedTileHeaderProps) {
+  const when = timestamp ? safeRelative(timestamp) : null
+
+  return (
+    <div
+      className={clsx(
+        'flex-shrink-0 z-30 flex items-center gap-2 px-3 py-1.5 border-b border-gray-100 dark:border-gray-800',
+        className
+      )}
+    >
+      {badge}
+
+      {(authorName || when) && (
+        <div className="min-w-0 flex flex-col justify-center leading-tight">
+          {authorName && (
+            <button
+              type="button"
+              onClick={onAuthorClick}
+              disabled={!onAuthorClick}
+              className="text-[13px] font-medium text-gray-700 dark:text-gray-200 truncate text-left no-touch-target disabled:cursor-default"
+            >
+              by {authorName}
+            </button>
+          )}
+          {when && (
+            <span className="text-[11px] text-gray-400 dark:text-gray-500 whitespace-nowrap">
+              {when}
+            </span>
+          )}
+        </div>
+      )}
+
+      {symbol && (
+        <TickerQuoteBadge symbol={symbol} companyName={companyName} className="ml-auto" />
+      )}
+
+      {actions && <div className="ml-auto flex items-center gap-2">{actions}</div>}
+    </div>
+  )
+}
+
+/** A malformed timestamp should cost the label, not the whole tile. */
+function safeRelative(value: string): string | null {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return null
+  return formatDistanceToNow(date, { addSuffix: true })
+}

--- a/src/components/mobile/SignalFeedTile.tsx
+++ b/src/components/mobile/SignalFeedTile.tsx
@@ -1,8 +1,7 @@
 import { clsx } from 'clsx'
-import { formatDistanceToNow } from 'date-fns'
 import { ArrowRight, CalendarClock, PenLine, Radar, Split, TimerReset } from 'lucide-react'
 import { ReelsChartPanel } from '../feed/ReelsChartPanel'
-import { TickerQuoteBadge } from './TickerQuoteBadge'
+import { FeedTileHeader } from './FeedTileHeader'
 import { ExpandableText } from './ExpandableText'
 import type { SignalCard, SignalType } from '../../hooks/ideas/useIdeasFeed'
 
@@ -59,22 +58,21 @@ export function SignalFeedTile({ signal, onAssetClick, onCapture }: SignalFeedTi
 
   return (
     <div className="relative w-full h-full flex flex-col bg-white dark:bg-gray-900">
-      <div className="flex-shrink-0 flex items-center gap-2 px-3 py-2 border-b border-gray-100 dark:border-gray-800">
-        <span className={clsx('flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium border', config.chip)}>
-          <Icon className="h-4 w-4" />
-          {config.label}
-        </span>
-        {primary ? (
-          <TickerQuoteBadge symbol={primary.symbol} className="ml-auto" />
-        ) : signal.createdAt ? (
-          <span className="ml-auto text-xs text-gray-400 whitespace-nowrap">
-            {formatDistanceToNow(new Date(signal.createdAt), { addSuffix: true })}
+      <FeedTileHeader
+        badge={
+          <span className={clsx('flex shrink-0 items-center gap-1 px-2 py-1 rounded-full text-[11px] font-medium border whitespace-nowrap', config.chip)}>
+            <Icon className="h-3.5 w-3.5 shrink-0" />
+            {config.label}
           </span>
-        ) : null}
-      </div>
+        }
+        // Signals are derived by the system, so the attribution slot stays
+        // empty rather than naming a person who did not write this.
+        timestamp={signal.createdAt}
+        symbol={primary?.symbol}
+      />
 
       {/* Headline leads, matching the decision card's instruction-first shape. */}
-      <div className="flex-shrink-0 px-3 pt-2 pb-1.5">
+      <div className="flex-shrink-0 px-3 pt-1.5 pb-1">
         <h2 className="text-xl font-bold leading-tight text-gray-900 dark:text-white">
           {signal.headline}
         </h2>


### PR DESCRIPTION
Each tile type built its own header and they had drifted: the author sat beside the badge on ideas, inside the title row on decisions, and nowhere at all on signals and insights. FeedTileHeader is now the only one, so attribution lands in the same place whatever kind of post it is.

Attribution stacks — name above time — instead of running along the row. Inline, the two competed with the badge for the same horizontal space and pushed the ticker out of the header; stacked they take one column and hand the whole right-hand side to the quote.

Signals and insights are derived by the system, so their attribution slot stays empty rather than naming someone who did not write them.

The text under the chart was unusably cramped. The chart keeps its share of the tile — what shrinks is its chrome: the timeframe strip loses most of its padding, the carousel controls a row of it. Moving attribution out of the decision title also gives the pair-trade title its full width back, which is what was forcing it onto two lines and squeezing everything below.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
