### PR TITLE
fix(mobile): hidden fields, markdown prose, scenarios, edit history, …

### DIFF
--- a/src/components/mobile/ExpandableText.tsx
+++ b/src/components/mobile/ExpandableText.tsx
@@ -1,11 +1,17 @@
 import { useEffect, useRef, useState } from 'react'
 import { clsx } from 'clsx'
 import { ChevronDown, ChevronUp } from 'lucide-react'
+import ReactMarkdown from 'react-markdown'
 
 interface ExpandableTextProps {
   text: string
   /** Lines shown before clamping. */
   lines?: 2 | 3 | 4 | 5 | 6
+  /** Render as markdown. Contribution prose is authored in it, so raw text
+   *  shows literal ** and - where bold and bullets belong. Off by default:
+   *  feed rationales and thoughts are plain text, and running them through a
+   *  parser would reformat anything that merely looks like markup. */
+  markdown?: boolean
   className?: string
 }
 
@@ -32,10 +38,10 @@ const CLAMP: Record<number, string> = {
  * rendered element rather than guessed from character count, which is wrong at
  * any width but the one it was tuned for.
  */
-export function ExpandableText({ text, lines = 4, className }: ExpandableTextProps) {
+export function ExpandableText({ text, lines = 4, markdown = false, className }: ExpandableTextProps) {
   const [expanded, setExpanded] = useState(false)
   const [isTruncated, setIsTruncated] = useState(false)
-  const ref = useRef<HTMLParagraphElement>(null)
+  const ref = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     const el = ref.current
@@ -47,15 +53,32 @@ export function ExpandableText({ text, lines = 4, className }: ExpandableTextPro
 
   return (
     <div className={className}>
-      <p
+      <div
         ref={ref}
         className={clsx(
           'text-[15px] leading-relaxed text-gray-800 dark:text-gray-200',
+          // Styled explicitly rather than with `prose`: @tailwindcss/typography
+          // is not installed (tailwind.config.js has `plugins: []`), so those
+          // classes emit nothing. Preflight also strips list markers and
+          // padding from ul/ol, so bullets have to be restored by hand or
+          // markdown lists render as unmarked lines.
+          markdown && [
+            '[&_p]:my-1 [&_p:first-child]:mt-0 [&_p:last-child]:mb-0',
+            '[&_ul]:list-disc [&_ul]:pl-5 [&_ul]:my-1',
+            '[&_ol]:list-decimal [&_ol]:pl-5 [&_ol]:my-1',
+            '[&_li]:my-0.5 [&_li]:pl-0.5',
+            '[&_strong]:font-semibold [&_strong]:text-gray-900 dark:[&_strong]:text-white',
+            '[&_em]:italic',
+            '[&_h1]:text-base [&_h2]:text-base [&_h3]:text-[15px] [&_h1]:font-bold [&_h2]:font-bold [&_h3]:font-semibold [&_h1]:my-1 [&_h2]:my-1 [&_h3]:my-1',
+            '[&_a]:text-primary-600 [&_a]:underline dark:[&_a]:text-primary-400',
+            '[&_code]:rounded [&_code]:bg-gray-100 [&_code]:px-1 [&_code]:text-[13px] dark:[&_code]:bg-gray-800',
+            '[&_blockquote]:border-l-2 [&_blockquote]:border-gray-300 [&_blockquote]:pl-3 [&_blockquote]:text-gray-600 dark:[&_blockquote]:border-gray-600 dark:[&_blockquote]:text-gray-400',
+          ],
           !expanded && CLAMP[lines]
         )}
       >
-        {text}
-      </p>
+        {markdown ? <ReactMarkdown>{text}</ReactMarkdown> : text}
+      </div>
 
       {(isTruncated || expanded) && (
         <button

--- a/src/components/mobile/MobileSearchOverlay.tsx
+++ b/src/components/mobile/MobileSearchOverlay.tsx
@@ -42,15 +42,37 @@ export function MobileSearchOverlay({ open, onClose, onSelectResult }: MobileSea
     return () => document.removeEventListener('keydown', onKeyDown)
   }, [open, onClose])
 
-  // Focus the search field once the panel is on screen. GlobalSearch owns its
-  // own input ref, so reach for it through the DOM rather than threading a ref
-  // through a shared component used on desktop too.
+  // Focus the field as soon as it exists, rather than after a fixed delay.
+  //
+  // The old version waited 60ms and focused once. iOS only raises the keyboard
+  // for a focus() it can attribute to the tap that caused it, and a timeout
+  // long enough for React to paint is already too late — the field took focus
+  // but no keyboard appeared, so the panel had to be tapped a second time to
+  // type. Polling on animation frames focuses at the first frame the input is
+  // mounted, which is inside the gesture's window.
   useEffect(() => {
     if (!open) return
-    const timer = setTimeout(() => {
-      panelRef.current?.querySelector('input')?.focus()
-    }, 60)
-    return () => clearTimeout(timer)
+    let frame = 0
+    let cancelled = false
+
+    const tryFocus = () => {
+      if (cancelled) return
+      const input = panelRef.current?.querySelector('input')
+      if (input) {
+        input.focus()
+        // Safari occasionally restores a previous selection; putting the caret
+        // at the end makes typing continue rather than overwrite.
+        const end = input.value.length
+        try { input.setSelectionRange(end, end) } catch { /* not all inputs support it */ }
+        return
+      }
+      // Give up after ~1s rather than spinning forever if the field never
+      // renders; a stuck rAF loop is worse than an unfocused input.
+      if (frame++ < 60) requestAnimationFrame(tryFocus)
+    }
+
+    tryFocus()
+    return () => { cancelled = true }
   }, [open])
 
   if (!open || typeof document === 'undefined') return null

--- a/src/components/mobile/asset/CaseFieldHistory.tsx
+++ b/src/components/mobile/asset/CaseFieldHistory.tsx
@@ -1,0 +1,145 @@
+import { useMemo } from 'react'
+import { clsx } from 'clsx'
+import { formatDistanceToNow } from 'date-fns'
+import { useContributionHistory } from '../../../hooks/useContributions'
+
+interface CaseFieldHistoryProps {
+  contributionId: string
+}
+
+/**
+ * What changed in one case field, and when.
+ *
+ * Shows the difference rather than the whole revision. A case section is
+ * several paragraphs, so a list of full versions is unreadable on a phone and
+ * buries the one sentence that actually moved — which is the thing worth
+ * reviewing before a decision.
+ */
+export function CaseFieldHistory({ contributionId }: CaseFieldHistoryProps) {
+  const { history, isLoading } = useContributionHistory(contributionId)
+
+  if (isLoading) {
+    return <div className="h-4 w-24 rounded bg-gray-100 dark:bg-gray-800 animate-pulse" />
+  }
+
+  if (!history.length) {
+    return (
+      <p className="text-xs text-gray-400">No edits recorded yet.</p>
+    )
+  }
+
+  return (
+    <ol className="space-y-3">
+      {history.map(entry => (
+        <li key={entry.id}>
+          <div className="flex items-baseline gap-2 mb-1">
+            <span className="text-[11px] font-semibold text-gray-600 dark:text-gray-300 truncate">
+              {entry.user?.full_name ?? 'Someone'}
+            </span>
+            <span className="text-[11px] text-gray-400 whitespace-nowrap">
+              {relative(entry.changed_at)}
+            </span>
+          </div>
+          <Diff before={entry.old_content} after={entry.new_content} />
+        </li>
+      ))}
+    </ol>
+  )
+}
+
+/**
+ * A word-level difference between two revisions.
+ *
+ * Word-level rather than character-level because prose edits are word edits:
+ * a character diff of a rewritten sentence produces confetti, where a word
+ * diff reads as a sentence with parts struck out and parts added.
+ */
+function Diff({ before, after }: { before: string | null; after: string }) {
+  const parts = useMemo(() => diffWords(before ?? '', after), [before, after])
+
+  // A first draft has nothing to compare against; showing every word as an
+  // addition is noise, so it reads as plain new text.
+  if (!before) {
+    return <p className="text-[13px] leading-relaxed text-gray-700 dark:text-gray-300">{after}</p>
+  }
+
+  return (
+    <p className="text-[13px] leading-relaxed text-gray-700 dark:text-gray-300">
+      {parts.map((part, i) => (
+        <span
+          key={i}
+          className={clsx(
+            part.kind === 'added' && 'bg-emerald-100 text-emerald-900 dark:bg-emerald-900/40 dark:text-emerald-200',
+            part.kind === 'removed' && 'bg-red-100 text-red-900 line-through dark:bg-red-900/40 dark:text-red-200'
+          )}
+        >
+          {part.text}
+        </span>
+      ))}
+    </p>
+  )
+}
+
+type DiffPart = { kind: 'same' | 'added' | 'removed'; text: string }
+
+/**
+ * Longest common subsequence over words.
+ *
+ * Guarded by size: LCS is O(n×m), and a pair of long revisions would otherwise
+ * build a matrix large enough to lock the main thread on a phone. Past the
+ * limit it falls back to showing the new text alone, which is honest — it just
+ * stops claiming to highlight what moved.
+ */
+export function diffWords(before: string, after: string): DiffPart[] {
+  const a = before.split(/(\s+)/).filter(Boolean)
+  const b = after.split(/(\s+)/).filter(Boolean)
+
+  const MAX = 400
+  if (a.length > MAX || b.length > MAX) {
+    return [{ kind: 'same', text: after }]
+  }
+
+  const lcs: number[][] = Array.from({ length: a.length + 1 }, () =>
+    new Array(b.length + 1).fill(0)
+  )
+  for (let i = a.length - 1; i >= 0; i--) {
+    for (let j = b.length - 1; j >= 0; j--) {
+      lcs[i][j] = a[i] === b[j] ? lcs[i + 1][j + 1] + 1 : Math.max(lcs[i + 1][j], lcs[i][j + 1])
+    }
+  }
+
+  const parts: DiffPart[] = []
+  const push = (kind: DiffPart['kind'], text: string) => {
+    const last = parts[parts.length - 1]
+    // Merge runs so a changed phrase is one highlighted block rather than a
+    // separate span per word.
+    if (last && last.kind === kind) last.text += text
+    else parts.push({ kind, text })
+  }
+
+  let i = 0
+  let j = 0
+  while (i < a.length && j < b.length) {
+    if (a[i] === b[j]) {
+      push('same', a[i])
+      i++
+      j++
+    } else if (lcs[i + 1][j] >= lcs[i][j + 1]) {
+      push('removed', a[i])
+      i++
+    } else {
+      push('added', b[j])
+      j++
+    }
+  }
+  while (i < a.length) push('removed', a[i++])
+  while (j < b.length) push('added', b[j++])
+
+  return parts
+}
+
+function relative(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return ''
+  return formatDistanceToNow(date, { addSuffix: true })
+}

--- a/src/components/mobile/asset/MobileAssetPage.tsx
+++ b/src/components/mobile/asset/MobileAssetPage.tsx
@@ -86,7 +86,7 @@ export function MobileAssetPage({ asset, onNavigate }: MobileAssetPageProps) {
       </div>
 
       <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain px-3 py-3 pb-safe space-y-3">
-        {subPage === 'case' && <MobileCaseView assetId={asset.id} />}
+        {subPage === 'case' && <MobileCaseView assetId={asset.id} symbol={asset.symbol} />}
 
         {subPage === 'decisions' && <DecisionsPanel assetId={asset.id} onNavigate={onNavigate} />}
 

--- a/src/components/mobile/asset/MobileCaseSection.tsx
+++ b/src/components/mobile/asset/MobileCaseSection.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useRef, useState } from 'react'
 import { clsx } from 'clsx'
-import { Check, Loader2, Pencil, X } from 'lucide-react'
+import { Check, History, Loader2, Pencil, X } from 'lucide-react'
 import { useAuth } from '../../../hooks/useAuth'
 import { useContributions } from '../../../hooks/useContributions'
 import { ExpandableText } from '../ExpandableText'
+import { CaseFieldHistory } from './CaseFieldHistory'
 
 interface MobileCaseSectionProps {
   assetId: string
@@ -73,6 +74,7 @@ export function MobileCaseSection({
   const isOwnView = viewFilter === 'aggregated' || viewFilter === user?.id
 
   const [editing, setEditing] = useState(false)
+  const [showHistory, setShowHistory] = useState(false)
   const [value, setValue] = useState('')
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const debounce = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -149,6 +151,22 @@ export function MobileCaseSection({
             Draft
           </span>
         )}
+        {!editing && myContribution && (
+          <button
+            type="button"
+            onClick={() => setShowHistory(v => !v)}
+            aria-expanded={showHistory}
+            className={clsx(
+              'shrink-0 inline-flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-semibold no-touch-target',
+              showHistory
+                ? 'text-primary-700 bg-primary-50 dark:text-primary-300 dark:bg-primary-900/30'
+                : 'text-gray-500 dark:text-gray-400 active:bg-gray-100 dark:active:bg-gray-800'
+            )}
+          >
+            <History className="h-3.5 w-3.5" />
+            Changes
+          </button>
+        )}
         {!editing && user && isOwnView && (
           <button
             type="button"
@@ -215,15 +233,21 @@ export function MobileCaseSection({
                     <X className="h-3 w-3" /> Discard
                   </button>
                 </div>
-                <ExpandableText text={draft!} lines={4} />
+                <ExpandableText text={draft!} lines={4} markdown />
               </div>
             )}
 
             {isOwnView && published ? (
-              <ExpandableText text={published} lines={6} />
+              <ExpandableText text={published} lines={6} markdown />
             ) : !hasDraft && otherContributions.length === 0 ? (
               <p className="text-sm text-gray-400 dark:text-gray-500">{emptyHint}</p>
             ) : null}
+
+            {showHistory && myContribution && (
+              <div className="mb-3 pb-3 border-b border-gray-100 dark:border-gray-800">
+                <CaseFieldHistory contributionId={myContribution.id} />
+              </div>
+            )}
 
             {otherContributions.length > 0 && (
               <div className={clsx(
@@ -236,7 +260,7 @@ export function MobileCaseSection({
                     <p className="mb-0.5 text-[11px] font-semibold text-gray-500 dark:text-gray-400">
                       {c.user?.full_name ?? 'Colleague'}
                     </p>
-                    <ExpandableText text={c.content} lines={4} />
+                    <ExpandableText text={c.content} lines={4} markdown />
                   </div>
                 ))}
               </div>

--- a/src/components/mobile/asset/MobileCaseView.tsx
+++ b/src/components/mobile/asset/MobileCaseView.tsx
@@ -8,9 +8,12 @@ import { useOrganization } from '../../../contexts/OrganizationContext'
 import { useUserAssetPagePreferences } from '../../../hooks/useUserAssetPagePreferences'
 import { contributionSectionsForSlug, writeSectionForSlug } from '../../../lib/research/contribution-sections'
 import { MobileCaseSection } from './MobileCaseSection'
+import { PriceTargetChart } from '../../outcomes/PriceTargetChart'
+import { PriceTargetsSummary } from '../../outcomes/PriceTargetsSummary'
 
 interface MobileCaseViewProps {
   assetId: string
+  symbol: string
 }
 
 /** 'aggregated' shows the firm's view; any other value is a user id. */
@@ -29,7 +32,7 @@ type ViewFilter = 'aggregated' | string
  * desktop page uses, so the phone shows the same template with the same
  * overrides applied rather than a second opinion about what the case contains.
  */
-export function MobileCaseView({ assetId }: MobileCaseViewProps) {
+export function MobileCaseView({ assetId, symbol }: MobileCaseViewProps) {
   const { user } = useAuth()
   const { currentOrgId } = useOrganization()
   const [view, setView] = useState<ViewFilter>('aggregated')
@@ -79,9 +82,15 @@ export function MobileCaseView({ assetId }: MobileCaseViewProps) {
 
   const activeLabel = options.find(o => o.userId === view)?.name ?? 'Firm view'
 
-  const sections = (displayedFieldsBySection ?? []).filter(
-    (s: any) => (s.fields ?? []).length > 0
-  )
+  // useUserAssetPagePreferences returns fields regardless of visibility — its
+  // own comment defers the is_visible filter to the renderer. Without it the
+  // page shows every field defined anywhere, including hidden scaffolding.
+  const sections = (displayedFieldsBySection ?? [])
+    .map((section: any) => ({
+      ...section,
+      fields: (section.fields ?? []).filter((f: any) => f.is_visible),
+    }))
+    .filter((section: any) => section.fields.length > 0)
 
   return (
     <div className="space-y-3">
@@ -140,6 +149,14 @@ export function MobileCaseView({ assetId }: MobileCaseViewProps) {
           </>
         )}
       </div>
+
+      {/* Bull / base / bear against the price. Both components return null
+          without target data, so an asset nobody has valued shows nothing
+          rather than an empty frame. */}
+      <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 overflow-hidden">
+        <PriceTargetChart assetId={assetId} symbol={symbol} height={200} />
+      </div>
+      <PriceTargetsSummary assetId={assetId} hideHeader />
 
       {isLoading ? (
         <div className="space-y-2">

--- a/src/components/mobile/asset/__tests__/diffWords.test.ts
+++ b/src/components/mobile/asset/__tests__/diffWords.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import { diffWords } from '../CaseFieldHistory'
+
+const render = (parts: ReturnType<typeof diffWords>) =>
+  parts.map(p => `${p.kind[0]}:${p.text}`).join('|')
+
+describe('diffWords', () => {
+  it('marks only what changed', () => {
+    const parts = diffWords('the thesis is intact', 'the thesis is broken')
+    expect(parts.filter(p => p.kind === 'same').map(p => p.text).join('')).toBe('the thesis is ')
+    expect(parts.find(p => p.kind === 'removed')?.text).toBe('intact')
+    expect(parts.find(p => p.kind === 'added')?.text).toBe('broken')
+  })
+
+  it('reconstructs both revisions exactly', () => {
+    const before = 'margins compress in the second half on mix'
+    const after = 'margins expand in the second half on price'
+
+    const parts = diffWords(before, after)
+    const rebuiltBefore = parts.filter(p => p.kind !== 'added').map(p => p.text).join('')
+    const rebuiltAfter = parts.filter(p => p.kind !== 'removed').map(p => p.text).join('')
+
+    // A diff that cannot rebuild its inputs is showing the reader something
+    // that was never written.
+    expect(rebuiltBefore).toBe(before)
+    expect(rebuiltAfter).toBe(after)
+  })
+
+  it('merges adjacent words into one run', () => {
+    const parts = diffWords('we like it', 'we do not like it')
+    // "do not " should be a single highlighted block, not three spans.
+    expect(parts.filter(p => p.kind === 'added')).toHaveLength(1)
+  })
+
+  it('handles pure insertion and pure deletion', () => {
+    expect(render(diffWords('', 'new text'))).toBe('a:new text')
+    expect(render(diffWords('old text', ''))).toBe('r:old text')
+  })
+
+  it('reports no change when nothing moved', () => {
+    const parts = diffWords('unchanged prose', 'unchanged prose')
+    expect(parts.every(p => p.kind === 'same')).toBe(true)
+  })
+
+  it('preserves whitespace so the text stays readable', () => {
+    const parts = diffWords('a  b', 'a  c')
+    expect(parts.filter(p => p.kind !== 'added').map(p => p.text).join('')).toBe('a  b')
+  })
+
+  it('falls back rather than building a huge matrix', () => {
+    // LCS is O(n x m); two long revisions would otherwise allocate millions of
+    // cells and block the main thread on a phone.
+    const long = Array.from({ length: 500 }, (_, i) => `word${i}`).join(' ')
+    const parts = diffWords(long, long + ' extra')
+
+    expect(parts).toHaveLength(1)
+    expect(parts[0].kind).toBe('same')
+    expect(parts[0].text).toBe(long + ' extra')
+  })
+})


### PR DESCRIPTION
…search focus

Hidden fields were rendering. useUserAssetPagePreferences returns fields regardless of visibility — its own comment defers the is_visible filter to the renderer — so the case listed everything defined anywhere, including scaffolding like test_rich_text.

Contribution prose is markdown but was rendered as raw text, showing literal ** and - where bold and bullets belong. ExpandableText now renders markdown when asked, opt-in because feed rationales and thoughts are plain text and would be reformatted by a parser.

It styles the output explicitly rather than with `prose`: @tailwindcss/typography is not installed and tailwind.config.js has `plugins: []`, so those classes emit nothing. Preflight also strips list markers and padding from ul/ol, which is why bullets were missing. The same applies to the desktop contribution views, which use `prose` throughout.

Bull, base and bear now appear against the price, reusing PriceTargetChart and PriceTargetsSummary. Both return null without target data, so an asset nobody has valued shows nothing rather than an empty frame.

Each field can show its own edit history as a word-level diff. Full revisions of a multi-paragraph section are unreadable on a phone and bury the sentence that actually moved. The diff is tested for the property that matters: it can rebuild both revisions exactly, so it never shows text nobody wrote. It falls back to plain new text past 400 words, where the LCS matrix would block the main thread.

Search took two taps. Focus ran on a 60ms timeout, and iOS only raises the keyboard for a focus() it can attribute to the originating tap — so the field took focus with no keyboard. It now focuses on the first frame the input exists, giving up after ~1s rather than spinning.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
