### PR TITLE
fix(mobile): per-type chart sizing, drop derived timestamps, tighten …

### DIFF
--- a/src/components/feed/ReelsFeedItem.tsx
+++ b/src/components/feed/ReelsFeedItem.tsx
@@ -231,7 +231,7 @@ export function ReelsFeedItem({
       {/* A third of the screen. The written reasoning below is the part that
           needs room, and the chart is one band among a header, an instruction
           and the case itself. */}
-      <div className="flex-shrink-0 h-[33%] min-h-[170px] max-h-[300px] px-3 pt-1 pb-1">
+      <div className={clsx("flex-shrink-0 px-3 pt-1 pb-1", isPairTrade ? "h-[42%] min-h-[230px] max-h-[380px]" : "h-[33%] min-h-[170px] max-h-[300px]")}>
         {isPairTrade ? (
           // A pair trade is a relationship between two positions; one chart
           // misrepresents it. Swipe horizontally between the legs.

--- a/src/components/mobile/AttentionFeedCard.tsx
+++ b/src/components/mobile/AttentionFeedCard.tsx
@@ -209,7 +209,7 @@ export function AttentionFeedCard({
       />
 
       {(isPair || symbol) && (
-        <div className="flex-shrink-0 h-[33%] min-h-[170px] max-h-[300px] px-3">
+        <div className={clsx("flex-shrink-0 px-3", isPair ? "h-[42%] min-h-[230px] max-h-[380px]" : "h-[33%] min-h-[170px] max-h-[300px]")}>
           {isPair ? (
             <PairTradeChartCarousel longLegs={longLegs as any} shortLegs={shortLegs as any} />
           ) : (
@@ -240,7 +240,7 @@ export function AttentionFeedCard({
         />
       </div>
 
-      <div className="flex-shrink-0 flex items-stretch gap-2 px-3 py-3 pb-safe border-t border-gray-200 dark:border-gray-700">
+      <div className="flex-shrink-0 flex items-stretch gap-2 px-3 py-2 pb-safe border-t border-gray-200 dark:border-gray-700">
         {onSnooze && (
           <button
             type="button"
@@ -288,7 +288,7 @@ export function AttentionFeedCard({
         <button
           type="button"
           onClick={() => onOpen?.(item)}
-          className="flex-1 flex items-center justify-center gap-2 h-12 rounded-xl bg-primary-600 text-white font-semibold no-touch-target"
+          className="flex-1 flex items-center justify-center gap-2 h-10 rounded-xl bg-primary-600 text-white font-semibold no-touch-target"
         >
           Open
           <ArrowRight className="h-4 w-4" />

--- a/src/components/mobile/DerivedInsightTile.tsx
+++ b/src/components/mobile/DerivedInsightTile.tsx
@@ -77,7 +77,7 @@ export function DerivedInsightTile({ insight, onAssetClick, onCapture }: Derived
         )}
       </div>
 
-      <div className="flex-shrink-0 h-[50%] min-h-[250px] max-h-[400px] px-3">
+      <div className="flex-shrink-0 h-[33%] min-h-[170px] max-h-[300px] px-3">
         <ReelsChartPanel symbol={insight.symbol} hideHeader />
       </div>
 
@@ -85,12 +85,12 @@ export function DerivedInsightTile({ insight, onAssetClick, onCapture }: Derived
         <ExpandableText text={insight.body} lines={4} />
       </div>
 
-      <div className="flex-shrink-0 flex items-stretch gap-2 px-3 py-3 pb-safe border-t border-gray-200 dark:border-gray-700">
+      <div className="flex-shrink-0 flex items-stretch gap-2 px-3 py-2 pb-safe border-t border-gray-200 dark:border-gray-700">
         <CaptureButton onCapture={onCapture ? () => onCapture(insight) : undefined} />
         <button
           type="button"
           onClick={() => onAssetClick?.(insight.assetId, insight.symbol)}
-          className="flex-1 flex items-center justify-center gap-2 h-12 rounded-xl bg-primary-600 text-white font-semibold no-touch-target"
+          className="flex-1 flex items-center justify-center gap-2 h-10 rounded-xl bg-primary-600 text-white font-semibold no-touch-target"
         >
           Open {insight.symbol}
           <ArrowRight className="h-4 w-4" />

--- a/src/components/mobile/SignalFeedTile.tsx
+++ b/src/components/mobile/SignalFeedTile.tsx
@@ -69,8 +69,10 @@ export function SignalFeedTile({ signal, onAssetClick, onCapture }: SignalFeedTi
         // Signals are derived by the system, so the attribution slot stays
         // empty rather than naming a person who did not write this.
         // Signals have no author either, so the headline uses that row.
+        // No timestamp: signal.createdAt is stamped when the card is derived,
+        // so it always reads "1 minute ago" — it describes the query, not the
+        // world, and it truncated the headline beside it.
         headline={signal.headline}
-        timestamp={signal.createdAt}
       />
 
       {/* Headline leads, matching the decision card's instruction-first shape. */}
@@ -79,7 +81,7 @@ export function SignalFeedTile({ signal, onAssetClick, onCapture }: SignalFeedTi
       </div>
 
       {primary && (
-        <div className="flex-shrink-0 h-[50%] min-h-[250px] max-h-[400px] px-3">
+        <div className="flex-shrink-0 h-[33%] min-h-[170px] max-h-[300px] px-3">
           <ReelsChartPanel symbol={primary.symbol} hideHeader />
         </div>
       )}
@@ -112,13 +114,13 @@ export function SignalFeedTile({ signal, onAssetClick, onCapture }: SignalFeedTi
         )}
       </div>
 
-      <div className="flex-shrink-0 flex items-stretch gap-2 px-3 py-3 pb-safe border-t border-gray-200 dark:border-gray-700">
+      <div className="flex-shrink-0 flex items-stretch gap-2 px-3 py-2 pb-safe border-t border-gray-200 dark:border-gray-700">
         <CaptureButton onCapture={onCapture} />
         <button
           type="button"
           onClick={() => primary && onAssetClick?.(primary.id, primary.symbol)}
           disabled={!primary}
-          className="flex-1 flex items-center justify-center gap-2 h-12 rounded-xl bg-primary-600 text-white font-semibold disabled:opacity-40 no-touch-target"
+          className="flex-1 flex items-center justify-center gap-2 h-10 rounded-xl bg-primary-600 text-white font-semibold disabled:opacity-40 no-touch-target"
         >
           {primary ? `Open ${primary.symbol}` : 'No linked asset'}
           <ArrowRight className="h-4 w-4" />

--- a/src/lib/org-scope/__tests__/org-scope-guard.test.ts
+++ b/src/lib/org-scope/__tests__/org-scope-guard.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { beforeAll, describe, expect, it } from 'vitest'
 // @ts-expect-error — plain ESM helper, intentionally untyped
 import { scanTree, ORG_SCOPED_TABLES } from '../org-scope-scan.mjs'
 import baseline from '../known-unscoped-queries.json'
@@ -28,8 +28,16 @@ import baseline from '../known-unscoped-queries.json'
 describe('organisation scoping', () => {
   const known = new Set(baseline as string[])
 
+  // Scanned once and shared. Walking the tree takes seconds and grows with the
+  // codebase; running it per-test put this suite on the edge of the default
+  // 5s timeout, where it failed for being slow rather than for finding
+  // anything. The scan is pure, so one result serves every assertion.
+  let violations: Array<{ file: string; line: number; table: string }>
+  beforeAll(() => {
+    violations = scanTree('src') as typeof violations
+  }, 60_000)
+
   it('introduces no new unscoped queries against org-scoped tables', () => {
-    const violations = scanTree('src') as Array<{ file: string; line: number; table: string }>
     const offenders = violations.filter(v => !known.has(v.file))
 
     const report = offenders
@@ -40,7 +48,6 @@ describe('organisation scoping', () => {
   })
 
   it('keeps the baseline honest — no stale entries', () => {
-    const violations = scanTree('src') as Array<{ file: string }>
     const stillUnscoped = new Set(violations.map(v => v.file))
     // A file listed as unscoped that no longer is should be removed from the
     // baseline, otherwise it silently regains permission to regress.


### PR DESCRIPTION
…CTA rows

Insight and signal tiles still carried the old half-screen chart band — the 33% change had only reached the decision and idea tiles.

Pair trades go the other way, to 42%. Their band is shared with the carousel's own quote row and leg controls, so at 33% the plot itself came out far smaller than a single chart's on the same tile height.

Signals no longer show a timestamp. signal.createdAt is stamped when the card is derived, not when anything happened, so it always read "1 minute ago" — it described the query rather than the world, and it truncated the headline it shared the row with.

CTA buttons drop to 40px and their row loses a third of its padding; at 48px with the new tile seam they met the edge of the tile with nothing between.

Also hoists the org-scope guard's tree scan into beforeAll. It ran per-test and had grown to ~5s, so the suite had started failing on the default timeout rather than on anything it found. The scan is pure; one result serves both assertions. Baseline is unchanged at 110 files.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
