### PR TITLE
feat(mobile): purpose-built asset page with inline case editing

### DIFF
--- a/src/components/mobile/asset/MobileAssetPage.tsx
+++ b/src/components/mobile/asset/MobileAssetPage.tsx
@@ -1,0 +1,271 @@
+import { useState } from 'react'
+import { clsx } from 'clsx'
+import { Briefcase, FileText, Layers, ListChecks, TrendingUp } from 'lucide-react'
+import { MobileCaseSection } from './MobileCaseSection'
+import { TickerQuoteBadge } from '../TickerQuoteBadge'
+import { ExpandableText } from '../ExpandableText'
+import { useAssetTradeIdeas } from '../../../hooks/useAssetTradeIdeas'
+import { useAssetHeaderContext } from '../../../hooks/useAssetHeaderContext'
+
+interface MobileAssetPageProps {
+  asset: { id: string; symbol: string; company_name?: string | null }
+  onNavigate?: (result: any) => void
+}
+
+type SubPage = 'case' | 'decisions' | 'lists'
+
+const SUB_PAGES: { key: SubPage; label: string; icon: typeof FileText }[] = [
+  { key: 'case', label: 'Case', icon: FileText },
+  { key: 'decisions', label: 'Decisions', icon: TrendingUp },
+  { key: 'lists', label: 'Lists', icon: Layers },
+]
+
+/** The three sections that make up an asset case, in the order they are argued. */
+const CASE_SECTIONS = [
+  {
+    sectionKey: 'thesis',
+    title: 'Thesis',
+    emptyHint: 'Why own this, and what has to be true.',
+  },
+  {
+    sectionKey: 'where_different',
+    title: "Where we're different",
+    emptyHint: 'What the market is missing or pricing wrongly.',
+  },
+  {
+    sectionKey: 'risks_to_thesis',
+    title: 'Risks to thesis',
+    emptyHint: 'What would break the case, and what you would watch for.',
+  },
+]
+
+/**
+ * The asset page, built for a phone.
+ *
+ * The desktop AssetTab is 4,300 lines carrying four sub-pages, an
+ * aggregated-versus-per-analyst view filter, four thesis view modes, custom
+ * widgets, analyst estimates and consensus panels. Reflowing that onto 390px
+ * was tried on the dashboard and did not converge; this reuses the same hooks
+ * and rebuilds only the surface.
+ *
+ * Three tabs, because they answer the three questions worth asking on a phone:
+ * what do we think (Case), what are we doing about it (Decisions), and where
+ * does it sit (Lists). Process/workflow stays on desktop — stage management is
+ * a wide control and a poor fit for a thumb.
+ */
+export function MobileAssetPage({ asset, onNavigate }: MobileAssetPageProps) {
+  const [subPage, setSubPage] = useState<SubPage>('case')
+
+  return (
+    <div className="h-full flex flex-col bg-gray-50 dark:bg-gray-950">
+      {/* Header: identity and price, nothing else. The desktop header also
+          carries coverage, priority, workflow and visibility controls; on a
+          phone those belong to the section that uses them. */}
+      <div className="flex-shrink-0 px-3 pt-3 pb-2 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white truncate">
+              {asset.symbol}
+            </h1>
+            {asset.company_name && (
+              <p className="text-sm text-gray-500 dark:text-gray-400 truncate">
+                {asset.company_name}
+              </p>
+            )}
+          </div>
+          <TickerQuoteBadge symbol={asset.symbol} showSymbol={false} className="shrink-0" />
+        </div>
+      </div>
+
+      <div className="flex-shrink-0 flex items-stretch gap-1 px-2 py-1.5 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800">
+        {SUB_PAGES.map(p => {
+          const Icon = p.icon
+          const active = subPage === p.key
+          return (
+            <button
+              key={p.key}
+              type="button"
+              onClick={() => setSubPage(p.key)}
+              aria-current={active}
+              className={clsx(
+                'flex-1 flex items-center justify-center gap-1.5 h-9 rounded-lg text-sm font-medium transition-colors no-touch-target',
+                active
+                  ? 'bg-primary-50 text-primary-700 dark:bg-primary-900/30 dark:text-primary-300'
+                  : 'text-gray-500 dark:text-gray-400 active:bg-gray-100 dark:active:bg-gray-800'
+              )}
+            >
+              <Icon className="h-4 w-4 shrink-0" />
+              {p.label}
+            </button>
+          )
+        })}
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain px-3 py-3 pb-safe space-y-3">
+        {subPage === 'case' &&
+          CASE_SECTIONS.map(s => (
+            <MobileCaseSection
+              key={s.sectionKey}
+              assetId={asset.id}
+              sectionKey={s.sectionKey}
+              title={s.title}
+              emptyHint={s.emptyHint}
+            />
+          ))}
+
+        {subPage === 'decisions' && <DecisionsPanel assetId={asset.id} onNavigate={onNavigate} />}
+
+        {subPage === 'lists' && <ListsPanel assetId={asset.id} onNavigate={onNavigate} />}
+      </div>
+    </div>
+  )
+}
+
+function DecisionsPanel({
+  assetId,
+  onNavigate,
+}: {
+  assetId: string
+  onNavigate?: (result: any) => void
+}) {
+  const { ideas, isLoading } = useAssetTradeIdeas({ assetId, limit: 25 })
+
+  if (isLoading) return <PanelSkeleton />
+  if (!ideas.length) {
+    return <EmptyPanel icon={TrendingUp} message="Nothing in flight on this name." />
+  }
+
+  return (
+    <div className="space-y-2">
+      {ideas.map(idea => (
+        <button
+          key={idea.id}
+          type="button"
+          onClick={() =>
+            onNavigate?.({ id: 'trade-queue', title: 'Idea Pipeline', type: 'trade-queue', data: null })
+          }
+          className="w-full text-left rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-3 active:bg-gray-50 dark:active:bg-gray-800"
+        >
+          <div className="flex items-center gap-2 mb-1.5">
+            <span
+              className={clsx(
+                'px-2 py-0.5 rounded-full text-[10px] font-bold uppercase tracking-wide',
+                idea.action === 'buy' || idea.action === 'add'
+                  ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300'
+                  : 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300'
+              )}
+            >
+              {idea.action}
+            </span>
+            <span className="text-[11px] font-medium text-gray-500 dark:text-gray-400 truncate">
+              {idea.stage?.replace(/_/g, ' ')}
+            </span>
+            {/* Stated only when it exists. proposed_weight is optional, and a
+                blank "—%" reads as a missing number rather than an absent one. */}
+            {idea.proposed_weight != null && (
+              <span className="ml-auto shrink-0 text-xs font-semibold tabular-nums text-gray-700 dark:text-gray-200">
+                {idea.proposed_weight}%
+              </span>
+            )}
+          </div>
+
+          {idea.rationale && <ExpandableText text={idea.rationale} lines={3} />}
+
+          <p className="mt-1.5 text-[11px] text-gray-400 truncate">
+            {idea.portfolio?.name ?? 'No portfolio'}
+            {idea.creator &&
+              ` · ${[idea.creator.first_name, idea.creator.last_name].filter(Boolean).join(' ')}`}
+          </p>
+        </button>
+      ))}
+    </div>
+  )
+}
+
+function ListsPanel({
+  assetId,
+  onNavigate,
+}: {
+  assetId: string
+  onNavigate?: (result: any) => void
+}) {
+  const { portfolios, listsMine, listsShared, themes, isLoading } = useAssetHeaderContext(assetId)
+
+  if (isLoading) return <PanelSkeleton />
+
+  const groups = [
+    { title: 'Portfolios', icon: Briefcase, rows: portfolios ?? [], type: 'portfolio' },
+    { title: 'My lists', icon: ListChecks, rows: listsMine ?? [], type: 'list' },
+    { title: 'Shared lists', icon: ListChecks, rows: listsShared ?? [], type: 'list' },
+    { title: 'Themes', icon: Layers, rows: themes ?? [], type: 'theme' },
+  ].filter(g => g.rows.length > 0)
+
+  if (!groups.length) {
+    return <EmptyPanel icon={Layers} message="Not in any portfolio, list or theme." />
+  }
+
+  return (
+    <div className="space-y-3">
+      {groups.map(group => {
+        const Icon = group.icon
+        return (
+          <section
+            key={group.title}
+            className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 overflow-hidden"
+          >
+            <div className="flex items-center gap-2 px-3 py-2 border-b border-gray-100 dark:border-gray-800">
+              <Icon className="h-4 w-4 text-gray-400 shrink-0" />
+              <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+                {group.title}
+              </h3>
+              <span className="ml-auto text-xs text-gray-400">{group.rows.length}</span>
+            </div>
+            <div className="divide-y divide-gray-100 dark:divide-gray-800">
+              {group.rows.map((row: any) => (
+                <button
+                  key={row.id}
+                  type="button"
+                  onClick={() =>
+                    onNavigate?.({
+                      id: row.id,
+                      title: row.name,
+                      type: group.type,
+                      data: row,
+                    })
+                  }
+                  className="w-full flex items-center gap-2 min-h-[44px] px-3 py-2 text-left active:bg-gray-50 dark:active:bg-gray-800"
+                >
+                  <span className="flex-1 min-w-0 text-sm text-gray-700 dark:text-gray-200 truncate">
+                    {row.name}
+                  </span>
+                </button>
+              ))}
+            </div>
+          </section>
+        )
+      })}
+    </div>
+  )
+}
+
+function PanelSkeleton() {
+  return (
+    <div className="space-y-2">
+      {[0, 1, 2].map(i => (
+        <div
+          key={i}
+          className="h-20 rounded-xl bg-gray-100 dark:bg-gray-800 animate-pulse"
+        />
+      ))}
+    </div>
+  )
+}
+
+function EmptyPanel({ icon: Icon, message }: { icon: typeof Layers; message: string }) {
+  return (
+    <div className="flex flex-col items-center justify-center gap-2 py-12 text-gray-400">
+      <Icon className="h-8 w-8 opacity-50" />
+      <p className="text-sm">{message}</p>
+    </div>
+  )
+}

