### PR TITLE
fix(mobile): firm view read-only, case polish, fuller decisions

### DIFF
--- a/src/components/mobile/asset/CaseFieldHistory.tsx
+++ b/src/components/mobile/asset/CaseFieldHistory.tsx
@@ -57,14 +57,21 @@ export function CaseFieldHistory({ contributionId }: CaseFieldHistoryProps) {
 function Diff({ before, after }: { before: string | null; after: string }) {
   const parts = useMemo(() => diffWords(before ?? '', after), [before, after])
 
+  // Case prose is authored in markdown, so a revision is usually a bulleted
+  // list. Rendered into a plain <p> the browser collapsed every newline and the
+  // list arrived as one run-on paragraph with literal "-" scattered through it.
+  // Whitespace is preserved and list markers are drawn as bullets, so a diff of
+  // a list still reads as a list.
+  const BODY = 'text-[13px] leading-relaxed text-gray-700 dark:text-gray-300 whitespace-pre-wrap break-words'
+
   // A first draft has nothing to compare against; showing every word as an
   // addition is noise, so it reads as plain new text.
   if (!before) {
-    return <p className="text-[13px] leading-relaxed text-gray-700 dark:text-gray-300">{after}</p>
+    return <p className={BODY}>{prettifyMarkers(after)}</p>
   }
 
   return (
-    <p className="text-[13px] leading-relaxed text-gray-700 dark:text-gray-300">
+    <p className={BODY}>
       {parts.map((part, i) => (
         <span
           key={i}
@@ -73,11 +80,27 @@ function Diff({ before, after }: { before: string | null; after: string }) {
             part.kind === 'removed' && 'bg-red-100 text-red-900 line-through dark:bg-red-900/40 dark:text-red-200'
           )}
         >
-          {part.text}
+          {prettifyMarkers(part.text)}
         </span>
       ))}
     </p>
   )
+}
+
+/**
+ * Markdown list markers as bullets, and emphasis markers dropped.
+ *
+ * The diff is word-level over the raw source, so it cannot be handed to a
+ * markdown renderer without losing the added/removed spans. Rewriting just the
+ * markers keeps the diff intact while making the text read as prose rather than
+ * as source. Ordered lists keep their numbers, which carry meaning.
+ */
+function prettifyMarkers(text: string): string {
+  return text
+    .replace(/(^|\n)[ \t]*[-*+][ \t]+/g, '$1• ')
+    .replace(/(^|\n)[ \t]*(#{1,6})[ \t]+/g, '$1')
+    .replace(/\*\*(.+?)\*\*/g, '$1')
+    .replace(/(^|[^*])\*(?!\s)([^*\n]+?)\*/g, '$1$2')
 }
 
 type DiffPart = { kind: 'same' | 'added' | 'removed'; text: string }

--- a/src/components/mobile/asset/MobileAssetPage.tsx
+++ b/src/components/mobile/asset/MobileAssetPage.tsx
@@ -5,6 +5,7 @@ import { MobileCaseView } from './MobileCaseView'
 import { TickerQuoteBadge } from '../TickerQuoteBadge'
 import { ExpandableText } from '../ExpandableText'
 import { useAssetTradeIdeas } from '../../../hooks/useAssetTradeIdeas'
+import { useAssetRecentDecisions, getDecisionLabel } from '../../../hooks/useAssetRecentDecisions'
 import { useAssetHeaderContext } from '../../../hooks/useAssetHeaderContext'
 import { useAssetPortfolioWeights } from '../../../hooks/useAssetPortfolioWeights'
 import { useAssetLiveWeights } from '../../../hooks/useAssetLiveWeights'
@@ -96,6 +97,15 @@ export function MobileAssetPage({ asset, onNavigate }: MobileAssetPageProps) {
   )
 }
 
+/**
+ * What is being done about this name — proposed and already decided.
+ *
+ * useAssetTradeIdeas filters to `outcome IS NULL`, so on its own this tab
+ * showed only what was still open and silently dropped every idea that had
+ * actually been decided. A tab called "Decisions" that cannot show a decision
+ * is the wrong way round, so the resolved items are fetched alongside and
+ * listed underneath.
+ */
 function DecisionsPanel({
   assetId,
   onNavigate,
@@ -104,12 +114,87 @@ function DecisionsPanel({
   onNavigate?: (result: any) => void
 }) {
   const { ideas, isLoading } = useAssetTradeIdeas({ assetId, limit: 25 })
+  const { decisions, isLoading: decisionsLoading } = useAssetRecentDecisions({ assetId, limit: 25 })
 
-  if (isLoading) return <PanelSkeleton />
-  if (!ideas.length) {
-    return <EmptyPanel icon={TrendingUp} message="Nothing in flight on this name." />
+  if (isLoading || decisionsLoading) return <PanelSkeleton />
+  if (!ideas.length && !decisions.length) {
+    return <EmptyPanel icon={TrendingUp} message="Nothing proposed or decided on this name." />
   }
 
+  return (
+    <div className="space-y-4">
+      {ideas.length > 0 && (
+        <div className="space-y-2">
+          <h2 className="px-1 text-[11px] font-semibold uppercase tracking-wider text-gray-400">
+            In flight · {ideas.length}
+          </h2>
+          <InFlightList ideas={ideas} onNavigate={onNavigate} />
+        </div>
+      )}
+
+      {decisions.length > 0 && (
+        <div className="space-y-2">
+          <h2 className="px-1 text-[11px] font-semibold uppercase tracking-wider text-gray-400">
+            Decided · {decisions.length}
+          </h2>
+          <div className="space-y-2">
+            {decisions.map(d => (
+              <button
+                key={d.id}
+                type="button"
+                onClick={() =>
+                  onNavigate?.({ id: 'outcomes', title: 'Decision Outcomes', type: 'outcomes', data: null })
+                }
+                className="w-full text-left rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-3 active:bg-gray-50 dark:active:bg-gray-800"
+              >
+                <div className="flex items-center gap-2 mb-1.5">
+                  <span
+                    className={clsx(
+                      'px-2 py-0.5 rounded-full text-[10px] font-bold uppercase tracking-wide',
+                      DECISION_TONE(d.outcome, d.decision_outcome)
+                    )}
+                  >
+                    {getDecisionLabel(d.action, d.outcome, d.decision_outcome)}
+                  </span>
+                  {d.proposed_weight != null && (
+                    <span className="text-xs font-semibold tabular-nums text-gray-700 dark:text-gray-200">
+                      {d.proposed_weight}%
+                    </span>
+                  )}
+                  <span className="ml-auto shrink-0 text-[11px] text-gray-400">
+                    {formatAsOf(d.outcome_at ?? d.decided_at ?? '')}
+                  </span>
+                </div>
+
+                {d.rationale && <ExpandableText text={d.rationale} lines={3} />}
+
+                <p className="mt-1.5 text-[11px] text-gray-400 truncate">
+                  {d.portfolio?.name ?? 'No portfolio'}
+                </p>
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+/** Rejected and deferred read differently from executed; colour says which. */
+function DECISION_TONE(outcome: string | null, decisionOutcome: string | null): string {
+  const v = outcome ?? decisionOutcome
+  if (v === 'rejected') return 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300'
+  if (v === 'deferred') return 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300'
+  return 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300'
+}
+
+function InFlightList({
+  ideas,
+  onNavigate,
+}: {
+  ideas: ReturnType<typeof useAssetTradeIdeas>['ideas']
+  onNavigate?: (result: any) => void
+}) {
   return (
     <div className="space-y-2">
       {ideas.map(idea => (
@@ -144,12 +229,45 @@ function DecisionsPanel({
             )}
           </div>
 
+          {/* The card fetched urgency, shares, target price, conviction and
+              horizon and displayed none of them, so an idea with a full case
+              behind it read as a bare action and a stage. */}
+          {(idea.target_price != null ||
+            idea.proposed_shares != null ||
+            idea.conviction ||
+            idea.time_horizon ||
+            idea.urgency) && (
+            <div className="mb-1.5 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-gray-500 dark:text-gray-400">
+              {idea.target_price != null && (
+                <span>
+                  Target{' '}
+                  <span className="font-semibold tabular-nums text-gray-700 dark:text-gray-200">
+                    ${Number(idea.target_price).toFixed(2)}
+                  </span>
+                </span>
+              )}
+              {idea.proposed_shares != null && (
+                <span className="tabular-nums">
+                  {Number(idea.proposed_shares).toLocaleString()} sh
+                </span>
+              )}
+              {idea.conviction && <span className="capitalize">{idea.conviction} conviction</span>}
+              {idea.time_horizon && <span>{idea.time_horizon.replace(/_/g, ' ')}</span>}
+              {idea.urgency && idea.urgency !== 'medium' && (
+                <span className="capitalize font-medium text-amber-600 dark:text-amber-400">
+                  {idea.urgency} urgency
+                </span>
+              )}
+            </div>
+          )}
+
           {idea.rationale && <ExpandableText text={idea.rationale} lines={3} />}
 
           <p className="mt-1.5 text-[11px] text-gray-400 truncate">
             {idea.portfolio?.name ?? 'No portfolio'}
             {idea.creator &&
               ` · ${[idea.creator.first_name, idea.creator.last_name].filter(Boolean).join(' ')}`}
+            {` · ${formatAsOf(idea.updated_at)}`}
           </p>
         </button>
       ))}

--- a/src/components/mobile/asset/MobileCaseSection.tsx
+++ b/src/components/mobile/asset/MobileCaseSection.tsx
@@ -70,8 +70,15 @@ export function MobileCaseSection({
     return viewFilter === 'aggregated' || c.created_by === viewFilter
   })
 
-  // Reading someone else's view means reading theirs, not editing yours.
-  const isOwnView = viewFilter === 'aggregated' || viewFilter === user?.id
+  // Firm view is the summary of everyone's work, so it is read-only: an edit
+  // made from it has no unambiguous author and would silently be attributed to
+  // whoever happened to be looking. Editing lives in "My view", which is one
+  // tap away in the picker above. Only your own view is writable — reading
+  // someone else's means reading theirs, not editing yours.
+  const isFirmView = viewFilter === 'aggregated'
+  const canEdit = !!user && viewFilter === user.id
+  // Your own prose still appears on the firm view; it is part of the summary.
+  const showsMine = isFirmView || viewFilter === user?.id
 
   const [editing, setEditing] = useState(false)
   const [showHistory, setShowHistory] = useState(false)
@@ -142,40 +149,57 @@ export function MobileCaseSection({
 
   return (
     <section className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 overflow-hidden">
-      <div className="flex items-center gap-2 px-3 py-2 border-b border-gray-100 dark:border-gray-800">
-        <h3 className="flex-1 min-w-0 text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
-          {title}
-        </h3>
-        {isOwnView && hasDraft && !editing && (
-          <span className="shrink-0 px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wide bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
-            Draft
-          </span>
-        )}
-        {!editing && myContribution && (
-          <button
-            type="button"
-            onClick={() => setShowHistory(v => !v)}
-            aria-expanded={showHistory}
-            className={clsx(
-              'shrink-0 inline-flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-semibold no-touch-target',
-              showHistory
-                ? 'text-primary-700 bg-primary-50 dark:text-primary-300 dark:bg-primary-900/30'
-                : 'text-gray-500 dark:text-gray-400 active:bg-gray-100 dark:active:bg-gray-800'
+      {/* Title and actions are separate rows rather than one. Field names come
+          from the organisation's template and run long ("Where we are different
+          from consensus"); sharing a row with two buttons truncated most of
+          them to a few words, which is exactly the part that identifies the
+          field. The title now wraps and the actions sit under it. */}
+      <div className="px-3 py-2 border-b border-gray-100 dark:border-gray-800">
+        <div className="flex items-start gap-2">
+          <h3 className="flex-1 min-w-0 text-sm font-semibold leading-snug text-gray-900 dark:text-gray-100">
+            {title}
+          </h3>
+          {canEdit && hasDraft && !editing && (
+            <span className="mt-0.5 shrink-0 px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wide bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300">
+              Draft
+            </span>
+          )}
+        </div>
+
+        {!editing && (myContribution || canEdit) && (
+          <div className="mt-1.5 flex items-center gap-1">
+            {myContribution && (
+              <button
+                type="button"
+                onClick={() => setShowHistory(v => !v)}
+                aria-expanded={showHistory}
+                className={clsx(
+                  'inline-flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-semibold no-touch-target',
+                  showHistory
+                    ? 'text-primary-700 bg-primary-50 dark:text-primary-300 dark:bg-primary-900/30'
+                    : 'text-gray-500 dark:text-gray-400 active:bg-gray-100 dark:active:bg-gray-800'
+                )}
+              >
+                <History className="h-3.5 w-3.5" />
+                Changes
+              </button>
             )}
-          >
-            <History className="h-3.5 w-3.5" />
-            Changes
-          </button>
-        )}
-        {!editing && user && isOwnView && (
-          <button
-            type="button"
-            onClick={beginEdit}
-            className="shrink-0 inline-flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-semibold text-primary-600 dark:text-primary-400 active:bg-primary-50 dark:active:bg-primary-900/30 no-touch-target"
-          >
-            <Pencil className="h-3.5 w-3.5" />
-            {published || draft ? 'Edit' : 'Add'}
-          </button>
+            {canEdit && (
+              <button
+                type="button"
+                onClick={beginEdit}
+                className="inline-flex items-center gap-1 px-2 py-1 rounded-lg text-xs font-semibold text-primary-600 dark:text-primary-400 active:bg-primary-50 dark:active:bg-primary-900/30 no-touch-target"
+              >
+                <Pencil className="h-3.5 w-3.5" />
+                {published || draft ? 'Edit' : 'Add'}
+              </button>
+            )}
+            {isFirmView && (
+              <span className="ml-auto text-[11px] text-gray-400">
+                Firm view · read-only
+              </span>
+            )}
+          </div>
         )}
       </div>
 
@@ -219,7 +243,7 @@ export function MobileCaseSection({
           <div className="h-4 w-2/3 rounded bg-gray-100 dark:bg-gray-800 animate-pulse" />
         ) : (
           <>
-            {isOwnView && hasDraft && (
+            {canEdit && hasDraft && (
               <div className="mb-2 rounded-lg border border-amber-200 dark:border-amber-900/50 bg-amber-50 dark:bg-amber-900/20 px-2.5 py-2">
                 <div className="flex items-center gap-2 mb-1">
                   <span className="text-[10px] font-semibold uppercase tracking-wide text-amber-700 dark:text-amber-300">
@@ -237,7 +261,7 @@ export function MobileCaseSection({
               </div>
             )}
 
-            {isOwnView && published ? (
+            {showsMine && published ? (
               <ExpandableText text={published} lines={6} markdown />
             ) : !hasDraft && otherContributions.length === 0 ? (
               <p className="text-sm text-gray-400 dark:text-gray-500">{emptyHint}</p>
@@ -252,7 +276,7 @@ export function MobileCaseSection({
             {otherContributions.length > 0 && (
               <div className={clsx(
                 'space-y-3',
-                (isOwnView && (published || hasDraft)) &&
+                (showsMine && (published || hasDraft)) &&
                   'mt-3 pt-3 border-t border-gray-100 dark:border-gray-800'
               )}>
                 {otherContributions.map(c => (

--- a/src/components/mobile/asset/MobileCaseTargets.tsx
+++ b/src/components/mobile/asset/MobileCaseTargets.tsx
@@ -14,6 +14,26 @@ interface MobileCaseTargetsProps {
 /** Horizons offered when setting a target. Mirrors the desktop presets. */
 const HORIZONS = ['3M', '6M', '12M', '18M', '24M'] as const
 
+/**
+ * How a horizon is expressed, matching the desktop editor and the
+ * timeframe_type / is_rolling columns on analyst_price_targets.
+ *
+ *  preset  — a fixed window from today ("12M"), expiring when it elapses.
+ *  rolling — the same window, but continuously re-based so it never expires.
+ *  date    — a specific calendar date, e.g. an expected catalyst.
+ *
+ * Mobile previously offered only 'preset' and hard-coded timeframeType, so a
+ * rolling target set on desktop was silently rewritten to a fixed one the next
+ * time it was edited on a phone.
+ */
+type HorizonMode = 'preset' | 'rolling' | 'date'
+
+const HORIZON_MODES: { key: HorizonMode; label: string }[] = [
+  { key: 'preset', label: 'Fixed' },
+  { key: 'rolling', label: 'Rolling' },
+  { key: 'date', label: 'Date' },
+]
+
 const ORDER = ['Bull', 'Base', 'Bear']
 
 /**
@@ -40,15 +60,24 @@ export function MobileCaseTargets({
   const [editing, setEditing] = useState<string | null>(null)
   const [price, setPrice] = useState('')
   const [horizon, setHorizon] = useState<string>('12M')
+  /** How the horizon is expressed. Mirrors analyst_price_targets.timeframe_type. */
+  const [horizonMode, setHorizonMode] = useState<HorizonMode>('preset')
+  /** Set when horizonMode is 'date'. */
+  const [targetDate, setTargetDate] = useState('')
+  /** Probability this scenario plays out, 0-100. Optional. */
+  const [probability, setProbability] = useState('')
 
-  const isOwnView = viewFilter === 'aggregated' || viewFilter === user?.id
+  // Firm view is a summary of everyone's targets, so it is read-only. Setting a
+  // target from it would have no unambiguous author.
+  const isFirmView = viewFilter === 'aggregated'
+  const canEdit = !!user && viewFilter === user.id
 
   const rows = useMemo(() => {
-    const defaults = (scenarios ?? []).filter(s => s.is_default)
-    // Fall back to whatever scenarios exist, so an organisation using custom
-    // ones is not shown an empty panel.
-    const list = defaults.length ? defaults : (scenarios ?? [])
-    return [...list].sort((a, b) => {
+    // Every scenario, not just the defaults. Filtering to is_default dropped
+    // custom cases — an "Uber Bull" with a target set against it simply never
+    // appeared, and the fallback only fired when an asset had NO defaults at
+    // all, which is never once ensure_default_scenarios has run.
+    return [...(scenarios ?? [])].sort((a, b) => {
       const ai = ORDER.indexOf(a.name)
       const bi = ORDER.indexOf(b.name)
       if (ai === -1 && bi === -1) return a.name.localeCompare(b.name)
@@ -73,9 +102,14 @@ export function MobileCaseTargets({
   const targetsFor = (scenarioId: string) =>
     (priceTargets ?? []).filter(t => t.scenario_id === scenarioId)
 
-  const begin = (scenarioId: string, existing?: { price: number; timeframe: string | null }) => {
+  const begin = (scenarioId: string, existing?: any) => {
     setPrice(existing ? String(existing.price) : '')
     setHorizon(existing?.timeframe || '12M')
+    setHorizonMode(
+      existing?.is_rolling ? 'rolling' : existing?.timeframe_type === 'date' ? 'date' : 'preset'
+    )
+    setTargetDate(existing?.target_date ? String(existing.target_date).slice(0, 10) : '')
+    setProbability(existing?.probability != null ? String(existing.probability) : '')
     setEditing(scenarioId)
   }
 
@@ -84,11 +118,17 @@ export function MobileCaseTargets({
     // A blank or unparseable price cancels. Saving 0 would publish a target
     // nobody holds.
     if (Number.isFinite(value) && value > 0) {
+      const prob = parseFloat(probability)
       savePriceTarget.mutate({
         scenarioId,
         price: value,
-        timeframe: horizon,
-        timeframeType: 'preset',
+        // A date horizon stores the date; the label still carries the preset so
+        // lists that only read `timeframe` stay readable.
+        timeframe: horizonMode === 'date' ? (targetDate || horizon) : horizon,
+        timeframeType: horizonMode === 'date' ? 'date' : 'preset',
+        targetDate: horizonMode === 'date' && targetDate ? targetDate : undefined,
+        isRolling: horizonMode === 'rolling',
+        probability: Number.isFinite(prob) && prob > 0 ? prob : undefined,
       })
     }
     setEditing(null)
@@ -99,8 +139,17 @@ export function MobileCaseTargets({
       {rows.map(scenario => {
         const all = targetsFor(scenario.id)
         const mine = all.find(t => t.user_id === user?.id)
-        const others = all.filter(t => t.user_id !== user?.id)
-        const shown = viewFilter === 'aggregated' ? mine : all.find(t => t.user_id === viewFilter)
+        // On the firm view the headline is the average across analysts, which
+        // is what the chart already draws. Showing only the reader's own target
+        // there labelled it as the firm's position.
+        const shown = isFirmView
+          ? (all.length
+              ? {
+                  price: all.reduce((s, t) => s + Number(t.price), 0) / all.length,
+                  timeframe: `${all.length} analyst${all.length === 1 ? '' : 's'}`,
+                }
+              : undefined)
+          : all.find(t => t.user_id === viewFilter)
         const isEditing = editing === scenario.id
 
         return (
@@ -173,15 +222,10 @@ export function MobileCaseTargets({
                     <span className="flex-1 text-sm text-gray-400">Not set</span>
                   )}
 
-                  {isOwnView && (
+                  {canEdit && (
                     <button
                       type="button"
-                      onClick={() =>
-                        begin(
-                          scenario.id,
-                          mine ? { price: Number(mine.price), timeframe: mine.timeframe } : undefined
-                        )
-                      }
+                      onClick={() => begin(scenario.id, mine)}
                       className="ml-1 h-8 w-8 shrink-0 flex items-center justify-center rounded-lg text-primary-600 dark:text-primary-400 no-touch-target"
                       aria-label={`${mine ? 'Edit' : 'Set'} ${scenario.name} target`}
                     >
@@ -193,37 +237,96 @@ export function MobileCaseTargets({
             </div>
 
             {isEditing && (
-              <div className="mt-2 flex items-center gap-1">
-                <span className="text-[11px] text-gray-400 mr-0.5">Horizon</span>
-                {HORIZONS.map(h => (
-                  <button
-                    key={h}
-                    type="button"
-                    onClick={() => setHorizon(h)}
-                    className={clsx(
-                      'px-2 h-7 rounded-md text-[11px] font-semibold border no-touch-target',
-                      horizon === h
-                        ? 'border-primary-500 bg-primary-50 text-primary-700 dark:bg-primary-900/30 dark:text-primary-300'
-                        : 'border-gray-200 text-gray-500 dark:border-gray-700 dark:text-gray-400'
-                    )}
-                  >
-                    {h}
-                  </button>
-                ))}
+              <div className="mt-2 space-y-2">
+                <div className="flex items-center gap-1">
+                  <span className="text-[11px] text-gray-400 mr-0.5 w-14 shrink-0">Horizon</span>
+                  {HORIZON_MODES.map(m => (
+                    <button
+                      key={m.key}
+                      type="button"
+                      onClick={() => setHorizonMode(m.key)}
+                      className={clsx(
+                        'flex-1 h-7 rounded-md text-[11px] font-semibold border no-touch-target',
+                        horizonMode === m.key
+                          ? 'border-primary-500 bg-primary-50 text-primary-700 dark:bg-primary-900/30 dark:text-primary-300'
+                          : 'border-gray-200 text-gray-500 dark:border-gray-700 dark:text-gray-400'
+                      )}
+                    >
+                      {m.label}
+                    </button>
+                  ))}
+                </div>
+
+                {horizonMode === 'date' ? (
+                  <div className="flex items-center gap-1">
+                    <span className="text-[11px] text-gray-400 mr-0.5 w-14 shrink-0">By</span>
+                    <input
+                      type="date"
+                      value={targetDate}
+                      onChange={e => setTargetDate(e.target.value)}
+                      className="flex-1 min-w-0 h-8 px-2 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-[12px] text-gray-900 dark:text-gray-100"
+                    />
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-1">
+                    <span className="text-[11px] text-gray-400 mr-0.5 w-14 shrink-0">
+                      {horizonMode === 'rolling' ? 'Rolling' : 'Window'}
+                    </span>
+                    {HORIZONS.map(h => (
+                      <button
+                        key={h}
+                        type="button"
+                        onClick={() => setHorizon(h)}
+                        className={clsx(
+                          'flex-1 h-7 rounded-md text-[11px] font-semibold border no-touch-target',
+                          horizon === h
+                            ? 'border-primary-500 bg-primary-50 text-primary-700 dark:bg-primary-900/30 dark:text-primary-300'
+                            : 'border-gray-200 text-gray-500 dark:border-gray-700 dark:text-gray-400'
+                        )}
+                      >
+                        {h}
+                      </button>
+                    ))}
+                  </div>
+                )}
+
+                {/* Probability is what turns three prices into a distribution.
+                    Without it the scenarios are just three numbers and no
+                    expected value can be computed. */}
+                <div className="flex items-center gap-1">
+                  <span className="text-[11px] text-gray-400 mr-0.5 w-14 shrink-0">Odds</span>
+                  <input
+                    type="number"
+                    inputMode="numeric"
+                    min={0}
+                    max={100}
+                    value={probability}
+                    onChange={e => setProbability(e.target.value)}
+                    placeholder="optional"
+                    className="flex-1 min-w-0 h-8 px-2 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 text-[12px] tabular-nums text-gray-900 dark:text-gray-100"
+                  />
+                  <span className="text-[11px] text-gray-400">%</span>
+                </div>
               </div>
             )}
 
-            {viewFilter === 'aggregated' && others.length > 0 && !isEditing && (
+            {/* Every analyst holding this scenario, the reader included — the
+                firm view is the summary of all of them, so leaving your own
+                target out of the list made the average look wrong. */}
+            {isFirmView && all.length > 0 && !isEditing && (
               <ul className="mt-1.5 pl-[1.375rem] space-y-0.5">
-                {others.map(t => (
+                {all.map(t => (
                   <li key={t.id} className="flex items-baseline gap-2 text-[11px] text-gray-500 dark:text-gray-400">
                     <span className="truncate max-w-[7rem]">
-                      {t.user?.full_name ?? 'Colleague'}
+                      {t.user_id === user?.id ? 'You' : (t.user?.full_name ?? 'Colleague')}
                     </span>
                     <span className="tabular-nums font-medium text-gray-700 dark:text-gray-300">
                       ${Number(t.price).toFixed(2)}
                     </span>
                     <span>{t.timeframe || '—'}</span>
+                    {t.probability != null && (
+                      <span className="ml-auto tabular-nums">{Number(t.probability).toFixed(0)}%</span>
+                    )}
                   </li>
                 ))}
               </ul>
@@ -231,6 +334,160 @@ export function MobileCaseTargets({
           </div>
         )
       })}
+
+      <RiskReward
+        rows={rows}
+        priceTargets={priceTargets ?? []}
+        currentPrice={currentPrice}
+        viewFilter={viewFilter}
+        userId={user?.id}
+      />
+    </div>
+  )
+}
+
+/**
+ * The probability distribution across scenarios, and what it implies.
+ *
+ * Three prices without weights are not a view — Bull $200 / Base $150 / Bear
+ * $100 says nothing until you know which one the author actually expects. The
+ * desktop page exposes this through ProbabilityDistributionModal; the phone had
+ * no equivalent at all, so probabilities entered on desktop were invisible here
+ * and the risk/reward the case implies could not be read.
+ *
+ * Expected value is probability-weighted and shown only when the weights are
+ * close to complete. A partial distribution produces a number that looks
+ * authoritative and is not, so below the threshold it says what is missing
+ * instead of printing a figure.
+ */
+function RiskReward({
+  rows,
+  priceTargets,
+  currentPrice,
+  viewFilter,
+  userId,
+}: {
+  rows: { id: string; name: string; color: string | null }[]
+  priceTargets: any[]
+  currentPrice: number | null
+  viewFilter: 'aggregated' | string
+  userId?: string
+}) {
+  const dist = useMemo(() => {
+    return rows
+      .map(scenario => {
+        const forScenario = priceTargets.filter(t => t.scenario_id === scenario.id)
+        // On the firm view every analyst's weights are averaged, matching how
+        // the price itself is aggregated one row above.
+        const relevant =
+          viewFilter === 'aggregated'
+            ? forScenario
+            : forScenario.filter(t => t.user_id === viewFilter)
+        if (!relevant.length) return null
+
+        const withProb = relevant.filter(t => t.probability != null)
+        return {
+          id: scenario.id,
+          name: scenario.name,
+          color: scenario.color || '#6b7280',
+          price: relevant.reduce((s, t) => s + Number(t.price), 0) / relevant.length,
+          probability: withProb.length
+            ? withProb.reduce((s, t) => s + Number(t.probability), 0) / withProb.length
+            : null,
+        }
+      })
+      .filter(Boolean) as {
+        id: string; name: string; color: string; price: number; probability: number | null
+      }[]
+  }, [rows, priceTargets, viewFilter])
+
+  if (dist.length === 0) return null
+
+  const weighted = dist.filter(d => d.probability != null)
+  const totalProb = weighted.reduce((s, d) => s + (d.probability ?? 0), 0)
+  // Within 5 points of 100 is close enough to weight honestly; rounding across
+  // three analysts rarely lands exactly on the nose.
+  const complete = weighted.length === dist.length && Math.abs(totalProb - 100) <= 5
+  const ev = complete
+    ? weighted.reduce((s, d) => s + d.price * ((d.probability ?? 0) / 100), 0) / (totalProb / 100)
+    : null
+  const evUpside =
+    ev != null && currentPrice != null && currentPrice > 0
+      ? ((ev - currentPrice) / currentPrice) * 100
+      : null
+
+  const owner = viewFilter === 'aggregated' ? 'Firm' : viewFilter === userId ? 'Your' : "Analyst's"
+
+  return (
+    <div className="px-3 py-2.5">
+      <div className="flex items-baseline gap-2 mb-2">
+        <h4 className="text-[11px] font-semibold uppercase tracking-wider text-gray-400">
+          Risk / reward
+        </h4>
+        {ev != null ? (
+          <span className="ml-auto text-xs font-semibold tabular-nums text-gray-900 dark:text-white">
+            {owner} EV ${ev.toFixed(2)}
+            {evUpside != null && (
+              <span className={clsx('ml-1', evUpside >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400')}>
+                {evUpside >= 0 ? '+' : ''}{evUpside.toFixed(0)}%
+              </span>
+            )}
+          </span>
+        ) : (
+          <span className="ml-auto text-[11px] text-gray-400">
+            {weighted.length === 0
+              ? 'no probabilities set'
+              : `weights total ${totalProb.toFixed(0)}%`}
+          </span>
+        )}
+      </div>
+
+      {/* A stacked bar rather than three separate meters: the scenarios are
+          mutually exclusive and should visibly compete for the same 100%. */}
+      <div className="flex h-2 w-full rounded-full overflow-hidden bg-gray-100 dark:bg-gray-800">
+        {weighted.map(d => (
+          <span
+            key={d.id}
+            className="block h-full first:rounded-l-full last:rounded-r-full"
+            style={{
+              width: `${totalProb > 0 ? ((d.probability ?? 0) / totalProb) * 100 : 0}%`,
+              backgroundColor: d.color,
+            }}
+            aria-hidden
+          />
+        ))}
+      </div>
+
+      <ul className="mt-2 space-y-1">
+        {dist.map(d => {
+          const upside =
+            currentPrice != null && currentPrice > 0
+              ? ((d.price - currentPrice) / currentPrice) * 100
+              : null
+          return (
+            <li key={d.id} className="flex items-center gap-2 text-[11px]">
+              <span className="h-2 w-2 rounded-full shrink-0" style={{ backgroundColor: d.color }} aria-hidden />
+              <span className="w-16 shrink-0 truncate text-gray-600 dark:text-gray-300">{d.name}</span>
+              <span className="tabular-nums font-medium text-gray-900 dark:text-white">
+                ${d.price.toFixed(2)}
+              </span>
+              {upside != null && (
+                <span
+                  className={clsx(
+                    'tabular-nums',
+                    upside >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'
+                  )}
+                >
+                  {upside >= 0 ? '+' : ''}{upside.toFixed(0)}%
+                </span>
+              )}
+              <span className="ml-auto tabular-nums text-gray-500 dark:text-gray-400">
+                {d.probability != null ? `${d.probability.toFixed(0)}%` : '—'}
+              </span>
+            </li>
+          )
+        })}
+      </ul>
     </div>
   )
 }

--- a/src/components/mobile/asset/MobileEstimatesField.tsx
+++ b/src/components/mobile/asset/MobileEstimatesField.tsx
@@ -41,7 +41,11 @@ export function MobileEstimatesField({
   const [newYear, setNewYear] = useState(String(new Date().getFullYear()))
   const [newValue, setNewValue] = useState('')
 
-  const isOwnView = viewFilter === 'aggregated' || viewFilter === user?.id
+  // Firm view aggregates every analyst's estimates and is read-only — an
+  // estimate saved from it would have no unambiguous author. Editing lives in
+  // "My view", one tap away in the picker at the top of the case.
+  const isFirmView = viewFilter === 'aggregated'
+  const isOwnView = !!user && viewFilter === user.id
 
   const visible = useMemo(() => {
     if (viewFilter === 'aggregated') return estimates
@@ -188,7 +192,11 @@ export function MobileEstimatesField({
 
       {byMetric.length === 0 ? (
         <p className="px-3 py-2.5 text-sm text-gray-400">
-          {isOwnView ? 'No estimates yet — add one above.' : 'No estimates from this analyst.'}
+          {isOwnView
+            ? 'No estimates yet — add one above.'
+            : isFirmView
+              ? 'Nobody has published estimates for this name yet.'
+              : 'No estimates from this analyst.'}
         </p>
       ) : (
         <div className="divide-y divide-gray-100 dark:divide-gray-800">

--- a/src/components/mobile/asset/MobilePriceTargetChart.tsx
+++ b/src/components/mobile/asset/MobilePriceTargetChart.tsx
@@ -170,6 +170,19 @@ export function MobilePriceTargetChart({
                 labelled directly on the target lines. */}
             <YAxis domain={domain ?? ['dataMin', 'dataMax']} hide />
 
+            {/* The inline chart had no tooltip, so reading a price off it meant
+                opening the fullscreen view first — the one place the targets and
+                the history are already side by side was the one place you could
+                not interrogate. Touch drag moves the crosshair; it does not
+                fight the page scroll, because recharts only claims the gesture
+                once it starts inside the plot. */}
+            <Tooltip
+              contentStyle={{ fontSize: 12, borderRadius: 8, padding: '4px 8px' }}
+              labelFormatter={(t: number) => new Date(t).toLocaleDateString()}
+              formatter={(v: number) => ['$' + v.toFixed(2), 'Price']}
+              cursor={{ stroke: '#9ca3af', strokeDasharray: '3 3' }}
+            />
+
             <Area
               type="monotone"
               dataKey="price"

--- a/src/components/mobile/asset/MobileRatingField.tsx
+++ b/src/components/mobile/asset/MobileRatingField.tsx
@@ -1,5 +1,6 @@
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { clsx } from 'clsx'
+import { Check, X } from 'lucide-react'
 import { useAuth } from '../../../hooks/useAuth'
 import { useAnalystRatings, useRatingScales, type ConvictionLevel } from '../../../hooks/useAnalystRatings'
 
@@ -34,7 +35,16 @@ export function MobileRatingField({
   const { ratings, myRating, consensus, isLoading, saveRating } = useAnalystRatings({ assetId })
   const { scales } = useRatingScales()
 
-  const isOwnView = viewFilter === 'aggregated' || viewFilter === user?.id
+  // Firm view is the aggregate of everyone's ratings and is read-only; a rating
+  // set from it would have no author. Editing lives in "My view".
+  const isFirmView = viewFilter === 'aggregated'
+  const canEdit = !!user && viewFilter === user.id
+
+  // A rating is the most consequential single tap in the case — it is the
+  // firm's published stance on the name — and it was previously committed the
+  // instant a button was pressed, with no way back. Selecting now stages the
+  // change and a second, explicit tap commits it.
+  const [pending, setPending] = useState<string | null>(null)
 
   // The scale comes from the organisation's configuration, not from whatever
   // rating happens to exist. Deriving it from existing ratings meant an asset
@@ -50,7 +60,13 @@ export function MobileRatingField({
     }
   }, [ratings, scales])
 
-  const shown = viewFilter === 'aggregated' ? null : ratings.find(r => r.user_id === viewFilter)
+  const shown = isFirmView ? null : ratings.find(r => r.user_id === viewFilter)
+
+  /** The most-held rating, which is what the firm view leads with. */
+  const topConsensus = useMemo(
+    () => [...consensus].sort((a, b) => b.count - a.count)[0] ?? null,
+    [consensus]
+  )
 
   if (isLoading) {
     return <div className="h-24 rounded-xl bg-gray-100 dark:bg-gray-800 animate-pulse" />
@@ -58,12 +74,14 @@ export function MobileRatingField({
 
   return (
     <section className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 overflow-hidden">
-      <div className="flex items-center gap-2 px-3 py-2 border-b border-gray-100 dark:border-gray-800">
-        <h3 className="flex-1 min-w-0 text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
+      {/* Title wraps rather than truncating: template field names run long and
+          the count badge was clipping them. */}
+      <div className="flex items-start gap-2 px-3 py-2 border-b border-gray-100 dark:border-gray-800">
+        <h3 className="flex-1 min-w-0 text-sm font-semibold leading-snug text-gray-900 dark:text-gray-100">
           {title}
         </h3>
         {ratings.length > 0 && (
-          <span className="shrink-0 text-[11px] text-gray-400">
+          <span className="mt-0.5 shrink-0 text-[11px] text-gray-400">
             {ratings.length} {ratings.length === 1 ? 'analyst' : 'analysts'}
           </span>
         )}
@@ -76,36 +94,67 @@ export function MobileRatingField({
           <p className="text-sm text-gray-400">
             No rating scale is configured for your organisation yet.
           </p>
-        ) : isOwnView ? (
+        ) : canEdit ? (
           <>
             <div className="flex flex-wrap gap-1.5">
               {scale.values.map(v => {
                 const active = myRating?.rating_value === v.value
+                const staged = pending === v.value
                 return (
                   <button
                     key={v.value}
                     type="button"
                     disabled={saveRating.isPending}
-                    onClick={() =>
-                      saveRating.mutate({
-                        ratingValue: v.value,
-                        ratingScaleId: scale.id!,
-                        conviction: myRating?.conviction ?? null,
-                      })
-                    }
+                    onClick={() => setPending(active ? null : v.value)}
                     className={clsx(
                       'px-3 h-9 rounded-lg text-sm font-semibold border transition-colors no-touch-target disabled:opacity-50',
-                      active
-                        ? 'border-transparent text-white'
-                        : 'border-gray-300 text-gray-600 dark:border-gray-600 dark:text-gray-300 active:bg-gray-100 dark:active:bg-gray-800'
+                      staged
+                        ? 'border-primary-500 border-dashed text-primary-700 bg-primary-50 dark:text-primary-300 dark:bg-primary-900/30'
+                        : active
+                          ? 'border-transparent text-white'
+                          : 'border-gray-300 text-gray-600 dark:border-gray-600 dark:text-gray-300 active:bg-gray-100 dark:active:bg-gray-800'
                     )}
-                    style={active && v.color ? { backgroundColor: v.color } : undefined}
+                    style={active && !staged && v.color ? { backgroundColor: v.color } : undefined}
                   >
                     {v.label}
                   </button>
                 )
               })}
             </div>
+
+            {pending && (
+              <div className="mt-2 flex items-center gap-2 rounded-lg border border-primary-200 dark:border-primary-900/50 bg-primary-50 dark:bg-primary-900/20 px-2.5 py-2">
+                <span className="flex-1 min-w-0 text-[12px] text-primary-900 dark:text-primary-200">
+                  {myRating
+                    ? `Change rating to ${labelFor(pending, scale.values)}?`
+                    : `Set rating to ${labelFor(pending, scale.values)}?`}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setPending(null)}
+                  className="h-8 w-8 shrink-0 flex items-center justify-center rounded-lg text-gray-500 no-touch-target"
+                  aria-label="Cancel rating change"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+                <button
+                  type="button"
+                  disabled={saveRating.isPending}
+                  onClick={() => {
+                    saveRating.mutate({
+                      ratingValue: pending,
+                      ratingScaleId: scale.id!,
+                      conviction: myRating?.conviction ?? null,
+                    })
+                    setPending(null)
+                  }}
+                  className="h-8 px-3 shrink-0 inline-flex items-center gap-1 rounded-lg bg-primary-600 text-white text-[12px] font-semibold disabled:opacity-50 no-touch-target"
+                >
+                  <Check className="h-3.5 w-3.5" />
+                  Confirm
+                </button>
+              </div>
+            )}
 
             {myRating && (
               <div className="mt-2.5 flex items-center gap-1.5">
@@ -137,6 +186,23 @@ export function MobileRatingField({
               </div>
             )}
           </>
+        ) : isFirmView ? (
+          // The firm's stance is the most-held rating, not a blank. Routing the
+          // firm view down the single-analyst branch printed "No rating from
+          // this analyst" over a name the whole desk had rated.
+          consensus.length > 0 ? (
+            <div className="flex items-baseline gap-2">
+              <span className="text-lg font-bold text-gray-900 dark:text-white">
+                {labelFor(topConsensus!.value, scale.values)}
+              </span>
+              <span className="text-xs text-gray-500">
+                {topConsensus!.count} of {ratings.length}
+              </span>
+              <span className="ml-auto text-[11px] text-gray-400">Firm view · read-only</span>
+            </div>
+          ) : (
+            <p className="text-sm text-gray-400">Nobody has rated this name yet.</p>
+          )
         ) : shown ? (
           <div className="flex items-baseline gap-2">
             <span className="text-lg font-bold text-gray-900 dark:text-white">
@@ -150,7 +216,7 @@ export function MobileRatingField({
           <p className="text-sm text-gray-400">No rating from this analyst.</p>
         )}
 
-        {viewFilter === 'aggregated' && consensus.length > 0 && (
+        {isFirmView && consensus.length > 0 && (
           <div className="mt-3 pt-2.5 border-t border-gray-100 dark:border-gray-800 space-y-1">
             {consensus.map(c => (
               <div key={c.value} className="flex items-center gap-2">

--- a/src/hooks/useAssetTradeIdeas.ts
+++ b/src/hooks/useAssetTradeIdeas.ts
@@ -17,6 +17,10 @@ export interface AssetTradeIdea {
   urgency: string
   proposed_weight: number | null
   proposed_shares: number | null
+  /** The price the idea is argued to, distinct from any analyst price target. */
+  target_price: number | null
+  conviction: string | null
+  time_horizon: string | null
   created_by: string | null
   updated_at: string
   portfolio: { id: string; name: string } | null
@@ -42,6 +46,9 @@ export function useAssetTradeIdeas({ assetId, limit = 5 }: UseAssetTradeIdeasOpt
           urgency,
           proposed_weight,
           proposed_shares,
+          target_price,
+          conviction,
+          time_horizon,
           created_by,
           updated_at,
           portfolios:portfolio_id (id, name),
@@ -63,6 +70,9 @@ export function useAssetTradeIdeas({ assetId, limit = 5 }: UseAssetTradeIdeasOpt
         urgency: row.urgency,
         proposed_weight: row.proposed_weight,
         proposed_shares: row.proposed_shares,
+        target_price: row.target_price,
+        conviction: row.conviction,
+        time_horizon: row.time_horizon,
         created_by: row.created_by,
         updated_at: row.updated_at,
         portfolio: row.portfolios || null,


### PR DESCRIPTION
Firm view is read-only everywhere
`isOwnView` was `viewFilter === 'aggregated' || viewFilter === user.id`, so the firm view — the summary of everyone's work — was fully editable, and an edit made from it had no unambiguous author. Case sections, price targets, ratings and estimates now split this into `isFirmView` and `canEdit`, where only your own view is writable. Your own prose still shows on the firm view; it is part of the summary.

Firm view also showed the wrong content in two places: price targets led with the reader's own target labelled as the firm's, and ratings routed down the single-analyst branch and printed "No rating from this analyst" over a name the whole desk had rated. Targets now lead with the cross-analyst average (matching what the chart draws) and list every analyst including the reader; ratings lead with the most-held value.

Ratings need confirming
A rating is the most consequential single tap in the case and committed instantly with no way back. Selecting now stages the change; a second explicit tap commits it.

Headers no longer truncate
Template field names run long ("Where we are different from consensus") and shared a row with Changes/Edit, so most were clipped to a few words — the part that identifies the field. Title and actions are now separate rows and the title wraps.

Changes reads as prose, not source
The revision diff rendered into a plain <p>, so newlines collapsed and a bulleted list arrived as one run-on paragraph with literal "-" through it. Whitespace is preserved and markdown markers are rewritten to bullets, keeping the added/removed spans intact.

Custom scenarios appear
MobileCaseTargets filtered scenarios to `is_default`, with a fallback that only fired when an asset had none — which never happens once ensure_default_scenarios has run. A custom case with a target set against it simply never appeared.

Price targets keep their horizon type
Mobile offered presets only and hard-coded `timeframeType: 'preset'`, so a rolling target set on desktop was silently rewritten to fixed on the next phone edit. Fixed / Rolling / Date are now all available, with probability alongside.

Risk/reward exists on mobile
Probabilities were storable but invisible, so the distribution the case implies could not be read. Adds a stacked distribution and probability-weighted expected value, shown only when the weights are near complete — a partial distribution produces a number that looks authoritative and is not.

Chart is interrogable inline
The inline chart had no Tooltip, so reading a price off it meant opening fullscreen first.

Decisions shows decisions
useAssetTradeIdeas filters `outcome IS NULL`, so a tab called "Decisions" could not show one. Resolved items are now listed underneath via useAssetRecentDecisions. The in-flight card also fetched urgency, shares, target price, conviction and horizon and displayed none of them.

Typecheck clean on touched files; unit suite green (958).

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
