### PR TITLE
fix(mobile): instruction-first titles, quote below the header, search…

### DIFF
--- a/src/components/feed/ReelsFeedItem.tsx
+++ b/src/components/feed/ReelsFeedItem.tsx
@@ -1,8 +1,9 @@
 import { clsx } from 'clsx'
-import { TrendingUp, TrendingDown, Lightbulb, FileText, GitBranch, Sparkles, MessageSquare, ChevronRight, Share2, PlusCircle, GitCompareArrows } from 'lucide-react'
+import { TrendingUp, Lightbulb, FileText, GitBranch, Sparkles, MessageSquare, ChevronRight, Share2, PlusCircle, GitCompareArrows } from 'lucide-react'
 import { ReelsChartPanel } from './ReelsChartPanel'
 import { PairTradeChartCarousel } from './PairTradeChartCarousel'
 import { FeedTileHeader } from '../mobile/FeedTileHeader'
+import { FeedTileTitle } from '../mobile/FeedTileTitle'
 import { ExpandableText } from '../mobile/ExpandableText'
 import type { ScoredFeedItem, ItemType } from '../../hooks/ideas/types'
 
@@ -172,8 +173,6 @@ export function ReelsFeedItem({
             : item.author.email?.split('@')[0] || 'Unknown')}
         onAuthorClick={onAuthorClick ? () => onAuthorClick(item.author.id) : undefined}
         timestamp={item.created_at}