--- a/src/components/mobile/asset/MobileCaseSection.tsx
+++ b/src/components/mobile/asset/MobileCaseSection.tsx
@@ -1,0 +1,218 @@
+import { useEffect, useRef, useState } from 'react'
+import { Check, Loader2, Pencil, X } from 'lucide-react'
+import { useAuth } from '../../../hooks/useAuth'
+import { useContributions } from '../../../hooks/useContributions'
+import { ExpandableText } from '../ExpandableText'
+
+interface MobileCaseSectionProps {
+  assetId: string
+  /** Storage key: 'thesis' | 'where_different' | 'risks_to_thesis'. */
+  sectionKey: string
+  title: string
+  /** Shown when nobody has written anything, so the section is never a blank box. */
+  emptyHint: string
+}
+
+/** Draft writes are debounced to avoid a request per keystroke. */
+const DRAFT_DEBOUNCE_MS = 1200
+
+/**
+ * One section of an asset case, readable and editable on a phone.
+ *
+ * Reuses useContributions unchanged, so a phone edit is the same write the
+ * desktop page makes — same draft/publish split, same revision history, same
+ * visibility rules. The mobile-specific part is only the interaction: tap to
+ * edit, autosave to draft, explicit publish.
+ *
+ * Draft and published are kept distinct rather than collapsed into one
+ * autosaving field. A half-finished thought typed on a phone should not become
+ * the firm's stated view of a position the moment the keyboard closes;
+ * publishing stays deliberate, exactly as on desktop.
+ */
+export function MobileCaseSection({
+  assetId,
+  sectionKey,
+  title,
+  emptyHint,
+}: MobileCaseSectionProps) {
+  const { user } = useAuth()
+  const {
+    myContribution,
+    otherContributions,
+    isLoading,
+    saveDraft,
+    publishDraft,
+    discardDraft,
+  } = useContributions({ assetId, section: sectionKey })
+
+  const [editing, setEditing] = useState(false)
+  const [value, setValue] = useState('')
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const debounce = useRef<ReturnType<typeof setTimeout> | null>(null)
+  /** The text last sent to the server, so an unchanged blur saves nothing. */
+  const lastSaved = useRef('')
+
+  const draft = myContribution?.draft_content ?? null
+  const published = myContribution?.content ?? ''
+  const hasDraft = !!draft && draft !== published
+
+  const beginEdit = () => {
+    const start = draft ?? published
+    setValue(start)
+    lastSaved.current = start
+    setEditing(true)
+  }
+
+  useEffect(() => {
+    if (!editing) return
+    const el = textareaRef.current
+    if (!el) return
+    el.focus()
+    // Caret to the end: starting mid-text is disorienting when the field was
+    // pre-filled with existing work.
+    el.setSelectionRange(el.value.length, el.value.length)
+  }, [editing])
+
+  // Autosave to draft, never straight to published.
+  useEffect(() => {
+    if (!editing) return
+    if (value === lastSaved.current) return
+    if (debounce.current) clearTimeout(debounce.current)
+    debounce.current = setTimeout(() => {
+      lastSaved.current = value
+      saveDraft.mutate({ content: value, sectionKey })
+    }, DRAFT_DEBOUNCE_MS)
+    return () => {
+      if (debounce.current) clearTimeout(debounce.current)
+    }
+  }, [value, editing, sectionKey, saveDraft])
+
+  const stopEditing = () => {
+    // Flush anything the debounce still owes, so closing the editor never
+    // silently drops the last few characters typed.
+    if (debounce.current) clearTimeout(debounce.current)
+    if (value !== lastSaved.current) {
+      lastSaved.current = value
+      saveDraft.mutate({ content: value, sectionKey })
+    }
+    setEditing(false)
+  }
+
+  const publish = () => {
+    if (debounce.current) clearTimeout(debounce.current)
+    const commit = () => publishDraft.mutate({ sectionKey })
+    if (value !== lastSaved.current) {
+      lastSaved.current = value
+      // Publish reads the stored draft, so the newest text has to land first.
+      saveDraft.mutate({ content: value, sectionKey }, { onSuccess: commit })
+    } else {
+      commit()
+    }
+    setEditing(false)
+  }
+
+  return (
+    <section className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 overflow-hidden">
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-gray-100 dark:border-gray-800">
+        <h3 className="flex-1 min-w-0 text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
+          {title}
+        </h3>
+        {hasDraft && !editing && (
+          <span className="shrink-0 px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wide bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
+            Draft
+          </span>
+        )}
+        {!editing && user && (
+          <button
+            type="button"
+            onClick={beginEdit}
+            className="shrink-0 inline-flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-semibold text-primary-600 dark:text-primary-400 active:bg-primary-50 dark:active:bg-primary-900/30 no-touch-target"
+          >
+            <Pencil className="h-3.5 w-3.5" />
+            {published || draft ? 'Edit' : 'Add'}
+          </button>
+        )}
+      </div>
+
+      <div className="px-3 py-2.5">
+        {editing ? (
+          <div>
+            <textarea
+              ref={textareaRef}
+              value={value}
+              onChange={e => setValue(e.target.value)}
+              rows={7}
+              placeholder={emptyHint}
+              className="w-full resize-y rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-[15px] leading-relaxed text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-500"
+            />
+
+            <div className="mt-2 flex items-center gap-2">
+              <span className="flex-1 min-w-0 text-[11px] text-gray-400 truncate">
+                {saveDraft.isPending ? 'Saving draft…' : 'Saved as draft'}
+              </span>
+              <button
+                type="button"
+                onClick={stopEditing}
+                className="inline-flex items-center gap-1 h-9 px-3 rounded-lg text-sm font-medium text-gray-600 dark:text-gray-300 active:bg-gray-100 dark:active:bg-gray-800 no-touch-target"
+              >
+                Done
+              </button>
+              <button
+                type="button"
+                onClick={publish}
+                disabled={publishDraft.isPending || !value.trim()}
+                className="inline-flex items-center gap-1.5 h-9 px-3 rounded-lg bg-primary-600 text-white text-sm font-semibold disabled:opacity-40 no-touch-target"
+              >
+                {publishDraft.isPending
+                  ? <Loader2 className="h-4 w-4 animate-spin" />
+                  : <Check className="h-4 w-4" />}
+                Publish
+              </button>
+            </div>
+          </div>
+        ) : isLoading ? (
+          <div className="h-4 w-2/3 rounded bg-gray-100 dark:bg-gray-800 animate-pulse" />
+        ) : (
+          <>
+            {hasDraft && (
+              <div className="mb-2 rounded-lg border border-amber-200 dark:border-amber-900/50 bg-amber-50 dark:bg-amber-900/20 px-2.5 py-2">
+                <div className="flex items-center gap-2 mb-1">
+                  <span className="text-[10px] font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-300">
+                    Your unpublished draft
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => discardDraft.mutate({ sectionKey })}
+                    className="ml-auto inline-flex items-center gap-0.5 text-[11px] font-medium text-amber-700 dark:text-amber-300 no-touch-target"
+                  >
+                    <X className="h-3 w-3" /> Discard
+                  </button>
+                </div>
+                <ExpandableText text={draft!} lines={4} />
+              </div>
+            )}
+
+            {published ? (
+              <ExpandableText text={published} lines={6} />
+            ) : !hasDraft ? (
+              <p className="text-sm text-gray-400 dark:text-gray-500">{emptyHint}</p>
+            ) : null}
+
+            {otherContributions.length > 0 && (
+              <div className="mt-3 pt-3 border-t border-gray-100 dark:border-gray-800 space-y-3">
+                {otherContributions.map(c => (
+                  <div key={c.id}>
+                    <p className="mb-0.5 text-[11px] font-semibold text-gray-500 dark:text-gray-400">
+                      {c.user?.full_name ?? 'Colleague'}
+                    </p>
+                    <ExpandableText text={c.content} lines={4} />
+                  </div>
+                ))}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+    </section>
+  )
+}

--- a/src/components/mobile/asset/__tests__/case-sections.test.ts
+++ b/src/components/mobile/asset/__tests__/case-sections.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+/**
+ * The mobile case editor writes through useContributions using a section key.
+ * If those keys drift from the ones the desktop page reads, a thesis edited on
+ * a phone lands in a section nothing displays — the write succeeds, the user
+ * sees a confirmation, and the work vanishes.
+ *
+ * Nothing else would catch that: both sides type the key as a bare string, and
+ * a wrong-but-valid key is a successful insert.
+ */
+describe('mobile asset case sections', () => {
+  const mobile = readFileSync('src/components/mobile/asset/MobileAssetPage.tsx', 'utf8')
+  const desktop = readFileSync('src/components/contributions/ThesisContainer.tsx', 'utf8')
+
+  const keysIn = (source: string, pattern: RegExp) => {
+    const found = new Set<string>()
+    for (const m of source.matchAll(pattern)) found.add(m[1])
+    return found
+  }
+
+  it('uses the same section keys the desktop thesis reads', () => {
+    const mobileKeys = keysIn(mobile, /sectionKey: '([a-z_]+)'/g)
+    const desktopKeys = keysIn(desktop, /useContributions\(\{ assetId, section: '([a-z_]+)' \}\)/g)
+
+    expect(desktopKeys.size).toBeGreaterThan(0)
+    expect([...mobileKeys].sort()).toEqual([...desktopKeys].sort())
+  })
+
+  it('covers every section rather than a subset', () => {
+    // A section present on desktop but missing here is not a crash, it is an
+    // invisible gap: the reader assumes they have seen the whole case.
+    const mobileKeys = keysIn(mobile, /sectionKey: '([a-z_]+)'/g)
+    expect(mobileKeys).toContain('thesis')
+    expect(mobileKeys).toContain('where_different')
+    expect(mobileKeys).toContain('risks_to_thesis')
+  })
+})

--- a/src/lib/mobile/mobile-surfaces.ts
+++ b/src/lib/mobile/mobile-surfaces.ts
@@ -84,7 +84,7 @@ export const MOBILE_SURFACES: MobileSurface[] = [
     type: 'asset', title: 'Asset', icon: TrendingUp,
     color: 'text-blue-500', bg: 'bg-blue-50',
     support: 'full', group: 'core',
-    mobileNote: 'Read and edit case narrative',
+    mobileNote: 'Read and edit the case; Process stays on desktop',
   },
   {
     type: 'notes-list', title: 'Notes', icon: StickyNote,

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -7,6 +7,7 @@ import { Layout } from '../components/layout/Layout'
 import type { Tab } from '../components/layout/TabManager'
 import { TabStateManager } from '../lib/tabStateManager'
 import { AssetTab } from '../components/tabs/AssetTab'
+import { MobileAssetPage } from '../components/mobile/asset/MobileAssetPage'
 import { AssetsListPage } from './AssetsListPage'
 import { ThemesListPage } from './ThemesListPage'
 import { PortfoliosListPage } from './PortfoliosListPage'
@@ -962,7 +963,13 @@ export function DashboardPage() {
 
     switch (activeTab.type) {
       case 'asset':
-        return activeTab.data ? <AssetTab asset={activeTab.data} onNavigate={handleSearchResult} /> : <AssetLoadingState />
+        if (!activeTab.data) return <AssetLoadingState />
+        // Phones get a purpose-built asset page. AssetTab is 4,300 lines of
+        // four sub-pages, view filters and analyst panels built for a wide
+        // screen; see MobileAssetPage.
+        return isMobile
+          ? <MobileAssetPage asset={activeTab.data} onNavigate={handleSearchResult} />
+          : <AssetTab asset={activeTab.data} onNavigate={handleSearchResult} />
       case 'assets-list':
         return <AssetsListPage onAssetSelect={handleSearchResult} />
       case 'portfolios-list':


### PR DESCRIPTION
AssetTab is 4,327 lines carrying four sub-pages, an aggregated-versus- per-analyst view filter, four thesis view modes, custom widgets and analyst consensus panels, laid out at px-8 for a wide screen. Reflowing a surface that size onto 390px was tried on the dashboard and did not converge, so this reuses the hooks and rebuilds only the surface.

Three tabs, answering the three questions worth asking on a phone: what do we think (Case), what are we doing about it (Decisions), and where does it sit (Lists). Process stays on desktop — stage management is a wide control.

Case sections are editable in place through useContributions unchanged, so a phone edit is the same write desktop makes: same draft/publish split, same revision history, same visibility rules. Typing autosaves to draft and never straight to published — a half-finished thought typed one-handed should not become the firm's stated view of a position the moment the keyboard closes. Closing the editor flushes whatever the debounce still owes, and publishing lands the newest text before committing, so neither path can drop the last characters typed.

A test pins the mobile section keys to the ones ThesisContainer reads. They are bare strings on both sides and a wrong-but-valid key is a successful insert, so drift would look like a saved edit that silently vanishes.

mobile-surfaces.ts has claimed 'Read and edit case narrative' since Phase 0 while the phone rendered the desktop component. That is now true, and the note says what actually ships.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
