### PR TITLE
feat(mobile): editable targets, ratings and estimates; dated chart axis

### DIFF
--- a/src/components/mobile/asset/MobileCaseTargets.tsx
+++ b/src/components/mobile/asset/MobileCaseTargets.tsx
@@ -1,0 +1,236 @@
+import { useMemo, useState } from 'react'
+import { clsx } from 'clsx'
+import { Check, Pencil, X } from 'lucide-react'
+import { useAuth } from '../../../hooks/useAuth'
+import { useScenarios } from '../../../hooks/useScenarios'
+import { useAnalystPriceTargets } from '../../../hooks/useAnalystPriceTargets'
+
+interface MobileCaseTargetsProps {
+  assetId: string
+  currentPrice: number | null
+  viewFilter?: 'aggregated' | string
+}
+
+/** Horizons offered when setting a target. Mirrors the desktop presets. */
+const HORIZONS = ['3M', '6M', '12M', '18M', '24M'] as const
+
+const ORDER = ['Bull', 'Base', 'Bear']
+
+/**
+ * The bull, base and bear cases, with their prices and horizons.
+ *
+ * Each scenario is one row: the reader's own target if they have set one, and
+ * the others' beneath. A target without its horizon is not an opinion anyone
+ * can act on — "$140" means something different over three months than over
+ * two years — so the horizon is shown next to the price rather than hidden in
+ * a tooltip.
+ *
+ * Editing sets price and horizon together for the same reason. Offering the
+ * price alone would let a target be saved with no time attached.
+ */
+export function MobileCaseTargets({
+  assetId,
+  currentPrice,
+  viewFilter = 'aggregated',
+}: MobileCaseTargetsProps) {
+  const { user } = useAuth()
+  const { scenarios, isLoading: scenariosLoading } = useScenarios({ assetId })
+  const { priceTargets, isLoading, savePriceTarget } = useAnalystPriceTargets({ assetId })
+
+  const [editing, setEditing] = useState<string | null>(null)
+  const [price, setPrice] = useState('')
+  const [horizon, setHorizon] = useState<string>('12M')
+
+  const isOwnView = viewFilter === 'aggregated' || viewFilter === user?.id
+
+  const rows = useMemo(() => {
+    const defaults = (scenarios ?? []).filter(s => s.is_default)
+    // Fall back to whatever scenarios exist, so an organisation using custom
+    // ones is not shown an empty panel.
+    const list = defaults.length ? defaults : (scenarios ?? [])
+    return [...list].sort((a, b) => {
+      const ai = ORDER.indexOf(a.name)
+      const bi = ORDER.indexOf(b.name)
+      if (ai === -1 && bi === -1) return a.name.localeCompare(b.name)
+      if (ai === -1) return 1
+      if (bi === -1) return -1
+      return ai - bi
+    })
+  }, [scenarios])
+
+  if (scenariosLoading || isLoading) {
+    return <div className="h-32 rounded-xl bg-gray-100 dark:bg-gray-800 animate-pulse" />
+  }
+
+  if (!rows.length) {
+    return (
+      <p className="px-1 py-3 text-sm text-gray-400">
+        No scenarios defined for this asset yet.
+      </p>
+    )
+  }
+
+  const targetsFor = (scenarioId: string) =>
+    (priceTargets ?? []).filter(t => t.scenario_id === scenarioId)
+
+  const begin = (scenarioId: string, existing?: { price: number; timeframe: string | null }) => {
+    setPrice(existing ? String(existing.price) : '')
+    setHorizon(existing?.timeframe || '12M')
+    setEditing(scenarioId)
+  }
+
+  const commit = (scenarioId: string) => {
+    const value = parseFloat(price)
+    // A blank or unparseable price cancels. Saving 0 would publish a target
+    // nobody holds.
+    if (Number.isFinite(value) && value > 0) {
+      savePriceTarget.mutate({
+        scenarioId,
+        price: value,
+        timeframe: horizon,
+        timeframeType: 'preset',
+      })
+    }
+    setEditing(null)
+  }
+
+  return (
+    <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 divide-y divide-gray-100 dark:divide-gray-800">
+      {rows.map(scenario => {
+        const all = targetsFor(scenario.id)
+        const mine = all.find(t => t.user_id === user?.id)
+        const others = all.filter(t => t.user_id !== user?.id)
+        const shown = viewFilter === 'aggregated' ? mine : all.find(t => t.user_id === viewFilter)
+        const isEditing = editing === scenario.id
+
+        return (
+          <div key={scenario.id} className="px-3 py-2.5">
+            <div className="flex items-center gap-2">
+              <span
+                className="h-2.5 w-2.5 rounded-full shrink-0"
+                style={{ backgroundColor: scenario.color || '#6b7280' }}
+                aria-hidden
+              />
+              <span className="text-sm font-semibold text-gray-900 dark:text-white w-12 shrink-0">
+                {scenario.name}
+              </span>
+
+              {isEditing ? (
+                <>
+                  <input
+                    type="number"
+                    inputMode="decimal"
+                    autoFocus
+                    value={price}
+                    onChange={e => setPrice(e.target.value)}
+                    placeholder="Price"
+                    className="flex-1 min-w-0 h-9 px-2 rounded-lg border border-primary-500 bg-white dark:bg-gray-800 text-sm tabular-nums text-gray-900 dark:text-gray-100 focus:outline-none"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => commit(scenario.id)}
+                    disabled={savePriceTarget.isPending}
+                    className="h-9 w-9 shrink-0 flex items-center justify-center rounded-lg bg-primary-600 text-white disabled:opacity-50 no-touch-target"
+                    aria-label="Save target"
+                  >
+                    <Check className="h-4 w-4" />
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setEditing(null)}
+                    className="h-9 w-9 shrink-0 flex items-center justify-center rounded-lg text-gray-500 no-touch-target"
+                    aria-label="Cancel"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                </>
+              ) : (
+                <>
+                  {shown ? (
+                    <>
+                      <span className="text-sm font-semibold tabular-nums text-gray-900 dark:text-white">
+                        ${Number(shown.price).toFixed(2)}
+                      </span>
+                      {/* The horizon is part of the claim, not decoration. */}
+                      <span className="px-1.5 py-0.5 rounded text-[10px] font-semibold bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300">
+                        {shown.timeframe || 'no horizon'}
+                      </span>
+                      {currentPrice != null && currentPrice > 0 && (
+                        <span
+                          className={clsx(
+                            'ml-auto text-xs font-semibold tabular-nums',
+                            Number(shown.price) >= currentPrice
+                              ? 'text-emerald-600 dark:text-emerald-400'
+                              : 'text-red-600 dark:text-red-400'
+                          )}
+                        >
+                          {Number(shown.price) >= currentPrice ? '+' : ''}
+                          {(((Number(shown.price) - currentPrice) / currentPrice) * 100).toFixed(0)}%
+                        </span>
+                      )}
+                    </>
+                  ) : (
+                    <span className="flex-1 text-sm text-gray-400">Not set</span>
+                  )}
+
+                  {isOwnView && (
+                    <button
+                      type="button"
+                      onClick={() =>
+                        begin(
+                          scenario.id,
+                          mine ? { price: Number(mine.price), timeframe: mine.timeframe } : undefined
+                        )
+                      }
+                      className="ml-1 h-8 w-8 shrink-0 flex items-center justify-center rounded-lg text-primary-600 dark:text-primary-400 no-touch-target"
+                      aria-label={`${mine ? 'Edit' : 'Set'} ${scenario.name} target`}
+                    >
+                      <Pencil className="h-3.5 w-3.5" />
+                    </button>
+                  )}
+                </>
+              )}
+            </div>
+
+            {isEditing && (
+              <div className="mt-2 flex items-center gap-1">
+                <span className="text-[11px] text-gray-400 mr-0.5">Horizon</span>
+                {HORIZONS.map(h => (
+                  <button
+                    key={h}
+                    type="button"
+                    onClick={() => setHorizon(h)}
+                    className={clsx(
+                      'px-2 h-7 rounded-md text-[11px] font-semibold border no-touch-target',
+                      horizon === h
+                        ? 'border-primary-500 bg-primary-50 text-primary-700 dark:bg-primary-900/30 dark:text-primary-300'
+                        : 'border-gray-200 text-gray-500 dark:border-gray-700 dark:text-gray-400'
+                    )}
+                  >
+                    {h}
+                  </button>
+                ))}
+              </div>
+            )}
+
+            {viewFilter === 'aggregated' && others.length > 0 && !isEditing && (
+              <ul className="mt-1.5 pl-[1.375rem] space-y-0.5">
+                {others.map(t => (
+                  <li key={t.id} className="flex items-baseline gap-2 text-[11px] text-gray-500 dark:text-gray-400">
+                    <span className="truncate max-w-[7rem]">
+                      {t.user?.full_name ?? 'Colleague'}
+                    </span>
+                    <span className="tabular-nums font-medium text-gray-700 dark:text-gray-300">
+                      ${Number(t.price).toFixed(2)}
+                    </span>
+                    <span>{t.timeframe || '—'}</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/mobile/asset/MobileCaseView.tsx
+++ b/src/components/mobile/asset/MobileCaseView.tsx
@@ -209,7 +209,7 @@ function CaseField({
           <h3 className="mb-1 px-1 text-sm font-semibold text-gray-900 dark:text-gray-100">
             {field.field_name}
           </h3>
-          <MobilePriceTargetChart assetId={assetId} symbol={symbol} />
+          <MobilePriceTargetChart assetId={assetId} symbol={symbol} viewFilter={view} />
         </div>
       )
 

--- a/src/components/mobile/asset/MobileEstimatesField.tsx
+++ b/src/components/mobile/asset/MobileEstimatesField.tsx
@@ -1,7 +1,11 @@
 import { useMemo, useState } from 'react'
-import { Check, Pencil, X } from 'lucide-react'
+import { Check, Pencil, Plus, X } from 'lucide-react'
 import { useAuth } from '../../../hooks/useAuth'
-import { useAnalystEstimates, type AnalystEstimate } from '../../../hooks/useAnalystEstimates'
+import {
+  useAnalystEstimates,
+  useEstimateMetrics,
+  type AnalystEstimate,
+} from '../../../hooks/useAnalystEstimates'
 
 interface MobileEstimatesFieldProps {
   assetId: string
@@ -29,8 +33,13 @@ export function MobileEstimatesField({
 }: MobileEstimatesFieldProps) {
   const { user } = useAuth()
   const { estimates, isLoading, saveEstimate } = useAnalystEstimates({ assetId })
+  const { metrics } = useEstimateMetrics()
   const [editing, setEditing] = useState<string | null>(null)
   const [draft, setDraft] = useState('')
+  const [adding, setAdding] = useState(false)
+  const [newMetric, setNewMetric] = useState('')
+  const [newYear, setNewYear] = useState(String(new Date().getFullYear()))
+  const [newValue, setNewValue] = useState('')
 
   const isOwnView = viewFilter === 'aggregated' || viewFilter === user?.id
 
@@ -83,16 +92,104 @@ export function MobileEstimatesField({
     setEditing(null)
   }
 
+  const addEstimate = () => {
+    const value = parseFloat(newValue)
+    const year = parseInt(newYear, 10)
+    const metricKey = newMetric || (metrics ?? [])[0]?.key
+    if (metricKey && Number.isFinite(value) && Number.isFinite(year)) {
+      saveEstimate.mutate({
+        metricKey,
+        periodType: 'annual',
+        fiscalYear: year,
+        fiscalQuarter: null,
+        value,
+      })
+    }
+    setAdding(false)
+    setNewValue('')
+  }
+
   return (
     <section className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 overflow-hidden">
       <div className="flex items-center gap-2 px-3 py-2 border-b border-gray-100 dark:border-gray-800">
         <h3 className="flex-1 min-w-0 text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
           {title}
         </h3>
+        {isOwnView && !adding && (metrics ?? []).length > 0 && (
+          <button
+            type="button"
+            onClick={() => {
+              setNewMetric((metrics ?? [])[0]?.key ?? '')
+              setAdding(true)
+            }}
+            className="shrink-0 inline-flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-semibold text-primary-600 dark:text-primary-400 active:bg-primary-50 dark:active:bg-primary-900/30 no-touch-target"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            Add
+          </button>
+        )}
       </div>
 
+      {/* Adding a figure needs the metric list, not just the rows that already
+          exist. Without this the field could only edit estimates made
+          elsewhere, which is no use on an asset nobody has modelled yet. */}
+      {adding && (
+        <div className="px-3 py-2.5 border-b border-gray-100 dark:border-gray-800 bg-gray-50 dark:bg-gray-800/50">
+          <div className="flex items-center gap-2">
+            <select
+              value={newMetric}
+              onChange={e => setNewMetric(e.target.value)}
+              className="flex-1 min-w-0 h-9 px-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100"
+            >
+              {(metrics ?? []).map(m => (
+                <option key={m.key} value={m.key}>
+                  {m.label}
+                </option>
+              ))}
+            </select>
+            <input
+              type="number"
+              inputMode="numeric"
+              value={newYear}
+              onChange={e => setNewYear(e.target.value)}
+              aria-label="Fiscal year"
+              className="w-20 shrink-0 h-9 px-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-sm tabular-nums text-gray-900 dark:text-gray-100"
+            />
+          </div>
+          <div className="mt-2 flex items-center gap-2">
+            <input
+              type="number"
+              inputMode="decimal"
+              autoFocus
+              value={newValue}
+              onChange={e => setNewValue(e.target.value)}
+              placeholder="Value"
+              className="flex-1 min-w-0 h-9 px-2 rounded-lg border border-primary-500 bg-white dark:bg-gray-800 text-sm tabular-nums text-gray-900 dark:text-gray-100 focus:outline-none"
+            />
+            <button
+              type="button"
+              onClick={addEstimate}
+              disabled={saveEstimate.isPending}
+              className="h-9 px-3 shrink-0 rounded-lg bg-primary-600 text-white text-sm font-semibold disabled:opacity-50 no-touch-target"
+            >
+              Save
+            </button>
+            <button
+              type="button"
+              onClick={() => setAdding(false)}
+              className="h-9 w-9 shrink-0 flex items-center justify-center rounded-lg text-gray-500 no-touch-target"
+              aria-label="Cancel"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+      )}
+
       {byMetric.length === 0 ? (
-        <p className="px-3 py-2.5 text-sm text-gray-400">No estimates yet.</p>
+        <p className="px-3 py-2.5 text-sm text-gray-400">
+          {isOwnView ? 'No estimates yet — add one above.' : 'No estimates from this analyst.'}
+        </p>
       ) : (
         <div className="divide-y divide-gray-100 dark:divide-gray-800">
           {byMetric.map(([key, group]) => (

--- a/src/components/mobile/asset/MobilePriceTargetChart.tsx
+++ b/src/components/mobile/asset/MobilePriceTargetChart.tsx
@@ -1,21 +1,26 @@
 import { useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { clsx } from 'clsx'
 import {
   Area,
   ComposedChart,
   ReferenceLine,
   ResponsiveContainer,
+  Tooltip,
   XAxis,
   YAxis,
 } from 'recharts'
+import { Maximize2, X } from 'lucide-react'
 import { usePriceTargetChart } from '../../../hooks/usePriceTargetChart'
+import { MobileCaseTargets } from './MobileCaseTargets'
 
 interface MobilePriceTargetChartProps {
   assetId: string
   symbol: string
+  viewFilter?: 'aggregated' | string
 }
 
-const TIMEFRAMES = ['3M', '6M', '1Y', '2Y'] as const
+const TIMEFRAMES = ['1M', '3M', '6M', '1Y', '2Y', '5Y'] as const
 type Timeframe = (typeof TIMEFRAMES)[number]
 
 /** Scenario ordering, as the case is argued rather than alphabetical. */
@@ -36,8 +41,13 @@ const ORDER = ['Bull', 'Base', 'Bear']
  * unreadable, and what the reader needs here is where the three cases sit
  * relative to the price, not who set which.
  */
-export function MobilePriceTargetChart({ assetId, symbol }: MobilePriceTargetChartProps) {
+export function MobilePriceTargetChart({
+  assetId,
+  symbol,
+  viewFilter = 'aggregated',
+}: MobilePriceTargetChartProps) {
   const [timeframe, setTimeframe] = useState<Timeframe>('1Y')
+  const [fullscreen, setFullscreen] = useState(false)
 
   const { historicalPrices, priceTargets, currentPrice, priceChangePercent, loading, error } =
     usePriceTargetChart({ assetId, symbol, timeframe: timeframe as any })
@@ -125,7 +135,14 @@ export function MobilePriceTargetChart({ assetId, symbol }: MobilePriceTargetCha
           {up ? '+' : ''}
           {priceChangePercent?.toFixed(2)}%
         </span>
-        <span className="ml-auto text-[11px] text-gray-400">{timeframe}</span>
+        <button
+          type="button"
+          onClick={() => setFullscreen(true)}
+          className="ml-auto h-8 w-8 flex items-center justify-center rounded-lg text-gray-400 active:bg-gray-100 dark:active:bg-gray-800 no-touch-target"
+          aria-label="Expand chart"
+        >
+          <Maximize2 className="h-4 w-4" />
+        </button>
       </div>
 
       <div className="h-48 px-1 pt-1">
@@ -138,7 +155,17 @@ export function MobilePriceTargetChart({ assetId, symbol }: MobilePriceTargetCha
               </linearGradient>
             </defs>
 
-            <XAxis dataKey="t" type="number" domain={['dataMin', 'dataMax']} hide />
+            <XAxis
+              dataKey="t"
+              type="number"
+              scale="time"
+              domain={['dataMin', 'dataMax']}
+              tickFormatter={formatTick(timeframe)}
+              tick={{ fontSize: 10, fill: '#9ca3af' }}
+              tickLine={false}
+              axisLine={false}
+              minTickGap={28}
+            />
             {/* Y axis hidden, as on the feed charts: the values that matter are
                 labelled directly on the target lines. */}
             <YAxis domain={domain ?? ['dataMin', 'dataMax']} hide />
@@ -173,63 +200,193 @@ export function MobilePriceTargetChart({ assetId, symbol }: MobilePriceTargetCha
         </ResponsiveContainer>
       </div>
 
-      <div className="flex items-center justify-between gap-0.5 px-2 py-1 border-t border-gray-100 dark:border-gray-800">
-        {TIMEFRAMES.map(tf => (
-          <button
-            key={tf}
-            type="button"
-            onClick={() => setTimeframe(tf)}
-            className={clsx(
-              'flex-1 py-1 rounded text-[11px] font-medium transition-colors no-touch-target',
-              tf === timeframe
-                ? 'bg-primary-100 text-primary-700 dark:bg-primary-900/40 dark:text-primary-300'
-                : 'text-gray-500 dark:text-gray-400'
-            )}
-          >
-            {tf}
-          </button>
-        ))}
+      <TimeframeBar value={timeframe} onChange={setTimeframe} />
+
+      <div className="border-t border-gray-100 dark:border-gray-800">
+        <MobileCaseTargets
+          assetId={assetId}
+          currentPrice={currentPrice ?? null}
+          viewFilter={viewFilter}
+        />
       </div>
 
-      {scenarioLines.length > 0 && (
-        <ul className="px-3 py-2 border-t border-gray-100 dark:border-gray-800 space-y-1">
-          {scenarioLines.map(line => {
-            const upside =
-              currentPrice > 0 ? ((line.price - currentPrice) / currentPrice) * 100 : null
-            return (
-              <li key={line.name} className="flex items-baseline gap-2">
-                <span
-                  className="h-2 w-2 rounded-full shrink-0"
-                  style={{ backgroundColor: line.color }}
-                  aria-hidden
-                />
-                <span className="text-sm font-semibold text-gray-900 dark:text-white w-12 shrink-0">
-                  {line.name}
-                </span>
-                <span className="text-sm tabular-nums text-gray-700 dark:text-gray-200">
-                  ${line.price.toFixed(2)}
-                </span>
-                {line.count > 1 && (
-                  <span className="text-[10px] text-gray-400">avg of {line.count}</span>
-                )}
-                {upside != null && (
-                  <span
-                    className={clsx(
-                      'ml-auto text-xs font-semibold tabular-nums',
-                      upside >= 0
-                        ? 'text-emerald-600 dark:text-emerald-400'
-                        : 'text-red-600 dark:text-red-400'
-                    )}
-                  >
-                    {upside >= 0 ? '+' : ''}
-                    {upside.toFixed(0)}%
-                  </span>
-                )}
-              </li>
-            )
-          })}
-        </ul>
+      {fullscreen && (
+        <FullscreenChart
+          symbol={symbol}
+          series={series}
+          domain={domain}
+          lineColor={lineColor}
+          scenarioLines={scenarioLines}
+          timeframe={timeframe}
+          onTimeframe={setTimeframe}
+          onClose={() => setFullscreen(false)}
+        />
       )}
     </div>
   )
+}
+
+
+function TimeframeBar({
+  value,
+  onChange,
+}: {
+  value: Timeframe
+  onChange: (tf: Timeframe) => void
+}) {
+  return (
+    <div className="flex items-center gap-1 px-2 py-1.5 border-t border-gray-100 dark:border-gray-800">
+      {TIMEFRAMES.map(tf => (
+        <button
+          key={tf}
+          type="button"
+          onClick={() => onChange(tf)}
+          aria-pressed={tf === value}
+          className={clsx(
+            'flex-1 h-8 rounded-lg text-xs font-semibold transition-colors no-touch-target',
+            tf === value
+              ? 'bg-gray-900 text-white dark:bg-white dark:text-gray-900'
+              : 'text-gray-500 dark:text-gray-400 active:bg-gray-100 dark:active:bg-gray-800'
+          )}
+        >
+          {tf}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+/**
+ * The chart given the whole screen.
+ *
+ * Inside a scrolling column a chart competes with everything else for height,
+ * and no amount of tuning gives it the aspect ratio a price series wants. Full
+ * screen it gets priced axis labels, a crosshair tooltip and room for the
+ * target lines to sit apart from one another.
+ */
+function FullscreenChart({
+  symbol,
+  series,
+  domain,
+  lineColor,
+  scenarioLines,
+  timeframe,
+  onTimeframe,
+  onClose,
+}: {
+  symbol: string
+  series: { t: number; price: number }[]
+  domain: [number, number] | null
+  lineColor: string
+  scenarioLines: { name: string; color: string; price: number; count: number }[]
+  timeframe: Timeframe
+  onTimeframe: (tf: Timeframe) => void
+  onClose: () => void
+}) {
+  if (typeof document === 'undefined') return null
+
+  return createPortal(
+    <div className="fixed inset-0 z-[90] flex flex-col bg-white dark:bg-gray-900">
+      <div className="flex-shrink-0 flex items-center gap-2 px-3 h-14 pt-safe border-b border-gray-200 dark:border-gray-700">
+        <span className="text-base font-bold text-gray-900 dark:text-white">{symbol}</span>
+        <button
+          type="button"
+          onClick={onClose}
+          className="ml-auto h-10 w-10 flex items-center justify-center rounded-full text-gray-500 dark:text-gray-400 no-touch-target"
+          aria-label="Close chart"
+        >
+          <X className="h-5 w-5" />
+        </button>
+      </div>
+
+      <div className="flex-1 min-h-0 px-1 py-2">
+        <ResponsiveContainer width="100%" height="100%">
+          <ComposedChart data={series} margin={{ top: 8, right: 8, bottom: 4, left: 8 }}>
+            <defs>
+              <linearGradient id={'mptc-full-' + symbol} x1="0" y1="0" x2="0" y2="1">
+                <stop offset="0%" stopColor={lineColor} stopOpacity={0.25} />
+                <stop offset="100%" stopColor={lineColor} stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <XAxis
+              dataKey="t"
+              type="number"
+              scale="time"
+              domain={['dataMin', 'dataMax']}
+              tickFormatter={formatTick(timeframe)}
+              tick={{ fontSize: 11, fill: '#9ca3af' }}
+              tickLine={false}
+              axisLine={false}
+              minTickGap={36}
+            />
+            {/* Full screen has room for prices on the axis, which the inline
+                chart does not. */}
+            <YAxis
+              domain={domain ?? ['dataMin', 'dataMax']}
+              orientation="right"
+              tick={{ fontSize: 11, fill: '#9ca3af' }}
+              tickLine={false}
+              axisLine={false}
+              width={52}
+              tickFormatter={(v: number) => '$' + v.toFixed(0)}
+            />
+            <Tooltip
+              contentStyle={{ fontSize: 12, borderRadius: 8 }}
+              labelFormatter={(t: number) => new Date(t).toLocaleDateString()}
+              formatter={(v: number) => ['$' + v.toFixed(2), 'Price']}
+            />
+            <Area
+              type="monotone"
+              dataKey="price"
+              stroke={lineColor}
+              strokeWidth={2}
+              fill={'url(#mptc-full-' + symbol + ')'}
+              isAnimationActive={false}
+              dot={false}
+            />
+            {scenarioLines.map(line => (
+              <ReferenceLine
+                key={line.name}
+                y={line.price}
+                stroke={line.color}
+                strokeDasharray="4 3"
+                strokeWidth={1.5}
+                label={{
+                  value: line.name + ' $' + line.price.toFixed(0),
+                  position: 'insideTopRight',
+                  fill: line.color,
+                  fontSize: 11,
+                  fontWeight: 700,
+                }}
+              />
+            ))}
+          </ComposedChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className="flex-shrink-0 pb-safe">
+        <TimeframeBar value={timeframe} onChange={onTimeframe} />
+      </div>
+    </div>,
+    document.body
+  )
+}
+
+/**
+ * Tick labels sized to the span. A year of daily candles labelled with full
+ * dates overlaps into unreadability at phone width, so short ranges show the
+ * day and long ranges the month or year.
+ */
+function formatTick(timeframe: Timeframe) {
+  return (value: number) => {
+    const d = new Date(value)
+    if (Number.isNaN(d.getTime())) return ''
+    if (timeframe === '1M' || timeframe === '3M') {
+      return d.toLocaleDateString(undefined, { day: 'numeric', month: 'short' })
+    }
+    if (timeframe === '5Y' || timeframe === '2Y') {
+      return d.toLocaleDateString(undefined, { year: '2-digit', month: 'short' })
+    }
+    return d.toLocaleDateString(undefined, { month: 'short' })
+  }
 }

--- a/src/components/mobile/asset/MobileRatingField.tsx
+++ b/src/components/mobile/asset/MobileRatingField.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 import { clsx } from 'clsx'
 import { useAuth } from '../../../hooks/useAuth'
-import { useAnalystRatings, type ConvictionLevel } from '../../../hooks/useAnalystRatings'
+import { useAnalystRatings, useRatingScales, type ConvictionLevel } from '../../../hooks/useAnalystRatings'
 
 interface MobileRatingFieldProps {
   assetId: string
@@ -20,9 +20,10 @@ const CONVICTIONS: ConvictionLevel[] = ['low', 'medium', 'high']
  * change. That makes it one of the few parts of a case genuinely better suited
  * to a phone than a desktop form.
  *
- * The scale comes from whatever rating is already on the asset. There is no
- * fallback list: inventing Buy/Hold/Sell when an organisation uses a 1-5 scale
- * would write a value its own rating scale does not contain.
+ * The scale is read from the organisation's configured rating scales, so the
+ * buttons appear on an asset nobody has rated yet. There is no hard-coded
+ * fallback: inventing Buy/Hold/Sell for an organisation that uses a 1-5 scale
+ * would write a value its own scale does not contain.
  */
 export function MobileRatingField({
   assetId,
@@ -31,17 +32,23 @@ export function MobileRatingField({
 }: MobileRatingFieldProps) {
   const { user } = useAuth()
   const { ratings, myRating, consensus, isLoading, saveRating } = useAnalystRatings({ assetId })
+  const { scales } = useRatingScales()
 
   const isOwnView = viewFilter === 'aggregated' || viewFilter === user?.id
 
+  // The scale comes from the organisation's configuration, not from whatever
+  // rating happens to exist. Deriving it from existing ratings meant an asset
+  // nobody had rated offered no buttons at all — the field was unusable
+  // exactly when it was most needed.
   const scale = useMemo(() => {
-    const withScale = ratings.find(r => r.rating_scale?.values?.length)
-    const values = withScale?.rating_scale?.values ?? []
+    const fromExisting = ratings.find(r => r.rating_scale?.values?.length)?.rating_scale
+    const configured = (scales ?? []).find(s => s.is_default) ?? (scales ?? [])[0]
+    const chosen = fromExisting ?? configured
     return {
-      id: withScale?.rating_scale_id ?? null,
-      values: [...values].sort((a, b) => a.sort - b.sort),
+      id: chosen?.id ?? null,
+      values: [...(chosen?.values ?? [])].sort((a, b) => a.sort - b.sort),
     }
-  }, [ratings])
+  }, [ratings, scales])
 
   const shown = viewFilter === 'aggregated' ? null : ratings.find(r => r.user_id === viewFilter)
 
@@ -64,10 +71,10 @@ export function MobileRatingField({
 
       <div className="px-3 py-2.5">
         {!scale.id ? (
-          // No rating scale is reachable until someone has rated on it, so
-          // offering buttons would mean guessing the organisation's vocabulary.
+          // Without a configured scale there is no vocabulary to offer, and
+          // guessing one would write values the organisation does not use.
           <p className="text-sm text-gray-400">
-            No rating scale set for this asset yet — set the first rating on desktop.
+            No rating scale is configured for your organisation yet.
           </p>
         ) : isOwnView ? (
           <>


### PR DESCRIPTION
Three fields could be read but not written, and all for the same reason: each derived its vocabulary from the rows that already existed, so with nothing there, there was nothing to edit from.

Rating now reads the organisation's configured scales via useRatingScales, so the buttons appear on an asset nobody has rated — which is when the field is most needed. Still no hard-coded Buy/Hold/Sell: an organisation on a 1-5 scale must not be offered values its own scale does not contain.

Estimates gain an add flow backed by useEstimateMetrics. Previously the field could only edit figures created elsewhere, which is no use on an asset nobody has modelled.

Price target cases are editable per scenario, setting price and horizon together. A target without its horizon is not actionable — $140 means something different over three months than over two years — so the horizon is shown beside the price rather than hidden, and cannot be omitted when setting one. Scenarios come from useScenarios rather than existing targets, so a case can be set for the first time.

The chart gains a dated x-axis, which it had none of, with tick formats scaled to the span so a year of candles does not overlap into unreadability. The timeframe row becomes a real segmented control spanning 1M to 5Y, and a full-screen view adds priced axis labels and a crosshair — inside a scrolling column no height gives a price series the aspect ratio it wants.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