-        symbol={hideHeaderActions && !isPairTrade ? displaySymbol : null}
-        companyName={asset?.company_name}
         actions={hideHeaderActions ? undefined : (
           <>
           {/* Share button */}
@@ -205,11 +204,34 @@ export function ReelsFeedItem({
         )}
       />
 
+      {/* The instruction leads, exactly as it does on a decision tile. It was
+          previously a small chip below the chart, so "BUY MSFT" read as a
+          different thing depending on which surface it arrived through. */}
+      {hideHeaderActions && (displaySymbol || isPairTrade) && (
+        <FeedTileTitle
+          action={item.type === 'trade_idea' && 'action' in item ? item.action : null}
+          symbol={isPairTrade ? null : displaySymbol}
+          longSymbols={
+            isPairTrade
+              ? ((item as any).long_legs ?? []).map((l: any) => l?.asset?.symbol).filter(Boolean)
+              : []
+          }
+          shortSymbols={
+            isPairTrade
+              ? ((item as any).short_legs ?? []).map((l: any) => l?.asset?.symbol).filter(Boolean)
+              : []
+          }
+          headline={'title' in item ? item.title : null}
+          quoteSymbol={isPairTrade ? null : displaySymbol}
+          quoteCompanyName={asset?.company_name}
+        />
+      )}
+
       {/* Chart area */}
-      {/* Chart takes less of a phone screen than a desktop one — the written
-          reasoning below it is the part that needs room, and at 50% the text
-          area was too short to read a thesis without scrolling. */}
-      <div className="flex-shrink-0 h-[52%] min-h-[260px] max-h-[420px] px-3 pt-2 pb-1">
+      {/* A third of the screen. The written reasoning below is the part that
+          needs room, and the chart is one band among a header, an instruction
+          and the case itself. */}
+      <div className="flex-shrink-0 h-[33%] min-h-[170px] max-h-[300px] px-3 pt-1 pb-1">
         {isPairTrade ? (
           // A pair trade is a relationship between two positions; one chart
           // misrepresents it. Swipe horizontally between the legs.
@@ -240,38 +262,24 @@ export function ReelsFeedItem({
       {/* Content area */}
       <div className="flex-1 min-h-0 px-3 py-2 overflow-hidden">
         <div className="bg-gray-50 border border-gray-200 rounded-xl p-3 max-h-full overflow-hidden dark:border-gray-700 dark:bg-gray-900">
-          {/* Qualifiers lead, compactly, so they frame the reasoning rather
-              than trailing after it as a stack of competing chips. */}
-          {item.type === 'trade_idea' && 'action' in item && item.action && (
+          {/* Action and urgency. The action is repeated in the title above on
+              tiles that have one, so only the urgency is shown there. */}
+          {item.type === 'trade_idea' && 'urgency' in item &&
+            (item.urgency === 'urgent' || item.urgency === 'high') && (
             <div className="flex items-center gap-2 mb-2">
               <span className={clsx(
-                'inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[11px] font-semibold uppercase tracking-wide',
-                item.action === 'buy'
-                  ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300'
-                  : 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300'
+                'px-2 py-0.5 rounded-full text-[11px] font-semibold uppercase tracking-wide',
+                item.urgency === 'urgent'
+                  ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300'
+                  : 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300'
               )}>
-                {item.action === 'buy'
-                  ? <TrendingUp className="h-3 w-3" />
-                  : <TrendingDown className="h-3 w-3" />}
-                {item.action.toUpperCase()}
+                {item.urgency}
               </span>
-              {/* Only surfaced when it actually signals something. "medium"
-                  and "low" on every card is noise. */}
-              {'urgency' in item && (item.urgency === 'urgent' || item.urgency === 'high') && (
-                <span className={clsx(
-                  'px-2 py-0.5 rounded-full text-[11px] font-semibold uppercase tracking-wide',
-                  item.urgency === 'urgent'
-                    ? 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-300'
-                    : 'bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-300'
-                )}>
-                  {item.urgency}
-                </span>
-              )}
             </div>
           )}
 
-          {/* Title for notes/insights */}
-          {'title' in item && item.title && (
+          {/* Title for notes/insights — mobile shows it in the title band. */}
+          {!hideHeaderActions && 'title' in item && item.title && (
             <h2 className="text-lg font-bold text-gray-900 mb-2 dark:text-white">
               {item.title}
             </h2>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -337,6 +337,19 @@ export function Header({
                 <Menu className="md:hidden h-4 w-4 text-gray-600 dark:text-gray-300" />
               </button>
 
+              {/* Search sits on the left, where the desktop search field is,
+                  and keeps its label. As a bare magnifier among five other
+                  icons on the right it read as one more utility button rather
+                  than the way into the app's content. */}
+              <button
+                onClick={() => setShowMobileSearch(true)}
+                className="md:hidden flex items-center gap-1.5 h-9 pl-2 pr-3 ml-1 rounded-full no-touch-target bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 active:bg-gray-200 dark:active:bg-gray-700 transition-colors"
+                aria-label="Search"
+              >
+                <Search className="h-4 w-4 shrink-0" />
+                <span className="text-sm">Search</span>
+              </button>
+
               {/* App Launcher Panel */}
               {showAppMenu && !isMobile && pilotMode.effectiveIsPilot && (
                 <div className="absolute left-0 top-full mt-2 w-80 bg-white dark:bg-gray-800 rounded-xl shadow-xl border border-gray-200 dark:border-gray-700 py-3 z-50">
@@ -654,21 +667,10 @@ export function Header({
             </div>
           </div>
 
-          {/* Right side actions. On phones only notifications and profile
-              survive — five 44px targets plus the avatar demand ~310px of a
-              390px viewport. Thoughts, AI and DMs are reachable from the nav
-              drawer instead. */}
+          {/* Right side actions. Search has moved to the left beside the
+              launcher, which leaves room for capture, AI, DMs, notifications
+              and the avatar. */}
           <div className="flex items-center flex-shrink-0 gap-1 md:gap-2">
-            {/* Mobile search entry point — replaces the inline input below md */}
-            <button
-              onClick={() => setShowMobileSearch(true)}
-              className="md:hidden inline-flex items-center justify-center h-9 w-9 rounded-full no-touch-target text-gray-400 hover:text-gray-600 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-              aria-label="Search"
-              title="Search"
-            >
-              <Search className="h-5 w-5" />
-            </button>
-
             {/* Capture Thought Button */}
             <button
               onClick={() => {

--- a/src/components/mobile/AttentionFeedCard.tsx
+++ b/src/components/mobile/AttentionFeedCard.tsx
@@ -7,6 +7,7 @@ import {
 import { ReelsChartPanel } from '../feed/ReelsChartPanel'
 import { PairTradeChartCarousel } from '../feed/PairTradeChartCarousel'
 import { FeedTileHeader } from './FeedTileHeader'
+import { FeedTileTitle } from './FeedTileTitle'
 import { ExpandablePanel } from './ExpandablePanel'
 import { CarouselControls } from './CarouselControls'
 import { useDecisionContext } from '../../hooks/mobile/useDecisionContext'
@@ -193,51 +194,22 @@ export function AttentionFeedCard({
         }
         authorName={decision?.recommendedBy}
         timestamp={item.last_activity_at || item.created_at}
-        // A pair's legs each carry their own quote in the carousel; one in the
-        // header could only describe half the trade.
-        symbol={isPair ? null : symbol}
-        companyName={companyName}
       />
 
-      {/* The instruction, first and unmissable. */}
-      <div className="flex-shrink-0 px-3 pt-1.5 pb-1">
-        <div className="flex items-baseline gap-2">
-          <h2 className="text-2xl font-bold leading-tight min-w-0">
-            {isPair ? (
-              // Name the whole trade. Showing only the leg that raised the
-              // alert would misdescribe a decision about both sides.
-              // Both sides named and coloured. A plain black "A / B vs C / D"
-              // left the reader guessing which side was being bought.
-              <span className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5 text-xl">
-                {longLegs.length > 0 && (
-                  <span className="text-emerald-600 dark:text-emerald-400">
-                    BUY {longLegs.map(l => l.asset?.symbol).filter(Boolean).join(' / ')}
-                  </span>
-                )}
-                {longLegs.length > 0 && shortLegs.length > 0 && (
-                  <span className="text-gray-400 text-base font-medium">vs</span>
-                )}
-                {shortLegs.length > 0 && (
-                  <span className="text-red-600 dark:text-red-400">
-                    SELL {shortLegs.map(l => l.asset?.symbol).filter(Boolean).join(' / ')}
-                  </span>
-                )}
-              </span>
-            ) : (
-              <>
-                <span className={tone}>{(decision?.action || verb || '').toUpperCase()}</span>{' '}
-                <span className="text-gray-900 dark:text-white">{ticker}</span>
-              </>
-            )}
-          </h2>
-        </div>
-        {item.subtitle && (
-          <p className="mt-0.5 text-sm font-medium text-gray-600 dark:text-gray-300">{item.subtitle}</p>
-        )}
-      </div>
+      {/* The instruction, first and unmissable. A pair's legs each carry their
+          own quote in the carousel; one here could only describe half the trade. */}
+      <FeedTileTitle
+        action={isPair ? null : (decision?.action || verb)}
+        symbol={isPair ? null : ticker}
+        longSymbols={longLegs.map(l => l.asset?.symbol).filter(Boolean) as string[]}
+        shortSymbols={shortLegs.map(l => l.asset?.symbol).filter(Boolean) as string[]}
+        subtitle={item.subtitle}
+        quoteSymbol={isPair ? null : symbol}
+        quoteCompanyName={companyName}
+      />
 
       {(isPair || symbol) && (
-        <div className="flex-shrink-0 h-[50%] min-h-[220px] max-h-[400px] px-3">
+        <div className="flex-shrink-0 h-[33%] min-h-[170px] max-h-[300px] px-3">
           {isPair ? (
             <PairTradeChartCarousel longLegs={longLegs as any} shortLegs={shortLegs as any} />
           ) : (

--- a/src/components/mobile/DerivedInsightTile.tsx
+++ b/src/components/mobile/DerivedInsightTile.tsx
@@ -2,6 +2,7 @@ import { clsx } from 'clsx'
 import { ArrowRight, FileQuestion, PenLine, Scale, TimerReset } from 'lucide-react'
 import { ReelsChartPanel } from '../feed/ReelsChartPanel'
 import { FeedTileHeader } from './FeedTileHeader'
+import { FeedTileTitle } from './FeedTileTitle'
 import { ExpandableText } from './ExpandableText'
 import type { DerivedInsight, DerivedInsightKind } from '../../hooks/mobile/useDerivedInsights'
 
@@ -59,14 +60,14 @@ export function DerivedInsightTile({ insight, onAssetClick, onCapture }: Derived
             {config.label}
           </span>
         }
-        symbol={insight.symbol}
-        companyName={insight.companyName}
       />
 
-      <div className="flex-shrink-0 px-3 pt-1.5 pb-1">
-        <h2 className="text-xl font-bold leading-tight text-gray-900 dark:text-white">
-          {insight.headline}
-        </h2>
+      <FeedTileTitle
+        headline={insight.headline}
+        quoteSymbol={insight.symbol}
+        quoteCompanyName={insight.companyName}
+      />
+      <div className="flex-shrink-0 px-3">
         {insight.portfolioName && (
           <p className="mt-0.5 text-sm font-medium text-gray-600 dark:text-gray-300">
             {insight.portfolioName}

--- a/src/components/mobile/FeedTileHeader.tsx
+++ b/src/components/mobile/FeedTileHeader.tsx
@@ -1,6 +1,5 @@
 import { clsx } from 'clsx'
 import { formatDistanceToNow } from 'date-fns'
-import { TickerQuoteBadge } from './TickerQuoteBadge'
 
 interface FeedTileHeaderProps {
   /** Type chip: "Trade Idea", "Decision needed", "Going stale". */
@@ -9,10 +8,6 @@ interface FeedTileHeaderProps {
   authorName?: string | null
   onAuthorClick?: () => void
   timestamp?: string | null
-  /** Quote block on the right. Omitted for pair trades, whose legs each need
-   *  their own and so carry it inside the carousel instead. */
-  symbol?: string | null
-  companyName?: string | null
   /** Desktop-only controls; the phone puts these in the bottom bar. */
   actions?: React.ReactNode
   className?: string
@@ -26,18 +21,20 @@ interface FeedTileHeaderProps {
  * sat inline beside the badge on ideas, inside the title row on decisions, and
  * nowhere at all on signals and insights.
  *
- * Attribution stacks — name above time — rather than running along the row.
- * Inline, the two competed with the badge for the same horizontal space and
- * forced the ticker out of the header entirely; stacked they occupy one column
- * and hand the whole right-hand side to the quote.
+ * Attribution stacks — name above time — and sits hard right, opposite the
+ * type badge. Inline and left-justified the two ran into whatever occupied the
+ * rest of the row.
+ *
+ * The quote deliberately does not live here. Sharing this row with attribution
+ * put a two-line ticker block against a two-line name block and they collided
+ * on narrow screens; each tile renders it below instead, beside its own title,
+ * where the full width is available.
  */
 export function FeedTileHeader({
   badge,
   authorName,
   onAuthorClick,
   timestamp,
-  symbol,
-  companyName,
   actions,
   className,
 }: FeedTileHeaderProps) {
@@ -53,13 +50,13 @@ export function FeedTileHeader({
       {badge}
 
       {(authorName || when) && (
-        <div className="min-w-0 flex flex-col justify-center leading-tight">
+        <div className="ml-auto min-w-0 flex flex-col justify-center items-end text-right leading-tight">
           {authorName && (
             <button
               type="button"
               onClick={onAuthorClick}
               disabled={!onAuthorClick}
-              className="text-[13px] font-medium text-gray-700 dark:text-gray-200 truncate text-left no-touch-target disabled:cursor-default"
+              className="text-[13px] font-medium text-gray-700 dark:text-gray-200 truncate text-right no-touch-target disabled:cursor-default"
             >
               by {authorName}
             </button>
@@ -70,10 +67,6 @@ export function FeedTileHeader({
             </span>
           )}
         </div>
-      )}
-
-      {symbol && (
-        <TickerQuoteBadge symbol={symbol} companyName={companyName} className="ml-auto" />
       )}
 
       {actions && <div className="ml-auto flex items-center gap-2">{actions}</div>}

--- a/src/components/mobile/FeedTileTitle.tsx
+++ b/src/components/mobile/FeedTileTitle.tsx
@@ -1,0 +1,103 @@
+import { clsx } from 'clsx'
+import { TickerQuoteBadge } from './TickerQuoteBadge'
+
+interface FeedTileTitleProps {
+  /** The instruction, e.g. "buy" / "sell" / "add" / "trim". */
+  action?: string | null
+  symbol?: string | null
+  /** Pair trades name both sides instead of a single symbol. */
+  longSymbols?: string[]
+  shortSymbols?: string[]
+  /** Used when the tile leads with a headline rather than an instruction. */
+  headline?: string | null
+  subtitle?: string | null
+  /** Quote shown beside the title. Omitted for pair trades, whose legs each
+   *  carry their own inside the carousel. */
+  quoteSymbol?: string | null
+  quoteCompanyName?: string | null
+  className?: string
+}
+
+/**
+ * The instruction band between a tile's header and its chart.
+ *
+ * Every tile leads with what it is asking of the reader — "SELL DASH", "BUY
+ * MSFT" — before any supporting detail. Trade ideas previously buried this in
+ * a small chip below the chart, so the same instruction read completely
+ * differently depending on whether it arrived as an idea or as a decision.
+ *
+ * The quote sits here rather than in the header, where it collided with
+ * attribution. Its symbol is suppressed when the title already names it: a
+ * row reading "BUY MSFT   MSFT $412.30" says the ticker twice and spends the
+ * width that the price and company name need.
+ */
+export function FeedTileTitle({
+  action,
+  symbol,
+  longSymbols = [],
+  shortSymbols = [],
+  headline,
+  subtitle,
+  quoteSymbol,
+  quoteCompanyName,
+  className,
+}: FeedTileTitleProps) {
+  const isPair = longSymbols.length > 0 || shortSymbols.length > 0
+
+  return (
+    <div className={clsx('flex-shrink-0 px-3 pt-1.5 pb-1', className)}>
+      <div className="flex items-start justify-between gap-2">
+        <h2 className="min-w-0 text-2xl font-bold leading-tight">
+          {isPair ? (
+            // Both sides named and coloured. A plain "A / B vs C / D" left the
+            // reader guessing which side was being bought.
+            <span className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5 text-xl">
+              {longSymbols.length > 0 && (
+                <span className="text-emerald-600 dark:text-emerald-400">
+                  BUY {longSymbols.join(' / ')}
+                </span>
+              )}
+              {longSymbols.length > 0 && shortSymbols.length > 0 && (
+                <span className="text-gray-400 text-base font-medium">vs</span>
+              )}
+              {shortSymbols.length > 0 && (
+                <span className="text-red-600 dark:text-red-400">
+                  SELL {shortSymbols.join(' / ')}
+                </span>
+              )}
+            </span>
+          ) : action || symbol ? (
+            <>
+              {action && <span className={actionTone(action)}>{action.toUpperCase()}</span>}
+              {action && symbol ? ' ' : null}
+              {symbol && <span className="text-gray-900 dark:text-white">{symbol}</span>}
+            </>
+          ) : (
+            <span className="text-xl text-gray-900 dark:text-white">{headline}</span>
+          )}
+        </h2>
+
+        {quoteSymbol && (
+          <TickerQuoteBadge
+            symbol={quoteSymbol}
+            companyName={quoteCompanyName}
+            showSymbol={quoteSymbol !== symbol}
+            className="shrink-0 pt-0.5"
+          />
+        )}
+      </div>
+
+      {subtitle && (
+        <p className="mt-0.5 text-sm font-medium text-gray-600 dark:text-gray-300">{subtitle}</p>
+      )}
+    </div>
+  )
+}
+
+/** Green buys, red sells — the same mapping the rest of the app uses. */
+function actionTone(action: string): string {
+  const a = action.toLowerCase()
+  if (a === 'buy' || a === 'add') return 'text-emerald-600 dark:text-emerald-400'
+  if (a === 'sell' || a === 'trim') return 'text-red-600 dark:text-red-400'
+  return 'text-gray-900 dark:text-white'
+}

--- a/src/components/mobile/SignalFeedTile.tsx
+++ b/src/components/mobile/SignalFeedTile.tsx
@@ -2,6 +2,7 @@ import { clsx } from 'clsx'
 import { ArrowRight, CalendarClock, PenLine, Radar, Split, TimerReset } from 'lucide-react'
 import { ReelsChartPanel } from '../feed/ReelsChartPanel'
 import { FeedTileHeader } from './FeedTileHeader'
+import { FeedTileTitle } from './FeedTileTitle'
 import { ExpandableText } from './ExpandableText'
 import type { SignalCard, SignalType } from '../../hooks/ideas/useIdeasFeed'
 
@@ -68,14 +69,14 @@ export function SignalFeedTile({ signal, onAssetClick, onCapture }: SignalFeedTi
         // Signals are derived by the system, so the attribution slot stays
         // empty rather than naming a person who did not write this.
         timestamp={signal.createdAt}
-        symbol={primary?.symbol}
       />
 
       {/* Headline leads, matching the decision card's instruction-first shape. */}
-      <div className="flex-shrink-0 px-3 pt-1.5 pb-1">
-        <h2 className="text-xl font-bold leading-tight text-gray-900 dark:text-white">
-          {signal.headline}
-        </h2>
+      <FeedTileTitle
+        headline={signal.headline}
+        quoteSymbol={primary?.symbol}
+      />
+      <div className="flex-shrink-0 px-3">
       </div>
 
       {primary && (

--- a/src/components/mobile/TickerQuoteBadge.tsx
+++ b/src/components/mobile/TickerQuoteBadge.tsx
@@ -5,6 +5,8 @@ import { financialDataService } from '../../lib/financial-data/browser-client'
 interface TickerQuoteBadgeProps {
   symbol: string
   companyName?: string | null
+  /** Suppress the ticker when the title beside it already names the asset. */
+  showSymbol?: boolean
   className?: string
 }
 
@@ -19,7 +21,7 @@ interface TickerQuoteBadgeProps {
  * Shares React Query's cache key with the chart panel (`reels-chart-quote`),
  * so displaying the price here costs no additional request.
  */
-export function TickerQuoteBadge({ symbol, companyName, className }: TickerQuoteBadgeProps) {
+export function TickerQuoteBadge({ symbol, companyName, showSymbol = true, className }: TickerQuoteBadgeProps) {
   const { data: quote } = useQuery({
     queryKey: ['reels-chart-quote', symbol],
     queryFn: async () => {
@@ -39,7 +41,9 @@ export function TickerQuoteBadge({ symbol, companyName, className }: TickerQuote
   return (
     <div className={clsx('flex flex-col items-end min-w-0 text-right', className)}>
       <div className="flex items-baseline gap-1.5 min-w-0">
-        <span className="text-sm font-bold text-gray-900 dark:text-white">{symbol}</span>
+        {showSymbol && (
+          <span className="text-sm font-bold text-gray-900 dark:text-white">{symbol}</span>
+        )}
         {price != null && (
           <span className="text-sm font-semibold tabular-nums text-gray-900 dark:text-white">
             ${price.toFixed(2)}


### PR DESCRIPTION
… on the left

Attribution moves to the right of the header, opposite the type badge. The quote leaves the header entirely — sharing that row put a two-line ticker block against a two-line name block and they collided.

The quote now sits beside the tile's title, in the band between the header and the chart. Its ticker is suppressed when the title already names the asset:
"BUY MSFT   MSFT $412.30" says the symbol twice and spends width the price and
company name need.

Trade ideas lead with the instruction, as decisions already did. "BUY MSFT" was previously a small chip below the chart, so the same instruction read differently depending on whether it arrived as an idea or as a decision. FeedTileTitle is now shared by all four tile types, so it cannot drift again.

Charts take a third of the tile, down from ~50%. A tile carries a header, an instruction, a chart and the written case; at half the screen the case had no usable room.

Search moves to the left beside the launcher, where the desktop search field is, and keeps its label. A bare magnifier among five other icons on the right read as one more utility button rather than the way into the app's content.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
