### PR TITLE
feat(outcomes): capture deferral price snapshots + idea ledger analysis

### DIFF
--- a/docs/archive/personal-tier-spec.md
+++ b/docs/archive/personal-tier-spec.md
@@ -1,0 +1,502 @@
+# Personal Tier — design spec
+
+**Status: NOT PURSUED (Aug 2026). Archived for the architecture, not the plan.**
+
+Written while exploring a free consumer tier with a public idea feed, then set
+aside: a public feed is a consumer-social product with consumer-social
+economics and cold-start problems, which is the wrong shape for this codebase
+and the wrong bet for a solo founder. The direction taken instead is the idea
+ledger — scoring the ideas a user considered and did not act on, inside the
+existing product. See `scripts/idea-ledger-analysis.mjs`.
+
+Two ideas here are still worth stealing if a single-player mode is ever built:
+
+1. **A personal user is an organization of one** (§2 Decision A). Avoids
+   org-less code paths entirely, so no existing RLS or query changes.
+2. **Publishing by projection, not by loosened predicate** (§2 Decision B).
+   A row's presence in the public table *is* the authorization, so there is no
+   policy to get wrong.
+
+Everything below is the original document, unedited.
+
+---
+
+A free, single-player entry point to Tesseract that a person can adopt alone,
+in five minutes, with no organization, no invite, no data import, and no
+colleagues. Its purpose is cheap traction and signal, and it is designed so
+that **nothing about the existing multi-tenant product changes**.
+
+The pitch is not "track your accuracy." It is **"never lose your reasoning."**
+Scoring is a private, unlockable view that arrives only after the user has a
+record worth scoring.
+
+---
+
+## 1. Non-negotiable constraints
+
+These are the constraints the design is built around, not aspirations.
+
+1. **Zero blast radius on the enterprise product.** No existing RLS predicate
+   is loosened. No existing query's org filter is relaxed. The cross-org leak
+   fixed in `20260605120000_quick_thoughts_organization_id.sql` and its
+   siblings must remain fixed by construction, not by care.
+2. **No org-less code paths.** Auditing every query and policy across 265
+   migrations for `organization_id IS NULL` handling is weeks of work with a
+   long tail of leaks. We will not do it.
+3. **Nothing is public unless explicitly published**, per item, by the author.
+4. **Firms can hard-disable publishing**, org-wide, and it defaults to off for
+   existing orgs.
+5. **The record belongs to the user.** Aggregate accuracy is never exposed to
+   an employer, a firm admin, or the public without an explicit user action.
+   This is a product principle, not a setting.
+
+---
+
+## 2. The two load-bearing decisions
+
+Everything else follows from these.
+
+### Decision A — a personal user is an organization of one
+
+Do **not** build an "org-less" mode. Instead, on personal signup, provision a
+real `organizations` row with `kind = 'personal'`, a membership, and set
+`users.current_organization_id` to it.
+
+Why this is the whole trick:
+
+- Every existing query, trigger, policy, and `.eq('organization_id', …)` call
+  works **unchanged**. `useIdeasFeed`'s `ctx.organizationId!` non-null
+  assertion stays valid.
+- No RLS is touched. The tenant-lint guard (`npm run tenant:lint:all`) keeps
+  passing.
+- The entire product you already built — notes, assets, price targets, themes,
+  charting, Trade Lab — becomes single-player usable immediately. Gating is
+  then a *navigation* concern, not an architecture concern.
+- Multi-org is already supported (`OrganizationContext.switchOrg`). When a
+  personal user later joins a firm, they get an org switcher for free, and
+  their personal record follows them between jobs. That portability is the
+  emotional core of the pitch.
+
+Cost: one additive column, one RPC, one branch in signup.
+
+### Decision B — the public feed is a projection, not a loosened predicate
+
+Publishing **copies a snapshot** into a separate public table. The public feed
+reads only that table. It never queries `quick_thoughts`, `trade_queue_items`,
+or `asset_notes`.
+
+Why:
+
+- A row's presence in `public_posts` *is* the authorization. There is no
+  predicate to get wrong, so there is no class of bug that leaks org content.
+- Org-scoped reads keep their existing policies verbatim.
+- It matches the architecture already sketched in
+  `docs/ideas-feed-content-tiles.md` — `public_posts` is that doc's
+  `content_tiles`, arriving earlier and via explicit user action rather than an
+  LLM trigger. When the tile engine is built later it writes to the same table.
+
+Cost: two new tables, one publish RPC, one unpublish RPC.
+
+---
+
+## 3. Data model — additive only
+
+No `ALTER` on any existing column. No policy rewrites.
+
+```sql
+-- A. Personal orgs -----------------------------------------------------------
+ALTER TABLE public.organizations
+  ADD COLUMN IF NOT EXISTS kind TEXT NOT NULL DEFAULT 'firm'
+    CHECK (kind IN ('firm', 'personal'));
+
+-- Org-wide publishing kill switch. OFF for every existing org.
+ALTER TABLE public.organizations
+  ADD COLUMN IF NOT EXISTS allow_public_publishing BOOLEAN NOT NULL DEFAULT FALSE;
+
+-- B. Public projection -------------------------------------------------------
+CREATE TABLE public.public_posts (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  author_id         UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  source_type       TEXT NOT NULL,     -- 'quick_thought' | 'trade_idea' | 'note' | 'claim'
+  source_id         UUID NOT NULL,     -- row in the origin org; never joined from the feed
+  source_org_id     UUID NOT NULL REFERENCES public.organizations(id),
+
+  -- Denormalized snapshot. The feed renders ONLY these columns.
+  headline          TEXT,
+  body              TEXT NOT NULL,
+  asset_id          UUID REFERENCES public.assets(id),
+  symbol            TEXT,              -- denormalized so the feed needs no join
+  sentiment         TEXT,
+  claim_id          UUID,              -- FK to public_claims when this post is a call
+
+  published_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  edited_at         TIMESTAMPTZ,
+  retracted_at      TIMESTAMPTZ,       -- soft delete; retraction is visible, not silent
+
+  reaction_count    INTEGER NOT NULL DEFAULT 0,
+  comment_count     INTEGER NOT NULL DEFAULT 0
+);
+
+-- C. Public claims -----------------------------------------------------------
+-- Mirrors the resolved state of an analyst_price_target so the public feed
+-- never reads the org-scoped table.
+CREATE TABLE public.public_claims (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  author_id         UUID NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  price_target_id   UUID NOT NULL,     -- origin analyst_price_targets row
+  asset_id          UUID NOT NULL REFERENCES public.assets(id),
+  symbol            TEXT NOT NULL,
+
+  direction         TEXT NOT NULL CHECK (direction IN ('up', 'down')),
+  price_at_call     NUMERIC NOT NULL,  -- frozen at publish; this is the immutability anchor
+  target_price      NUMERIC NOT NULL,
+  target_date       DATE NOT NULL,
+  confidence_pct    INTEGER,           -- from analyst_price_targets.probability
+  rationale         TEXT,
+
+  status            TEXT NOT NULL DEFAULT 'open',
+  resolved_at       TIMESTAMPTZ,
+  resolution_price  NUMERIC,
+  accuracy_pct      NUMERIC,
+  days_to_resolve   INTEGER,
+
+  published_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+**Immutability.** Once `public_claims` has a row, `direction`, `price_at_call`,
+`target_price`, `target_date`, and `confidence_pct` are locked by a `BEFORE
+UPDATE` trigger. Changing your mind creates a *new* claim that supersedes the
+old one; the old one still resolves. Without this the record is worthless, and
+this is far cheaper to enforce now than to retrofit.
+
+**RLS.**
+
+- `public_posts` / `public_claims`: `SELECT` to `anon` and `authenticated`
+  where `retracted_at IS NULL`. `INSERT`/`UPDATE`/`DELETE` only via
+  `SECURITY DEFINER` RPCs — never direct from the client.
+- `publish_post(source_type, source_id)` asserts: caller owns the row, the row
+  is `visibility = 'public'`, and the source org has
+  `allow_public_publishing = TRUE` **or** `kind = 'personal'`.
+- Personal orgs get `allow_public_publishing = TRUE` at provisioning. Firms
+  stay `FALSE` until an admin flips it. **This single default is what makes the
+  feature invisible to every existing customer on day one.**
+
+---
+
+## 4. Surface gating
+
+Mirror the established idiom in `src/lib/mobile/mobile-surfaces.ts`. Add
+`src/lib/tiers/tier-surfaces.ts`, keyed the same way (`Tab['type']`), so
+"what a personal user can see" is decided in exactly one file:
+
+```ts
+export type Tier = 'personal' | 'firm'
+
+export interface TierSurface {
+  type: string          // matches Tab['type'] in TabManager.tsx
+  tiers: Tier[]
+  /** Shown on the upgrade card when a personal user reaches a firm surface. */
+  firmReason?: string
+}
+```
+
+Personal tier gets: `ideas`, `asset`, `note`, `search`, `profile`,
+`settings`, `charting`, plus a new `record` surface. Everything else —
+coverage, portfolios, trade book, trade queue, approvals, projects, ops,
+admin — is firm-only and simply never renders in nav.
+
+This composes with `MOBILE_SURFACES` rather than replacing it: a surface must
+pass both registries to render on a phone.
+
+---
+
+## 5. What it looks like
+
+Five screens. Four of them are components you already have.
+
+### 5.1 Onboarding — under 60 seconds
+
+```
+┌──────────────────────────────────────┐
+│                                      │
+│   Your investing memory.             │
+│                                      │
+│   Write down what you think and      │
+│   why. We'll remember, and tell      │
+│   you how it turned out.             │
+│                                      │
+│   [ Continue with email       ]      │
+│   [ Continue with Google      ]      │
+│                                      │
+└──────────────────────────────────────┘
+          ↓
+┌──────────────────────────────────────┐
+│  What do you follow?                 │
+│  ┌────────────────────────────────┐  │
+│  │ 🔍 Search tickers              │  │
+│  └────────────────────────────────┘  │
+│  ✓ NVDA  ✓ MSFT  ✓ TSM   + AAPL     │
+│  + GOOGL  + AMZN  + META             │
+│                        [ Done → ]    │
+└──────────────────────────────────────┘
+```
+
+No org step, no invite, no team. Behind it: `create_personal_org()` RPC →
+org row (`kind='personal'`, name = user's name) → membership → coverage rows
+for the picked tickers so the feed and attention system have something to
+rank against on first load.
+
+### 5.2 Home — the feed
+
+`IdeasFeedPage` with the source swapped to `public_posts`. Same
+`FeedCard` / `FeedChart` / `SignalFeedCard` components.
+
+```
+┌────────────────────────────────────────────┐
+│  Tesseract              🔍      ⚙          │
+│  ┌──────────┬──────────┬────────────────┐  │
+│  │ Following│ Discover │ My Record      │  │
+│  └──────────┴──────────┴────────────────┘  │
+├────────────────────────────────────────────┤
+│ ⏱ 3 of your calls resolve this month   →   │  ← own-stake strip
+├────────────────────────────────────────────┤
+│ ┌────────────────────────────────────────┐ │
+│ │ Sarah Chen  · 2h                       │ │
+│ │ ▲ 64% · 41 calls                       │ │  ← record badge, opt-in
+│ │                                        │ │
+│ │ NVDA  $412 → $480 by Q3   ▲ 16%        │ │
+│ │ "Hyperscaler capex guides all revised  │ │
+│ │  up; supply is the only constraint."   │ │
+│ │  ╭──────────────────────────────────╮  │ │
+│ │  │      ╱‾‾╲      ╱╲   ┈┈┈┈┈ target │  │ │
+│ │  │   ╱‾╯    ╲╱‾‾╲╱                  │  │ │
+│ │  ╰──────────────────────────────────╯  │ │
+│ │  ♡ 24   💬 6   ⤴                       │ │
+│ └────────────────────────────────────────┘ │
+│ ┌────────────────────────────────────────┐ │
+│ │ ⚡ DEBATE                               │ │  ← existing SignalFeedCard
+│ │ Two people you follow disagree on TSM   │ │
+│ └────────────────────────────────────────┘ │
+│                                    ( + )   │
+└────────────────────────────────────────────┘
+```
+
+The record badge (`▲ 64% · 41 calls`) is **opt-in per user** and only offered
+once they have ≥ 10 resolved claims. Off by default. It is a flex people
+choose, not an audit imposed. Below 10 resolved it renders as
+`· 4 calls tracked` with no percentage — never a percentage on a small sample.
+
+### 5.3 Capture — the core loop
+
+`QuickThoughtCapture.tsx` already has the visibility selector including
+`public`. Add a second mode.
+
+```
+┌────────────────────────────────────────────┐
+│  ┌──────────┬──────────┐              ✕    │
+│  │ Thought  │ ✓ Call   │                   │
+│  └──────────┴──────────┘                   │
+│                                            │
+│   NVDA   Nvidia Corp          $412.30      │
+│                                            │
+│   ▲ Up          ▼ Down                     │
+│                                            │
+│   Target  $ 480          by  Q3 2026 ▾     │
+│                          ↑ +16.4%          │
+│                                            │
+│   How confident?                           │
+│   ───────────●──────────  70%              │
+│                                            │
+│   Why (one line)                           │
+│   ┌──────────────────────────────────────┐ │
+│   │ Capex guides revised up across all   │ │
+│   └──────────────────────────────────────┘ │
+│                                            │
+│   🔒 Private ▾                    [ Post ] │
+└────────────────────────────────────────────┘
+```
+
+Writes to `analyst_price_targets` in the personal org — the **existing** table,
+with its existing `create_outcome_for_target()` trigger. If visibility is
+Public, the client then calls `publish_post` + `publish_claim`.
+
+Private is the default and it must stay the default. Most value accrues to
+users who never publish anything.
+
+### 5.4 My Record — the private page
+
+```
+┌────────────────────────────────────────────┐
+│  My Record                                 │
+│                                            │
+│   14 open      ·   23 resolved             │
+│                                            │
+│  ┌──────────────────────────────────────┐  │
+│  │  🔒 Calibration                      │  │
+│  │  ████████████░░░░  23 / 30           │  │
+│  │  7 more resolved calls unlocks this. │  │
+│  └──────────────────────────────────────┘  │
+│                                            │
+│  RESOLVING SOON                            │
+│   NVDA  $480 by Mar 31    $471  ▲ 98%      │
+│   TSM   $210 by Apr 15    $186  ▼ 89%      │
+│                                            │
+│  RESOLVED                                  │
+│   ✓ MSFT $480 · hit in 47d · +2.1% over    │
+│   ✗ ADBE $620 · expired at $541            │
+│                                            │
+│  ─────────────────────────────────────     │
+│  Only you can see this page.               │
+└────────────────────────────────────────────┘
+```
+
+The lock is a real gate, not a paywall — calibration on n < 30 is noise, and
+saying so builds more trust than showing a number. It is also the single best
+retention mechanic in the product: a progress bar that only advances by using
+it, whose payoff arrives on the market's schedule rather than yours.
+
+Calibration, when unlocked: bucket resolved claims by stated
+`confidence_pct` (50–60, 60–70, …), plot stated vs. actual hit rate against
+the 45° line, and report a Brier score. This is the one genuinely new metric —
+`useScorecards.ts:310` currently computes `hitRate * 0.6 + avgAccuracy * 0.4`
+and discards `probability` entirely, even though it is already stored on every
+target.
+
+### 5.5 The resolution artifact — the growth loop
+
+When `price_target_outcomes.status` flips to `hit` or `missed`, notify the
+author. Tapping it opens a shareable card.
+
+```
+┌────────────────────────────────────────┐
+│                                        │
+│   NVDA                          ✓ HIT  │
+│                                        │
+│   $412  →  $480                        │
+│   Called 14 Jan · Hit in 47 days       │
+│                                        │
+│   ╭────────────────────────────────╮   │
+│   │              ╱‾╲    ┈┈┈┈┈┈┈┈┈  │   │
+│   │      ╱‾╲   ╱╯   ╲╱             │   │
+│   │  ╱‾╲╱   ╲╱                     │   │
+│   ╰────────────────────────────────╯   │
+│                                        │
+│   "Hyperscaler capex guides all        │
+│    revised up."                        │
+│                                        │
+│   Sarah Chen · tesseract.app           │
+└────────────────────────────────────────┘
+        [ Share ]    [ Keep private ]
+```
+
+This card is the entire marketing budget. It carries the product's whole
+thesis in one image, it is generated automatically, and people only share
+their wins — which is fine, because the private record stays complete either
+way and the public graph still gets built.
+
+- **v1:** render the card as real DOM, rasterize client-side (`html-to-image`),
+  hand to the Web Share API. Zero infrastructure.
+- **v2:** an `og-card` Edge Function rendering the same layout server-side so
+  links unfurl on X. This matters more than it sounds — an unfurled card is the
+  difference between a link and an ad. Defer it, but design the layout once so
+  both renderers share it.
+
+---
+
+## 6. Claims and resolution — mostly already built
+
+This is the part that is far cheaper than it looks. Already in the schema from
+`20251230000000_add_price_target_analytics.sql`:
+
+- `price_target_outcomes` — `status` (pending/hit/missed/expired/cancelled),
+  `hit_date`, `hit_price`, `accuracy_pct`, `days_to_hit`
+- `create_outcome_for_target()` — trigger that opens an outcome on insert
+- `calculate_accuracy()`, `calculate_target_date()`
+- `update_analyst_performance()` + `analyst_performance_snapshots`
+- `price_history_cache`
+
+And `supabase/functions/yahoo-chart-proxy` is a working free price source.
+
+What is missing is only the **sweep**: a scheduled job that walks pending
+outcomes, pulls closes since `target_set_date`, marks hit/missed/expired, and
+mirrors the result onto `public_claims`. One Edge Function on a daily cron.
+
+Resolution rule, stated explicitly so it can't drift: a claim is `hit` if the
+**daily close** touches the target at any point on or before `target_date`;
+`missed` if `target_date` passes without that; direction-aware. Intraday highs
+are excluded deliberately — they are noisy and unfalsifiable to a reader.
+
+---
+
+## 7. Blast radius on the existing product
+
+| Area | Change |
+|---|---|
+| Existing RLS policies | none |
+| Existing queries / org filters | none |
+| `organizations` | two additive columns, both defaulted safely |
+| Firm users' experience | none, until an admin sets `allow_public_publishing` |
+| `tenant:lint:all` | unaffected; `public_posts` added to the known-unscoped allowlist with a written justification |
+| New tables | `public_posts`, `public_claims` — read-only to clients |
+| Rollback | drop the two tables and the RPCs; nothing else references them |
+
+The whole personal tier sits behind one flag (`VITE_PERSONAL_TIER`) so it can
+ship to `main` dark and be flipped on independently of deploys.
+
+---
+
+## 8. Build order
+
+Sequenced so something is demoable early and nothing is wasted if you stop.
+
+| # | Slice | Rough size |
+|---|---|---|
+| 1 | `kind` + `allow_public_publishing` columns, `create_personal_org()` RPC, signup branch | S |
+| 2 | `tier-surfaces.ts` registry + nav gating | S–M |
+| 3 | Call mode in `QuickThoughtCapture` → `analyst_price_targets` | S |
+| 4 | Resolution sweep Edge Function + daily cron | M |
+| 5 | My Record page (open / resolved lists, locked calibration meter) | M |
+| 6 | Resolution artifact card + client-side share | M |
+| 7 | `public_posts` / `public_claims` + publish RPCs | M |
+| 8 | Feed source swap behind `mode='discover'` | M |
+| 9 | Onboarding flow | S |
+| 10 | Calibration view unlock | M |
+
+Slices 1 and 3–6 give a complete, useful, **entirely private** product with no
+public surface at all. That is worth shipping on its own, and it is the
+lower-risk half. Public (7–9) can follow once the private loop retains.
+
+---
+
+## 9. What signal this is actually for
+
+Define these before launch or the data won't mean anything.
+
+- **Activation:** % of signups that log ≥ 1 claim in week 1.
+- **The real one — return-after-resolution:** % of users who open the app
+  within 48h of their first claim resolving. This tests the single hypothesis
+  the whole product rests on: *does automated feedback on your own judgment
+  pull people back?* If this is weak, the thesis is wrong and no amount of feed
+  polish saves it.
+- **Retention:** % still logging in week 4. Idea journals die here; the
+  resolution loop is the only defense.
+- **Publish rate:** % of claims made public. Low is fine and expected — but if
+  it is near zero, the public feed will never have supply and slices 7–9 should
+  be cut rather than built.
+
+---
+
+## 10. Open questions
+
+1. **Naming.** "Personal tier" is internal. The public-facing frame should
+   lead with memory, not measurement.
+2. **Asset universe.** Personal orgs need `assets` rows for arbitrary tickers.
+   Does the existing asset table cover the retail long tail, or is on-demand
+   creation from the Yahoo proxy needed at capture time?
+3. **Personal → firm migration.** When a personal user joins a firm, does their
+   record move, copy, or stay separate? Recommend: stays personal, always;
+   portability is the promise. Needs a UI answer, not a schema one.
+4. **Moderation.** A public feed of financial claims will attract promotion.
+   Minimum viable: report button, rate limit on publish, and no public feed
+   until slice 7 is genuinely needed.

--- a/scripts/idea-ledger-analysis.mjs
+++ b/scripts/idea-ledger-analysis.mjs
@@ -1,0 +1,492 @@
+#!/usr/bin/env node
+/**
+ * idea-ledger-analysis.mjs
+ *
+ * READ-ONLY. Writes nothing to the database. Ever.
+ *
+ * Answers the question the product doesn't currently ask: what happened to
+ * the ideas nobody acted on?
+ *
+ * The Decision Outcomes page follows approved ideas into execution and drops
+ * rejected/deferred/cancelled ones on the floor (`showRejected` defaults to
+ * false, and every impact metric filters `stage === 'approved'`). But the
+ * ideas that were passed on are the larger and more interesting half: nobody
+ * anywhere can tell you whether the calls they *didn't* make were right.
+ *
+ * This script reconstructs that retroactively from data that already exists,
+ * so the thesis can be tested before any feature is built.
+ *
+ * ── How a price anchor is resolved ──────────────────────────────────────────
+ * For each idea, in order:
+ *   1. decision_price_snapshots for the matching snapshot_type (exact, cheap)
+ *   2. the daily close on the decision date, from Yahoo (backfill)
+ *   3. unscoreable — counted and reported, never silently dropped
+ *
+ * Step 3 matters as much as the others. If most ideas can't be anchored, that
+ * is the finding, and it says build the recorder before the report.
+ *
+ * ── How "right" is defined ─────────────────────────────────────────────────
+ * Direction-adjusted against the idea's action:
+ *   buy / add   → the idea wanted MORE exposure; the asset going up means the
+ *                 idea was right, so passing on it was a MISS.
+ *   sell / trim → the idea wanted LESS exposure; the asset going down means
+ *                 the idea was right, so passing on it was a MISS.
+ * A pass is a DODGE when the idea would have been wrong.
+ *
+ * Daily closes only — no intraday. Noisier data would not change any
+ * conclusion at these horizons and would make the numbers harder to defend.
+ *
+ * The headline output is not the pass hit-rate on its own — that number is
+ * meaningless in isolation. It is the comparison between ideas that were
+ * acted on and ideas that were passed on, by the same people. If the passes
+ * beat the acts, that is worth knowing and nothing today would surface it.
+ *
+ * ── Usage ──────────────────────────────────────────────────────────────────
+ *   SUPABASE_URL=... SUPABASE_SERVICE_KEY=... node scripts/idea-ledger-analysis.mjs
+ *
+ *   --org <uuid>            restrict to one organization
+ *   --user <uuid>           restrict to one creator
+ *   --since <ISO date>      ignore ideas created before this (default: all time)
+ *   --min-days <n>          skip ideas anchored fewer than n days ago (default 30)
+ *   --silent-pass-days <n>  idle days before an open idea counts as a pass (default 60)
+ *   --limit <n>             cap ideas fetched (default 5000)
+ *   --csv <path>            also write the per-idea rows to CSV
+ *   --no-backfill           snapshots only; skip all Yahoo calls
+ */
+
+import { createClient } from '@supabase/supabase-js'
+import { writeFile } from 'node:fs/promises'
+
+// ============================================================
+// Config
+// ============================================================
+
+const SUPABASE_URL = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_KEY || process.env.VITE_SUPABASE_ANON_KEY
+
+if (!SUPABASE_URL || !SUPABASE_KEY) {
+  console.error('ERROR: Set SUPABASE_URL and SUPABASE_SERVICE_KEY (or VITE_ variants)')
+  process.exit(1)
+}
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
+  auth: { persistSession: false },
+})
+
+function arg(name, fallback = undefined) {
+  const i = process.argv.indexOf(`--${name}`)
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : fallback
+}
+function flag(name) {
+  return process.argv.includes(`--${name}`)
+}
+
+const OPTS = {
+  org: arg('org'),
+  user: arg('user'),
+  since: arg('since'),
+  minDays: Number(arg('min-days', '30')),
+  silentPassDays: Number(arg('silent-pass-days', '60')),
+  limit: Number(arg('limit', '5000')),
+  csv: arg('csv'),
+  backfill: !flag('no-backfill'),
+}
+
+/** Ideas that were acted on. */
+const ACTED = new Set(['approved', 'executed'])
+/** Ideas that were consciously not acted on. */
+const PASSED = new Set(['rejected', 'cancelled'])
+/** Not yet dispositioned. Split into open vs silent_pass by idle time. */
+const OPEN = new Set(['idea', 'discussing', 'deciding', 'simulating'])
+
+/** status → snapshot_type recorded by decision-snapshot-service. */
+const STATUS_SNAPSHOT_TYPE = {
+  approved: 'approval',
+  executed: 'approval',
+  rejected: 'rejection',
+  cancelled: 'cancellation',
+}
+
+/** Actions wanting MORE exposure; the rest want less. */
+const LONG_ACTIONS = new Set(['buy', 'add'])
+
+const DAY_MS = 86_400_000
+
+// ============================================================
+// Fetch
+// ============================================================
+
+async function fetchIdeas() {
+  let q = supabase
+    .from('trade_queue_items')
+    .select(
+      'id, asset_id, portfolio_id, organization_id, action, status, stage, outcome, ' +
+      'outcome_at, decision_outcome, decided_at, deferred_until, created_at, created_by, ' +
+      'updated_at, stage_changed_at, archived_at, target_price, conviction, rationale, ' +
+      'assets:asset_id(id, symbol, company_name, current_price)',
+    )
+    .is('deleted_at', null)
+    .order('created_at', { ascending: false })
+    .limit(OPTS.limit)
+
+  if (OPTS.org) q = q.eq('organization_id', OPTS.org)
+  if (OPTS.user) q = q.eq('created_by', OPTS.user)
+  if (OPTS.since) q = q.gte('created_at', OPTS.since)
+
+  const { data, error } = await q
+  if (error) throw new Error(`Fetch ideas failed: ${error.message}`)
+  return data || []
+}
+
+async function fetchSnapshots(ideaIds) {
+  const byIdea = new Map()
+  const CHUNK = 200
+  for (let i = 0; i < ideaIds.length; i += CHUNK) {
+    const { data, error } = await supabase
+      .from('decision_price_snapshots')
+      .select('trade_queue_item_id, snapshot_type, snapshot_price, snapshot_at')
+      .in('trade_queue_item_id', ideaIds.slice(i, i + CHUNK))
+    if (error) throw new Error(`Fetch snapshots failed: ${error.message}`)
+    for (const row of data || []) {
+      if (!byIdea.has(row.trade_queue_item_id)) byIdea.set(row.trade_queue_item_id, {})
+      byIdea.get(row.trade_queue_item_id)[row.snapshot_type] = {
+        price: Number(row.snapshot_price),
+        at: row.snapshot_at,
+      }
+    }
+  }
+  return byIdea
+}
+
+// ============================================================
+// Yahoo daily closes
+// ============================================================
+
+/**
+ * One request per symbol covering the full window any idea on it needs,
+ * then closes are looked up by date. Keeps this to ~N requests for N
+ * distinct tickers rather than one per idea.
+ */
+async function fetchDailyCloses(symbol, fromMs, toMs) {
+  const period1 = Math.floor((fromMs - 7 * DAY_MS) / 1000)
+  const period2 = Math.floor((toMs + DAY_MS) / 1000)
+  const url =
+    `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}` +
+    `?interval=1d&period1=${period1}&period2=${period2}`
+
+  const res = await fetch(url, {
+    headers: { 'User-Agent': 'Mozilla/5.0 (compatible; TesseractLedger/1.0)' },
+  })
+  if (!res.ok) return null
+
+  const json = await res.json()
+  const result = json?.chart?.result?.[0]
+  const stamps = result?.timestamp
+  const closes = result?.indicators?.quote?.[0]?.close
+  if (!Array.isArray(stamps) || !Array.isArray(closes)) return null
+
+  // date (YYYY-MM-DD, UTC) → close
+  const series = new Map()
+  for (let i = 0; i < stamps.length; i++) {
+    const c = closes[i]
+    if (c == null || !isFinite(c)) continue
+    series.set(new Date(stamps[i] * 1000).toISOString().slice(0, 10), Number(c))
+  }
+  return series
+}
+
+/** Close on `date`, walking back up to 5 days over weekends/holidays. */
+function closeOnOrBefore(series, date) {
+  if (!series) return null
+  const d = new Date(date)
+  for (let i = 0; i < 6; i++) {
+    const key = d.toISOString().slice(0, 10)
+    if (series.has(key)) return series.get(key)
+    d.setUTCDate(d.getUTCDate() - 1)
+  }
+  return null
+}
+
+async function mapWithConcurrency(items, limit, fn) {
+  const out = new Array(items.length)
+  let cursor = 0
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, async () => {
+      while (cursor < items.length) {
+        const i = cursor++
+        try {
+          out[i] = await fn(items[i], i)
+        } catch {
+          out[i] = null
+        }
+      }
+    }),
+  )
+  return out
+}
+
+// ============================================================
+// Classification
+// ============================================================
+
+/**
+ * An idea sitting untouched in an open stage for months is a pass. Nobody
+ * clicked reject, but nobody acted either, and not deciding is deciding.
+ *
+ * This is not a hypothetical: as of Aug 2026, production held 114 open ideas
+ * against 2 explicitly rejected ones, and 86% of the open ones had been idle
+ * 30+ days. Scoring only the explicit rejections would measure almost nothing.
+ * Silent passes are the real inventory.
+ */
+function idleDays(idea) {
+  const touched = idea.stage_changed_at || idea.updated_at || idea.created_at
+  return (Date.now() - new Date(touched).getTime()) / DAY_MS
+}
+
+function classify(idea) {
+  const status = idea.status
+  if (ACTED.has(status)) return 'acted'
+  if (PASSED.has(status)) return 'passed'
+  if (idea.outcome === 'deferred' || idea.decision_outcome === 'deferred') return 'passed'
+  if (status === 'archived') return idea.outcome ? 'passed' : 'abandoned'
+  if (OPEN.has(status)) {
+    return idleDays(idea) >= OPTS.silentPassDays ? 'silent_pass' : 'open'
+  }
+  return 'other'
+}
+
+/**
+ * The date the price anchor is taken from.
+ *
+ * Explicit dispositions anchor at the decision. Silent passes and abandoned
+ * ideas anchor at CREATION — the honest question for an idea nobody ever
+ * dispositioned is "I thought of this and never acted; what would it have
+ * done", and creation is the only moment that was ever real.
+ */
+function decisionDate(idea) {
+  const d = classify(idea)
+  if (d === 'silent_pass' || d === 'abandoned') return idea.created_at
+  return idea.outcome_at || idea.decided_at || idea.archived_at || idea.created_at
+}
+
+/** Return the idea implied, sign-adjusted for direction. */
+function directionalReturn(anchorPrice, currentPrice, action) {
+  const raw = (currentPrice - anchorPrice) / anchorPrice
+  return LONG_ACTIONS.has(action) ? raw : -raw
+}
+
+// ============================================================
+// Main
+// ============================================================
+
+async function main() {
+  console.log('Idea Ledger — retroactive analysis (read-only)\n')
+
+  const ideas = await fetchIdeas()
+  console.log(`Fetched ${ideas.length} ideas.`)
+  if (ideas.length === 0) {
+    console.log('\nNothing to analyse. Widen --since / --limit, or check org filter.')
+    return
+  }
+
+  const snapshots = await fetchSnapshots(ideas.map(i => i.id))
+  console.log(`Found snapshots for ${snapshots.size} of them.\n`)
+
+  // ── Bucket ──
+  const buckets = { acted: [], passed: [], silent_pass: [], open: [], abandoned: [], other: [] }
+  for (const idea of ideas) buckets[classify(idea)].push(idea)
+
+  const cutoff = Date.now() - OPTS.minDays * DAY_MS
+  const scorable = [
+    ...buckets.acted, ...buckets.passed, ...buckets.silent_pass, ...buckets.abandoned,
+  ].filter(i => {
+    const d = decisionDate(i)
+    return d && new Date(d).getTime() <= cutoff && i.assets?.symbol
+  })
+
+  console.log('DISPOSITION')
+  console.log(`  acted on          ${String(buckets.acted.length).padStart(5)}`)
+  console.log(`  passed (explicit) ${String(buckets.passed.length).padStart(5)}  (rejected / cancelled / deferred)`)
+  console.log(`  passed (silent)   ${String(buckets.silent_pass.length).padStart(5)}  (open, untouched ${OPTS.silentPassDays}d+)`)
+  console.log(`  abandoned         ${String(buckets.abandoned.length).padStart(5)}  (archived, no outcome set)`)
+  console.log(`  still active      ${String(buckets.open.length).padStart(5)}`)
+  console.log(`  other             ${String(buckets.other.length).padStart(5)}`)
+  console.log(`  → eligible        ${String(scorable.length).padStart(5)}  (anchor >${OPTS.minDays}d ago, has ticker)\n`)
+
+  // ── Price series, one fetch per symbol ──
+  const needBackfill = new Map() // symbol → [minMs, maxMs]
+  for (const idea of scorable) {
+    const type = STATUS_SNAPSHOT_TYPE[idea.status]
+    if (type && snapshots.get(idea.id)?.[type]) continue // snapshot covers it
+    const sym = idea.assets.symbol
+    const t = new Date(decisionDate(idea)).getTime()
+    const cur = needBackfill.get(sym)
+    needBackfill.set(sym, cur ? [Math.min(cur[0], t), Math.max(cur[1], t)] : [t, t])
+  }
+
+  const seriesBySymbol = new Map()
+  if (OPTS.backfill && needBackfill.size > 0) {
+    console.log(`Backfilling daily closes for ${needBackfill.size} tickers...`)
+    const entries = [...needBackfill.entries()]
+    const results = await mapWithConcurrency(entries, 4, async ([sym, [lo, hi]]) =>
+      [sym, await fetchDailyCloses(sym, lo, hi)],
+    )
+    for (const r of results) if (r && r[1]) seriesBySymbol.set(r[0], r[1])
+    console.log(`  resolved ${seriesBySymbol.size}/${needBackfill.size}\n`)
+  }
+
+  // ── Score ──
+  const rows = []
+  const unscoreable = { noAnchor: 0, noCurrent: 0 }
+
+  for (const idea of scorable) {
+    const symbol = idea.assets.symbol
+    const dDate = decisionDate(idea)
+    const type = STATUS_SNAPSHOT_TYPE[idea.status]
+
+    let anchor = null
+    let anchorSource = null
+    const snap = type ? snapshots.get(idea.id)?.[type] : null
+    if (snap?.price > 0) {
+      anchor = snap.price
+      anchorSource = 'snapshot'
+    } else {
+      const c = closeOnOrBefore(seriesBySymbol.get(symbol), dDate)
+      if (c > 0) {
+        anchor = c
+        anchorSource = 'backfill'
+      }
+    }
+    if (!anchor) { unscoreable.noAnchor++; continue }
+
+    const current = Number(idea.assets.current_price)
+    if (!(current > 0)) { unscoreable.noCurrent++; continue }
+
+    const disposition = classify(idea)
+    const ret = directionalReturn(anchor, current, idea.action)
+
+    rows.push({
+      id: idea.id,
+      symbol,
+      company: idea.assets.company_name || '',
+      action: idea.action,
+      disposition,
+      status: idea.status,
+      decided_at: dDate,
+      days_since: Math.round((Date.now() - new Date(dDate).getTime()) / DAY_MS),
+      anchor_price: anchor,
+      anchor_source: anchorSource,
+      current_price: current,
+      idea_return_pct: ret * 100,
+      // For any flavour of pass: the idea being right means passing was a miss.
+      verdict: disposition === 'acted'
+        ? (ret > 0.001 ? 'right' : ret < -0.001 ? 'wrong' : 'flat')
+        : (ret > 0.001 ? 'miss' : ret < -0.001 ? 'dodge' : 'flat'),
+      created_by: idea.created_by,
+      organization_id: idea.organization_id,
+      conviction: idea.conviction || '',
+    })
+  }
+
+  console.log('COVERAGE')
+  console.log(`  scored            ${String(rows.length).padStart(5)}`)
+  console.log(`    from snapshot   ${String(rows.filter(r => r.anchor_source === 'snapshot').length).padStart(5)}`)
+  console.log(`    from backfill   ${String(rows.filter(r => r.anchor_source === 'backfill').length).padStart(5)}`)
+  console.log(`  no anchor price   ${String(unscoreable.noAnchor).padStart(5)}`)
+  console.log(`  no current price  ${String(unscoreable.noCurrent).padStart(5)}\n`)
+
+  if (rows.length === 0) {
+    console.log('Nothing scoreable. That is itself the finding: the data to answer')
+    console.log('this question is not being recorded yet.')
+    return
+  }
+
+  // ── The headline comparison ──
+  const acted = rows.filter(r => r.disposition === 'acted')
+  const passedExplicit = rows.filter(r => r.disposition === 'passed')
+  const passedSilent = rows.filter(r => r.disposition === 'silent_pass' || r.disposition === 'abandoned')
+  const passed = [...passedExplicit, ...passedSilent]
+
+  const median = xs => {
+    if (xs.length === 0) return null
+    const s = [...xs].sort((a, b) => a - b)
+    const m = s.length >> 1
+    return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2
+  }
+  const pct = (n, d) => (d === 0 ? '—' : `${((n / d) * 100).toFixed(0)}%`)
+  const fmt = v => (v == null ? '—' : `${v >= 0 ? '+' : ''}${v.toFixed(1)}%`)
+
+  console.log('THE COMPARISON  (the number that matters)')
+  console.log('                        n      right   median idea return')
+  const line = (label, list, rightVerdict) => console.log(
+    `  ${label.padEnd(18)}${String(list.length).padStart(5)}` +
+    `      ${pct(list.filter(r => r.verdict === rightVerdict).length, list.length).padStart(4)}` +
+    `      ${fmt(median(list.map(r => r.idea_return_pct))).padStart(7)}`,
+  )
+  line('acted on', acted, 'right')
+  line('passed (explicit)', passedExplicit, 'dodge')
+  line('passed (silent)', passedSilent, 'dodge')
+  line('all passes', passed, 'dodge')
+  console.log('\n  "right" = the idea worked. For a pass, that means the pass was a MISS,')
+  console.log('  so the passed-on row shows the share correctly DODGED. If passes and')
+  console.log('  acts score alike, selection is adding nothing — that is the finding.\n')
+
+  const misses = passed.filter(r => r.verdict === 'miss').sort((a, b) => b.idea_return_pct - a.idea_return_pct)
+  const dodges = passed.filter(r => r.verdict === 'dodge').sort((a, b) => a.idea_return_pct - b.idea_return_pct)
+
+  const table = (title, list) => {
+    if (list.length === 0) return
+    console.log(title)
+    for (const r of list.slice(0, 10)) {
+      console.log(
+        `  ${r.symbol.padEnd(8)} ${r.action.padEnd(5)} ` +
+        `${String(r.days_since).padStart(4)}d  ` +
+        `${fmt(r.idea_return_pct).padStart(8)}  ${r.disposition}`,
+      )
+    }
+    console.log()
+  }
+  table('BIGGEST MISSES  (passed on, idea would have worked)', misses)
+  table('BEST DODGES  (passed on, idea would have failed)', dodges)
+
+  // ── Per-person, only where n is large enough to mean anything ──
+  const byUser = new Map()
+  for (const r of rows) {
+    if (!r.created_by) continue
+    if (!byUser.has(r.created_by)) byUser.set(r.created_by, [])
+    byUser.get(r.created_by).push(r)
+  }
+  const meaningful = [...byUser.entries()].filter(([, rs]) => rs.length >= 10)
+  if (meaningful.length > 0) {
+    console.log('BY PERSON  (n >= 10 only; smaller samples are noise)')
+    for (const [uid, rs] of meaningful) {
+      const a = rs.filter(r => r.disposition === 'acted')
+      const p = rs.filter(r => r.disposition !== 'acted')
+      console.log(
+        `  ${uid.slice(0, 8)}  acted ${String(a.length).padStart(3)} ` +
+        `(${pct(a.filter(r => r.verdict === 'right').length, a.length)})   ` +
+        `passed ${String(p.length).padStart(3)} ` +
+        `(${pct(p.filter(r => r.verdict === 'dodge').length, p.length)} dodged)`,
+      )
+    }
+    console.log()
+  } else {
+    console.log('BY PERSON  skipped — nobody has 10+ scoreable ideas yet.\n')
+  }
+
+  if (OPTS.csv) {
+    const cols = Object.keys(rows[0])
+    const esc = v => {
+      const s = v == null ? '' : String(v)
+      return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s
+    }
+    const csv = [cols.join(','), ...rows.map(r => cols.map(c => esc(r[c])).join(','))].join('\n')
+    await writeFile(OPTS.csv, csv, 'utf8')
+    console.log(`Wrote ${rows.length} rows → ${OPTS.csv}`)
+  }
+}
+
+main().catch(err => {
+  console.error('\nFAILED:', err.message)
+  process.exit(1)
+})

--- a/src/lib/services/decision-snapshot-service.ts
+++ b/src/lib/services/decision-snapshot-service.ts
@@ -18,7 +18,7 @@ import { supabase } from '../supabase'
 // Types
 // ============================================================
 
-export type SnapshotType = 'approval' | 'rejection' | 'cancellation'
+export type SnapshotType = 'approval' | 'rejection' | 'cancellation' | 'deferral'
 export type PriceSource = 'db_cached' | 'live_quote' | 'manual' | 'backfill'
 
 export interface DecisionPriceSnapshot {
@@ -68,6 +68,32 @@ export async function captureDecisionPriceSnapshot(params: {
   } = params
 
   try {
+    // Preserve-first types (deferral) must not be overwritten by a later
+    // occurrence of the same outcome. Checked before the price fetch so a
+    // repeat deferral costs one indexed lookup and nothing else.
+    if (snapshotTypePreservesFirst(snapshotType)) {
+      const { data: existingRow } = await supabase
+        .from('decision_price_snapshots')
+        .select('*')
+        .eq('trade_queue_item_id', tradeQueueItemId)
+        .eq('snapshot_type', snapshotType)
+        .maybeSingle()
+
+      // Cast through unknown: the generated client types resolve this table's
+      // row to `never`, same as everywhere else in this file.
+      const existing = existingRow as unknown as DecisionPriceSnapshot | null
+
+      if (existing) {
+        return {
+          success: true,
+          snapshot: {
+            ...existing,
+            snapshot_price: Number(existing.snapshot_price),
+          } as DecisionPriceSnapshot,
+        }
+      }
+    }
+
     // Get the price
     let price: number
     let priceSource: PriceSource
@@ -169,7 +195,7 @@ export async function fetchDecisionSnapshots(
 
 /**
  * Map a trade outcome to the appropriate snapshot type.
- * Returns null for outcomes that don't need a snapshot (e.g., deferred).
+ * Returns null for outcomes that carry no decision moment to anchor to.
  */
 export function outcomeToSnapshotType(outcome: string): SnapshotType | null {
   switch (outcome) {
@@ -178,8 +204,27 @@ export function outcomeToSnapshotType(outcome: string): SnapshotType | null {
       return 'approval'
     case 'rejected':
       return 'rejection'
-    // 'deferred' doesn't need a snapshot — the decision isn't terminal
+    case 'deferred':
+      // A deferral is not terminal, which is why it used to be skipped. But
+      // "we looked at it and didn't act" is exactly the case the idea ledger
+      // needs to score, and the price at that moment is unrecoverable later.
+      // Captured with preserveExisting so the FIRST pass stays the anchor.
+      return 'deferral'
     default:
       return null
   }
+}
+
+/**
+ * Whether a snapshot type should keep its original price rather than being
+ * overwritten when the same outcome is set again.
+ *
+ * Approvals want last-write-wins: if an idea is re-approved, the price that
+ * matters is the one at the commitment that actually stood. Passes want
+ * first-write-wins: an idea deferred three times should still be measured
+ * from the first time it was passed on, otherwise repeatedly revisiting a
+ * name silently resets its scorecard and flatters the record.
+ */
+export function snapshotTypePreservesFirst(snapshotType: SnapshotType): boolean {
+  return snapshotType === 'deferral'
 }

--- a/supabase/migrations/20260808120000_deferral_price_snapshots.sql
+++ b/supabase/migrations/20260808120000_deferral_price_snapshots.sql
@@ -1,0 +1,42 @@
+-- Deferral price snapshots
+--
+-- `decision_price_snapshots` recorded a price when an idea was approved,
+-- rejected, or cancelled, but deliberately skipped `deferred` on the grounds
+-- that a deferral "isn't terminal" (see outcomeToSnapshotType in
+-- src/lib/services/decision-snapshot-service.ts).
+--
+-- That reasoning holds for execution analysis and fails for idea-ledger
+-- analysis. "We looked at this and chose not to act, for now" is the single
+-- most common way an idea dies, and without a price anchored to that moment
+-- there is no way to ask later whether the pass was right.
+--
+-- The price at the moment of deferral is not recoverable after the fact from
+-- assets.current_price, so every deferral that happens before this ships is
+-- a permanently unanswerable question. Daily closes can be backfilled from a
+-- market data provider, but only at day granularity and only for assets we
+-- can map to a public ticker.
+--
+-- Additive only: widens a CHECK constraint. No existing row changes, no
+-- existing query is affected.
+
+ALTER TABLE decision_price_snapshots
+  DROP CONSTRAINT IF EXISTS decision_price_snapshots_snapshot_type_check;
+
+ALTER TABLE decision_price_snapshots
+  ADD CONSTRAINT decision_price_snapshots_snapshot_type_check
+  CHECK (snapshot_type IN ('approval', 'rejection', 'cancellation', 'deferral'));
+
+COMMENT ON TABLE decision_price_snapshots IS
+    'Records asset price at decision time (approval/rejection/cancellation/deferral). '
+    'Price source is assets.current_price (DB-cached proxy, not real-time). '
+    'Approval snapshots drive delay cost and move-since-decision on the Decision '
+    'Outcomes page. Rejection and deferral snapshots anchor "was the pass right?" '
+    'analysis for ideas that were never acted on.';
+
+COMMENT ON COLUMN decision_price_snapshots.snapshot_type IS
+    'approval   — idea was accepted/executed; latest wins (re-approval updates it). '
+    'rejection  — idea was killed outright. '
+    'cancellation — idea was withdrawn. '
+    'deferral   — idea was passed on for now; FIRST deferral wins and is never '
+    'overwritten, because the question being answered is "what was it worth when '
+    'we first decided not to act", not "when we most recently decided not to act".';


### PR DESCRIPTION
Groundwork for asking a question the product doesn't currently ask: what happened to the ideas nobody acted on?

Decision Outcomes follows approved ideas into execution and drops the rest (`showRejected` defaults false; every impact metric filters stage === 'approved'). The ideas that were passed on are the larger half, and nobody anywhere can tell you whether the calls they didn't make were right.

Deferral snapshots
- Widen decision_price_snapshots.snapshot_type to allow 'deferral'. outcomeToSnapshotType previously returned null for 'deferred' because a deferral isn't terminal. True for execution analysis, wrong for ledger analysis: "we looked and didn't act" is the most common way an idea dies, and assets.current_price at that moment is unrecoverable afterwards.
- Deferrals preserve the FIRST snapshot rather than upserting. An idea deferred three times is still measured from the first pass; otherwise revisiting a name silently resets its scorecard and flatters the record. Approvals keep last-write-wins, which is correct for them.

Analysis script (read-only, writes nothing)
- Reconstructs the ledger retroactively: anchor price from a snapshot, else the daily close on the decision date backfilled from Yahoo, else counted as unscoreable and reported. Coverage is an output, not a footnote.
- Verdicts are direction-adjusted by action: for buy/add the asset rising means the idea was right, so a pass on it was a miss; inverted for sell/trim. Daily closes only.
- Headline is the comparison between acted-on and passed-on ideas by the same people, not the pass rate alone, which means nothing in isolation.

Silent passes
Production currently holds 114 open ideas against 2 explicitly rejected ones, and 86% of the open ones have been idle 30+ days. Scoring only explicit rejections would measure nothing. Open ideas untouched past a threshold (default 60d) are therefore classified as passes and anchored at creation — not deciding is deciding.

Additive only: one widened CHECK constraint, no existing row or query affected. Unit suite green (958).

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
