### PR TITLE
fix(mobile): search placement, headline in header for system tiles, t…

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -337,18 +337,6 @@ export function Header({
                 <Menu className="md:hidden h-4 w-4 text-gray-600 dark:text-gray-300" />
               </button>
 
-              {/* Search sits on the left, where the desktop search field is,
-                  and keeps its label. As a bare magnifier among five other
-                  icons on the right it read as one more utility button rather
-                  than the way into the app's content. */}
-              <button
-                onClick={() => setShowMobileSearch(true)}
-                className="md:hidden flex items-center gap-1.5 h-9 pl-2 pr-3 ml-1 rounded-full no-touch-target bg-gray-100 dark:bg-gray-800 text-gray-500 dark:text-gray-400 active:bg-gray-200 dark:active:bg-gray-700 transition-colors"
-                aria-label="Search"
-              >
-                <Search className="h-4 w-4 shrink-0" />
-                <span className="text-sm">Search</span>
-              </button>
 
               {/* App Launcher Panel */}
               {showAppMenu && !isMobile && pilotMode.effectiveIsPilot && (
@@ -565,6 +553,20 @@ export function Header({
                 </div>
               )}
             </div>
+
+            {/* Search, on the left where the desktop search field is, separated
+                from the launcher by the same divider the org switcher uses.
+                Unfilled: a solid pill read as a button competing with the
+                launcher, where this is really the head of the content column. */}
+            <div className="md:hidden h-5 w-px bg-gray-200 dark:bg-gray-700 mx-2 flex-shrink-0" />
+            <button
+              onClick={() => setShowMobileSearch(true)}
+              className="md:hidden flex items-center gap-1.5 min-w-0 h-9 -ml-0.5 pr-2 rounded-lg no-touch-target text-gray-400 dark:text-gray-500 active:bg-gray-100 dark:active:bg-gray-800 transition-colors"
+              aria-label="Search"
+            >
+              <Search className="h-[18px] w-[18px] shrink-0" />
+              <span className="text-sm truncate">Search</span>
+            </button>
 
             {/* Divider + Org Switcher. Hidden on phones: the drawer carries
                 the org name and switcher, which frees the top bar for the

--- a/src/components/mobile/DerivedInsightTile.tsx
+++ b/src/components/mobile/DerivedInsightTile.tsx
@@ -60,10 +60,12 @@ export function DerivedInsightTile({ insight, onAssetClick, onCapture }: Derived
             {config.label}
           </span>
         }
+        // No author, so the headline takes that space and the band below
+        // belongs entirely to the quote.
+        headline={insight.headline}
       />
 
       <FeedTileTitle
-        headline={insight.headline}
         quoteSymbol={insight.symbol}
         quoteCompanyName={insight.companyName}
       />

--- a/src/components/mobile/FeedTileHeader.tsx
+++ b/src/components/mobile/FeedTileHeader.tsx
@@ -4,6 +4,10 @@ import { formatDistanceToNow } from 'date-fns'
 interface FeedTileHeaderProps {
   /** Type chip: "Trade Idea", "Decision needed", "Going stale". */
   badge: React.ReactNode
+  /** Short summary shown beside the badge. Used by system-derived tiles, which
+   *  have no author, so the row is free and the band below can go to the
+   *  quote instead of splitting it with a title. */
+  headline?: string | null
   /** Who is responsible for the post — author, or recommender on a decision. */
   authorName?: string | null
   onAuthorClick?: () => void
@@ -32,6 +36,7 @@ interface FeedTileHeaderProps {
  */
 export function FeedTileHeader({
   badge,
+  headline,
   authorName,
   onAuthorClick,
   timestamp,
@@ -48,6 +53,12 @@ export function FeedTileHeader({
       )}
     >
       {badge}
+
+      {headline && (
+        <span className="min-w-0 flex-1 text-[13px] font-semibold text-gray-900 dark:text-gray-100 truncate">
+          {headline}
+        </span>
+      )}
 
       {(authorName || when) && (
         <div className="ml-auto min-w-0 flex flex-col justify-center items-end text-right leading-tight">

--- a/src/components/mobile/FeedTileTitle.tsx
+++ b/src/components/mobile/FeedTileTitle.tsx
@@ -43,6 +43,20 @@ export function FeedTileTitle({
   className,
 }: FeedTileTitleProps) {
   const isPair = longSymbols.length > 0 || shortSymbols.length > 0
+  const hasTitle = isPair || !!action || !!symbol || !!headline
+
+  // Nothing to title means the quote gets the band to itself, at full size,
+  // rather than being squeezed into a corner of an empty row.
+  if (!hasTitle && quoteSymbol) {
+    return (
+      <div className={clsx('flex-shrink-0 px-3 pt-1.5 pb-1', className)}>
+        <TickerQuoteBadge symbol={quoteSymbol} companyName={quoteCompanyName} variant="lead" />
+        {subtitle && (
+          <p className="mt-0.5 text-sm font-medium text-gray-600 dark:text-gray-300">{subtitle}</p>
+        )}
+      </div>
+    )
+  }
 
   return (
     <div className={clsx('flex-shrink-0 px-3 pt-1.5 pb-1', className)}>

--- a/src/components/mobile/MobileDashboard.tsx
+++ b/src/components/mobile/MobileDashboard.tsx
@@ -437,7 +437,7 @@ export function MobileDashboard({
             const linked = a.context?.asset_id ? attentionAssets?.[a.context.asset_id] : null
             const target = attentionTarget(a)
             return (
-              <section key={a.attention_id} className="relative h-full w-full snap-start snap-always">
+              <section key={a.attention_id} className="relative h-full w-full snap-start snap-always border-b-8 border-gray-200 dark:border-gray-800">
                 <AttentionFeedCard
                   item={a}
                   symbol={linked?.symbol}
@@ -463,7 +463,7 @@ export function MobileDashboard({
             return (
               <section
                 key={`${entry.insight.id}-r${entry.round}`}
-                className="relative h-full w-full snap-start snap-always"
+                className="relative h-full w-full snap-start snap-always border-b-8 border-gray-200 dark:border-gray-800"
               >
                 <DerivedInsightTile
                   insight={entry.insight}
@@ -480,7 +480,7 @@ export function MobileDashboard({
 
           if (entry.kind === 'signal') {
             return (
-              <section key={entry.signal.id} className="relative h-full w-full snap-start snap-always">
+              <section key={entry.signal.id} className="relative h-full w-full snap-start snap-always border-b-8 border-gray-200 dark:border-gray-800">
                 <SignalFeedTile
                   signal={entry.signal}
                   onAssetClick={openAsset}
@@ -504,7 +504,7 @@ export function MobileDashboard({
             <section
               key={item.id}
               ref={track({ assetId: itemAssetId, authorId: itemAuthorId })}
-              className="relative h-full w-full snap-start snap-always"
+              className="relative h-full w-full snap-start snap-always border-b-8 border-gray-200 dark:border-gray-800"
             >
               {/* Inset by exactly the bar height so the card never renders
                   underneath the actions. */}

--- a/src/components/mobile/SignalFeedTile.tsx
+++ b/src/components/mobile/SignalFeedTile.tsx
@@ -68,14 +68,13 @@ export function SignalFeedTile({ signal, onAssetClick, onCapture }: SignalFeedTi
         }
         // Signals are derived by the system, so the attribution slot stays
         // empty rather than naming a person who did not write this.
+        // Signals have no author either, so the headline uses that row.
+        headline={signal.headline}
         timestamp={signal.createdAt}
       />
 
       {/* Headline leads, matching the decision card's instruction-first shape. */}
-      <FeedTileTitle
-        headline={signal.headline}
-        quoteSymbol={primary?.symbol}
-      />
+      <FeedTileTitle quoteSymbol={primary?.symbol} />
       <div className="flex-shrink-0 px-3">
       </div>
 

--- a/src/components/mobile/TickerQuoteBadge.tsx
+++ b/src/components/mobile/TickerQuoteBadge.tsx
@@ -7,6 +7,9 @@ interface TickerQuoteBadgeProps {
   companyName?: string | null
   /** Suppress the ticker when the title beside it already names the asset. */
   showSymbol?: boolean
+  /** `lead` gives the quote the row to itself — used where the tile has no
+   *  title to sit beside, so the price is the most useful thing there. */
+  variant?: 'badge' | 'lead'
   className?: string
 }
 
@@ -21,7 +24,7 @@ interface TickerQuoteBadgeProps {
  * Shares React Query's cache key with the chart panel (`reels-chart-quote`),
  * so displaying the price here costs no additional request.
  */
-export function TickerQuoteBadge({ symbol, companyName, showSymbol = true, className }: TickerQuoteBadgeProps) {
+export function TickerQuoteBadge({ symbol, companyName, showSymbol = true, variant = 'badge', className }: TickerQuoteBadgeProps) {
   const { data: quote } = useQuery({
     queryKey: ['reels-chart-quote', symbol],
     queryFn: async () => {
@@ -38,21 +41,32 @@ export function TickerQuoteBadge({ symbol, companyName, showSymbol = true, class
   const changePercent = (quote as any)?.changePercent as number | undefined
   const isPositive = (changePercent ?? 0) >= 0
 
+  const lead = variant === 'lead'
+
   return (
-    <div className={clsx('flex flex-col items-end min-w-0 text-right', className)}>
-      <div className="flex items-baseline gap-1.5 min-w-0">
+    <div
+      className={clsx(
+        'flex flex-col min-w-0',
+        lead ? 'items-start text-left' : 'items-end text-right',
+        className
+      )}
+    >
+      <div className="flex items-baseline gap-2 min-w-0">
         {showSymbol && (
-          <span className="text-sm font-bold text-gray-900 dark:text-white">{symbol}</span>
+          <span className={clsx('font-bold text-gray-900 dark:text-white', lead ? 'text-2xl' : 'text-sm')}>
+            {symbol}
+          </span>
         )}
         {price != null && (
-          <span className="text-sm font-semibold tabular-nums text-gray-900 dark:text-white">
+          <span className={clsx('font-semibold tabular-nums text-gray-900 dark:text-white', lead ? 'text-xl' : 'text-sm')}>
             ${price.toFixed(2)}
           </span>
         )}
         {changePercent != null && (
           <span
             className={clsx(
-              'text-xs font-semibold tabular-nums',
+              'font-semibold tabular-nums',
+              lead ? 'text-base' : 'text-xs',
               isPositive ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'
             )}
           >
@@ -62,7 +76,7 @@ export function TickerQuoteBadge({ symbol, companyName, showSymbol = true, class
         )}
       </div>
       {companyName && (
-        <span className="text-[11px] text-gray-500 dark:text-gray-400 truncate max-w-[11rem]">
+        <span className={clsx('text-gray-500 dark:text-gray-400 truncate', lead ? 'text-sm max-w-full' : 'text-[11px] max-w-[11rem]')}>
           {companyName}
         </span>
       )}

--- a/src/hooks/mobile/useDerivedInsights.ts
+++ b/src/hooks/mobile/useDerivedInsights.ts
@@ -116,7 +116,7 @@ export function useDerivedInsights() {
           out.push({
             id: `insight-nothesis-${asset.id}`,
             kind: 'no_thesis',
-            headline: `${asset.symbol} has no written research`,
+            headline: `${asset.symbol} has no research`,
             body: `${asset.symbol}${weight != null ? ` is ${weight.toFixed(2)}% of ${portfolioName ?? 'the book'}` : ' is held'}, and there are no notes, thoughts or contributions recorded against it.`,
             assetId: asset.id,
             symbol: asset.symbol,
@@ -133,7 +133,7 @@ export function useDerivedInsights() {
           out.push({
             id: `insight-stale-${asset.id}`,
             kind: 'stale_research',
-            headline: `${asset.symbol}: ${days} days without research`,
+            headline: `${asset.symbol} — ${days}d stale`,
             body: `Nothing has been written on ${asset.symbol}${weight != null ? `, currently ${weight.toFixed(2)}% of ${portfolioName ?? 'the book'}` : ''}, since ${new Date(touched).toLocaleDateString()}.`,
             assetId: asset.id,
             symbol: asset.symbol,


### PR DESCRIPTION
…ile seams

Search was rendering below the launcher rather than beside it: it had been nested inside the launcher's `relative` positioning wrapper, a block container, so it stacked. It is now a sibling in the flex row, separated by the same divider the org switcher already uses.

It also loses its filled pill. Solid, it read as a second button competing with the launcher; unfilled it reads as the head of the content column, which is what it is.

System-derived tiles — insights and signals — have no author, so their header row had an empty right-hand side while the headline sat below competing with the quote. The headline moves up beside the badge, and the band below goes entirely to the quote, which renders at full size there rather than shrunk into a corner. "has no written research" becomes "has no research": the badge already says the rest.

Feed tiles are full-screen and white, so mid-scroll two of them ran together with no visible seam. Each now closes with a band, which is what makes the boundary legible while paging.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
