### PR TITLE
fix(mobile): the move error, and rework the pipeline interaction

### DIFF
--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -136,7 +136,17 @@ function ToastContainer({ toasts, onClose }: ToastContainerProps) {
 
   return (
     <div
-      className="fixed top-4 right-4 z-50 space-y-2 pointer-events-none"
+      // z-[9998] because a toast is the app's last line of feedback and must
+      // outrank whatever it is reporting on. At z-50 it rendered *behind* every
+      // overlay above it — bottom sheets (z-[60]), fullscreen surfaces
+      // (z-[90]) — so an action that failed inside a sheet reported the failure
+      // invisibly, and the user saw nothing happen. Sits just under the z-[9999]
+      // reserved for the topmost portal.
+      //
+      // Insets rather than a bare top-4/right-4: on a notched phone top-4 puts
+      // the toast under the status bar, and a fixed right offset with no left
+      // bound lets a long message run off a 390px screen.
+      className="fixed top-4 right-4 left-4 sm:left-auto sm:max-w-sm pt-safe z-[9998] space-y-2 pointer-events-none"
       aria-live="polite"
       aria-atomic="false"
       role="region"

--- a/src/components/mobile/MobilePipeline.tsx
+++ b/src/components/mobile/MobilePipeline.tsx
@@ -1,47 +1,28 @@
 import { useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { clsx } from 'clsx'
 import {
-  ArrowRight, Check, ChevronLeft, ChevronRight, Loader2, ListTodo, Lock, Search, X,
+  ArrowRight, Check, ChevronDown, ChevronLeft, ChevronRight,
+  Loader2, ListTodo, Lock, Search, X,
 } from 'lucide-react'
 import { useAuth } from '../../hooks/useAuth'
 import { usePipelineItems } from '../../hooks/usePipelineItems'
 import { useTradeIdeaService } from '../../hooks/useTradeIdeaService'
 import { isCreatorOrCoAnalyst } from '../../lib/permissions/trade-idea-permissions'
-import {
-  RESEARCH_STAGES,
-  RESEARCH_STAGE_CONFIG,
-} from '../../lib/trade-status-semantics'
-import type { ResearchStage, UISource } from '../../types/trading'
+import { RESEARCH_STAGES, RESEARCH_STAGE_CONFIG } from '../../lib/trade-status-semantics'
 import {
   groupIntoRows,
   rowSearchText,
+  missingForStage,
+  isForwardMove,
   COMMITTED_PIPELINE_STATUSES,
   ARCHIVED_PIPELINE_STATUSES,
   type PipelineRow,
 } from '../../lib/mobile/pipeline-rows'
+import type { ResearchStage, UISource } from '../../types/trading'
 import { BottomSheet } from './BottomSheet'
 import { ExpandableText } from './ExpandableText'
 
-/**
- * The idea pipeline on a phone.
- *
- * The desktop board is a five-column kanban moved with native HTML5 drag
- * (`e.dataTransfer`). That API does not fire on touch at all — not "works
- * badly", it produces no events — so the board is not merely cramped on a
- * phone, it is inert. A drag polyfill was rejected: five columns will not fit
- * at 390px regardless of how the gesture is captured, and dragging a card
- * across a horizontally-scrolling viewport with one thumb is a poor
- * interaction even where it works.
- *
- * So the board becomes one stage at a time, and moving becomes an explicit
- * action rather than a gesture. This is the same shape Trello itself uses on
- * mobile, and it has a property dragging does not: a move can be confirmed,
- * and a stage the reader lacks permission to move into can be shown as
- * unavailable with a reason instead of silently refusing the drop.
- *
- * Writes go through useTradeIdeaService.moveTrade — the same audited mutation
- * the board uses, with `uiSource` distinguishing where the move came from.
- */
 type View = 'pipeline' | 'committed' | 'archived'
 
 const VIEWS: { key: View; label: string }[] = [
@@ -50,6 +31,35 @@ const VIEWS: { key: View; label: string }[] = [
   { key: 'archived', label: 'Archived' },
 ]
 
+/**
+ * The idea pipeline on a phone.
+ *
+ * The desktop board moves cards with native HTML5 drag (`e.dataTransfer`),
+ * which produces no events at all on touch — the kanban is not cramped on a
+ * phone, it is inert. A drag polyfill was rejected: five columns do not fit at
+ * 390px however the gesture is captured.
+ *
+ * Three decisions shape this surface, all of them corrections:
+ *
+ * 1. One stage at a time, chosen from a sheet rather than a scrolling strip of
+ *    pills. A horizontal strip hides stages off-screen, gives no sense of where
+ *    you are in a five-step process, and makes reaching the last stage a scroll
+ *    plus a tap. A single control naming the current stage, with paging
+ *    chevrons either side, shows position and reaches any stage in one tap.
+ *
+ * 2. Moving is never a single tap. Stage is the shared state of the whole
+ *    desk's process, and a mis-tap on a phone silently rewrites it. Every move
+ *    is chosen, then confirmed against a plain sentence naming both stages.
+ *
+ * 3. A card is a summary and opens full screen. A pipeline card cannot hold a
+ *    thesis, a target, sizing and provenance at this width, and an idea that
+ *    cannot be read in full is one that gets advanced without being read.
+ *
+ * Writes go through useTradeIdeaService — the same audited mutations the board
+ * uses — and forward moves are gated client-side against the same requirements
+ * the service enforces, so the reader is told what is missing before tapping
+ * rather than after.
+ */
 export function MobilePipeline() {
   const { user } = useAuth()
   const { data: items = [], isLoading } = usePipelineItems()
@@ -58,7 +68,9 @@ export function MobilePipeline() {
   const [view, setView] = useState<View>('pipeline')
   const [stage, setStage] = useState<ResearchStage>('aware')
   const [search, setSearch] = useState('')
-  const [moving, setMoving] = useState<PipelineRow | null>(null)
+  const [stagePickerOpen, setStagePickerOpen] = useState(false)
+  const [detail, setDetail] = useState<PipelineRow | null>(null)
+  const [moveTarget, setMoveTarget] = useState<PipelineRow | null>(null)
 
   const busy = isMoving || isMovingPairTrade
 
@@ -73,19 +85,24 @@ export function MobilePipeline() {
   const byStage = useMemo(() => {
     const map = new Map<ResearchStage, PipelineRow[]>(RESEARCH_STAGES.map(s => [s, []]))
     for (const row of visible) {
-      if (COMMITTED_PIPELINE_STATUSES.includes(row.status) || ARCHIVED_PIPELINE_STATUSES.includes(row.status)) continue
+      if (COMMITTED_PIPELINE_STATUSES.includes(row.status)) continue
+      if (ARCHIVED_PIPELINE_STATUSES.includes(row.status)) continue
       const s = row.stage as ResearchStage
       if (map.has(s)) map.get(s)!.push(row)
     }
     return map
   }, [visible])
 
-  const committedRows = useMemo(() => visible.filter(r => COMMITTED_PIPELINE_STATUSES.includes(r.status)), [visible])
-  const archivedRows = useMemo(() => visible.filter(r => ARCHIVED_PIPELINE_STATUSES.includes(r.status)), [visible])
+  const committedRows = useMemo(
+    () => visible.filter(r => COMMITTED_PIPELINE_STATUSES.includes(r.status)),
+    [visible]
+  )
+  const archivedRows = useMemo(
+    () => visible.filter(r => ARCHIVED_PIPELINE_STATUSES.includes(r.status)),
+    [visible]
+  )
 
   const canMove = (row: PipelineRow) => {
-    // A pair is governed by its legs; the first one answers, since every leg of
-    // a pair is created together by the same author.
     const subject = row.kind === 'pair' ? row.legs[0] : row.item
     if (!subject || !user?.id) return false
     return isCreatorOrCoAnalyst(user.id, {
@@ -96,35 +113,32 @@ export function MobilePipeline() {
   }
 
   const stageIndex = RESEARCH_STAGES.indexOf(stage)
-  const current = byStage.get(stage) ?? []
+  const pipelineTotal = [...byStage.values()].reduce((n, r) => n + r.length, 0)
+  const list =
+    view === 'pipeline' ? (byStage.get(stage) ?? []) : view === 'committed' ? committedRows : archivedRows
 
+  // Failures surface through the app's toast, which now outranks these
+  // overlays (see ToastContainer) and already rolls the optimistic update back.
+  // Reporting them a second time inline would double-report the same event.
   const commit = (row: PipelineRow, target: ResearchStage, uiSource: UISource) => {
     if (row.kind === 'pair') {
       movePairTrade({ pairTradeId: row.id, targetStatus: target as any, uiSource })
     } else {
       moveTrade({ tradeId: row.id, targetStatus: target as any, uiSource })
     }
-    setMoving(null)
+    setMoveTarget(null)
+    setDetail(null)
   }
-
-
-  const list = view === 'pipeline' ? current : view === 'committed' ? committedRows : archivedRows
 
   return (
     <div className="h-full flex flex-col bg-gray-50 dark:bg-gray-950">
       <div className="flex-shrink-0 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800">
-        {/* Pipeline / Committed / Archived. The board carries these as a fourth
-            column with its own dropdown; at phone width they are better as a
-            top-level switch, because the archive is browsed rather than worked
-            and does not want to compete with the stages for room. */}
         <div className="flex gap-1 px-3 pt-2">
           {VIEWS.map(v => {
             const count =
-              v.key === 'pipeline'
-                ? [...byStage.values()].reduce((n, rows) => n + rows.length, 0)
-                : v.key === 'committed'
-                  ? committedRows.length
-                  : archivedRows.length
+              v.key === 'pipeline' ? pipelineTotal
+                : v.key === 'committed' ? committedRows.length
+                : archivedRows.length
             return (
               <button
                 key={v.key}
@@ -145,40 +159,50 @@ export function MobilePipeline() {
           })}
         </div>
 
-        {/* Stage strip. Horizontally scrollable rather than five squeezed tabs:
-            the labels are the vocabulary of the process and abbreviating them
-            to fit ("Deep Res.") makes the board harder to read, not smaller. */}
+        {/* Stage selector. Paging chevrons plus a tappable label, rather than a
+            horizontally scrolling strip of pills: the strip hid stages off the
+            edge, gave no sense of position in a five-step process, and made the
+            last stage a scroll away. */}
         {view === 'pipeline' && (
-          <div className="flex gap-1.5 px-3 py-2 overflow-x-auto no-scrollbar">
-            {RESEARCH_STAGES.map(s => {
-              const cfg = RESEARCH_STAGE_CONFIG[s]
-              const count = (byStage.get(s) ?? []).length
-              const active = s === stage
-              return (
-                <button
-                  key={s}
-                  type="button"
-                  onClick={() => setStage(s)}
-                  aria-current={active}
-                  className={clsx(
-                    'shrink-0 inline-flex items-center gap-1.5 h-9 px-3 rounded-full text-sm font-medium transition-colors no-touch-target',
-                    active
-                      ? 'bg-gray-900 text-white dark:bg-white dark:text-gray-900'
-                      : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300'
-                  )}
-                >
-                  {cfg.shortLabel}
-                  <span
-                    className={clsx(
-                      'min-w-[1.25rem] px-1 rounded-full text-[11px] font-semibold tabular-nums',
-                      active ? 'bg-white/20' : 'bg-white dark:bg-gray-900'
-                    )}
-                  >
-                    {count}
-                  </span>
-                </button>
-              )
-            })}
+          <div className="flex items-center gap-1.5 px-3 py-2">
+            <button
+              type="button"
+              disabled={stageIndex === 0}
+              onClick={() => setStage(RESEARCH_STAGES[stageIndex - 1])}
+              className="h-10 w-10 shrink-0 flex items-center justify-center rounded-lg border border-gray-200 dark:border-gray-700 text-gray-500 disabled:opacity-25 no-touch-target"
+              aria-label="Previous stage"
+            >
+              <ChevronLeft className="h-4 w-4" />
+            </button>
+
+            <button
+              type="button"
+              onClick={() => setStagePickerOpen(true)}
+              className="flex-1 min-w-0 h-10 px-3 flex items-center gap-2 rounded-lg border border-gray-200 dark:border-gray-700 no-touch-target"
+            >
+              <span className="min-w-0 flex-1 text-left">
+                <span className="block text-sm font-semibold text-gray-900 dark:text-white truncate">
+                  {RESEARCH_STAGE_CONFIG[stage].label}
+                </span>
+                <span className="block text-[10px] text-gray-400">
+                  Stage {stageIndex + 1} of {RESEARCH_STAGES.length}
+                </span>
+              </span>
+              <span className="shrink-0 text-sm font-semibold tabular-nums text-gray-500 dark:text-gray-400">
+                {(byStage.get(stage) ?? []).length}
+              </span>
+              <ChevronDown className="h-4 w-4 shrink-0 text-gray-400" />
+            </button>
+
+            <button
+              type="button"
+              disabled={stageIndex === RESEARCH_STAGES.length - 1}
+              onClick={() => setStage(RESEARCH_STAGES[stageIndex + 1])}
+              className="h-10 w-10 shrink-0 flex items-center justify-center rounded-lg border border-gray-200 dark:border-gray-700 text-gray-500 disabled:opacity-25 no-touch-target"
+              aria-label="Next stage"
+            >
+              <ChevronRight className="h-4 w-4" />
+            </button>
           </div>
         )}
 
@@ -216,7 +240,7 @@ export function MobilePipeline() {
       <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain px-3 pb-safe space-y-2">
         {isLoading ? (
           [0, 1, 2].map(i => (
-            <div key={i} className="h-28 rounded-xl bg-gray-100 dark:bg-gray-800 animate-pulse" />
+            <div key={i} className="h-24 rounded-xl bg-gray-100 dark:bg-gray-800 animate-pulse" />
           ))
         ) : list.length === 0 ? (
           <div className="flex flex-col items-center justify-center gap-2 py-16 text-gray-400">
@@ -225,7 +249,7 @@ export function MobilePipeline() {
               {search
                 ? 'Nothing here matches that.'
                 : view === 'pipeline'
-                  ? 'Nothing in ' + RESEARCH_STAGE_CONFIG[stage].shortLabel + '.'
+                  ? 'Nothing in ' + RESEARCH_STAGE_CONFIG[stage].label + '.'
                   : view === 'committed'
                     ? 'Nothing committed yet.'
                     : 'Nothing archived yet.'}
@@ -233,77 +257,58 @@ export function MobilePipeline() {
           </div>
         ) : (
           list.map(row => (
-            <PipelineCard
-              key={row.id}
-              row={row}
-              movable={view === 'pipeline' && canMove(row)}
-              showMoveControls={view === 'pipeline'}
-              busy={busy}
-              prev={stageIndex > 0 ? RESEARCH_STAGES[stageIndex - 1] : null}
-              next={stageIndex < RESEARCH_STAGES.length - 1 ? RESEARCH_STAGES[stageIndex + 1] : null}
-              onStep={(target) => commit(row, target, 'mobile_step')}
-              onOpenSheet={() => setMoving(row)}
-            />
+            <PipelineCard key={row.id} row={row} onOpen={() => setDetail(row)} />
           ))
         )}
       </div>
 
-      <BottomSheet
-        open={!!moving}
-        onClose={() => setMoving(null)}
-        title={
-          moving
-            ? moving.kind === 'pair'
-              ? 'Move ' + (moving.pair?.name || 'pair trade')
-              : 'Move ' + (moving.item.assets?.symbol ?? 'idea')
-            : undefined
-        }
-        fitContent
-      >
+      {/* Which stage to look at. */}
+      <BottomSheet open={stagePickerOpen} onClose={() => setStagePickerOpen(false)} title="Go to stage" fitContent>
         <div className="px-3 pb-3 space-y-1">
-          {moving?.kind === 'pair' && (
-            <p className="px-1 pb-1 text-[11px] text-gray-500 dark:text-gray-400">
-              Both legs move together.
-            </p>
-          )}
-          {RESEARCH_STAGES.map(s => {
+          {RESEARCH_STAGES.map((s, i) => {
             const cfg = RESEARCH_STAGE_CONFIG[s]
-            const isCurrent = moving ? moving.stage === s : false
             return (
               <button
                 key={s}
                 type="button"
-                disabled={isCurrent || busy}
-                onClick={() => moving && commit(moving, s, 'mobile_sheet')}
+                onClick={() => { setStage(s); setStagePickerOpen(false) }}
                 className={clsx(
-                  'w-full flex items-start gap-3 rounded-xl px-3 py-3 text-left no-touch-target',
-                  isCurrent ? 'bg-gray-100 dark:bg-gray-800' : 'active:bg-gray-50 dark:active:bg-gray-800'
+                  'w-full flex items-center gap-3 rounded-xl px-3 py-3 text-left no-touch-target',
+                  s === stage ? 'bg-primary-50 dark:bg-primary-900/20' : 'active:bg-gray-50 dark:active:bg-gray-800'
                 )}
               >
-                <span className="mt-1 h-2.5 w-2.5 shrink-0 rounded-full bg-current opacity-70" aria-hidden />
+                <span className="w-5 shrink-0 text-[11px] font-semibold tabular-nums text-gray-400">{i + 1}</span>
                 <span className="min-w-0 flex-1">
-                  <span className="block text-sm font-semibold text-gray-900 dark:text-gray-100">
-                    {cfg.label}
-                  </span>
-                  <span className="block text-[11px] leading-snug text-gray-500 dark:text-gray-400">
-                    {cfg.description}
-                  </span>
+                  <span className="block text-sm font-semibold text-gray-900 dark:text-gray-100">{cfg.label}</span>
+                  <span className="block text-[11px] leading-snug text-gray-500 dark:text-gray-400">{cfg.description}</span>
                 </span>
-                {isCurrent && (
-                  <span className="mt-0.5 shrink-0 inline-flex items-center gap-1 text-[11px] font-semibold text-gray-500">
-                    <Check className="h-3.5 w-3.5" /> Current
-                  </span>
-                )}
+                <span className="shrink-0 text-sm font-semibold tabular-nums text-gray-500">
+                  {(byStage.get(s) ?? []).length}
+                </span>
               </button>
             )
           })}
-          {busy && (
-            <p className="flex items-center justify-center gap-1.5 py-2 text-xs text-gray-400">
-              <Loader2 className="h-3.5 w-3.5 animate-spin" /> Moving…
-            </p>
-          )}
         </div>
       </BottomSheet>
+
+      {detail && (
+        <IdeaDetail
+          row={detail}
+          readOnly={view !== 'pipeline'}
+          movable={view === 'pipeline' && canMove(detail)}
+          onClose={() => setDetail(null)}
+          onRequestMove={() => setMoveTarget(detail)}
+        />
+      )}
+
+      {moveTarget && (
+        <MoveSheet
+          row={moveTarget}
+          busy={busy}
+          onClose={() => setMoveTarget(null)}
+          onConfirm={target => commit(moveTarget, target, 'mobile_sheet')}
+        />
+      )}
     </div>
   )
 }
@@ -315,136 +320,338 @@ function actionTone(action: string): string {
     : 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300'
 }
 
-function PipelineCard({
-  row,
-  movable,
-  showMoveControls,
-  busy,
-  prev,
-  next,
-  onStep,
-  onOpenSheet,
-}: {
-  row: PipelineRow
-  movable: boolean
-  showMoveControls: boolean
-  busy: boolean
-  prev: ResearchStage | null
-  next: ResearchStage | null
-  onStep: (target: ResearchStage) => void
-  onOpenSheet: () => void
-}) {
-  const isPair = row.kind === 'pair'
-  const subject: any = isPair ? row.legs[0] : row.item
+/**
+ * A card is a summary, and the whole card is the tap target.
+ *
+ * It carries no move controls. Stage changes belong behind the detail view
+ * where the idea can actually be read first — the previous inline arrows made
+ * advancing an idea easier than opening it.
+ */
+function PipelineCard({ row, onOpen }: { row: PipelineRow; onOpen: () => void }) {
+  const subject: any = row.kind === 'pair' ? row.legs[0] : row.item
 
   return (
-    <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-3">
+    <button
+      type="button"
+      onClick={onOpen}
+      className="w-full text-left rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-3 active:bg-gray-50 dark:active:bg-gray-800"
+    >
       {row.kind === 'pair' ? (
         <>
-          <div className="flex items-center gap-2 mb-2">
+          <div className="flex items-center gap-2 mb-1.5">
             <span className="px-2 py-0.5 rounded-full text-[10px] font-bold uppercase tracking-wide bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300">
               Pair
             </span>
             <span className="min-w-0 flex-1 truncate text-sm font-semibold text-gray-900 dark:text-white">
               {row.pair?.name || 'Pair trade'}
             </span>
-            <span className="shrink-0 text-[11px] text-gray-400">{row.legs.length} legs</span>
+            <ChevronRight className="h-4 w-4 shrink-0 text-gray-300" />
           </div>
-
-          {/* Both legs, so the pair reads as a relationship rather than a name.
-              A pair whose legs are hidden behind a tap is indistinguishable
-              from a single idea at a glance. */}
-          <ul className="mb-2 space-y-1">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
             {row.legs.map((leg: any) => (
-              <li key={leg.id} className="flex items-center gap-2">
+              <span key={leg.id} className="inline-flex items-center gap-1.5">
                 <span className={clsx('px-1.5 py-0.5 rounded text-[10px] font-bold uppercase', actionTone(leg.action))}>
                   {leg.pair_leg_type || leg.action}
                 </span>
                 <span className="text-sm font-bold text-gray-900 dark:text-white">
                   {leg.assets?.symbol ?? '—'}
                 </span>
-                <span className="min-w-0 flex-1 truncate text-[11px] text-gray-400">
-                  {leg.assets?.company_name}
-                </span>
-                {leg.proposed_weight != null && (
-                  <span className="shrink-0 text-[11px] font-semibold tabular-nums text-gray-600 dark:text-gray-300">
-                    {leg.proposed_weight}%
-                  </span>
-                )}
-              </li>
+              </span>
             ))}
-          </ul>
-
-          {(row.pair?.rationale || subject?.rationale) && (
-            <ExpandableText text={row.pair?.rationale || subject.rationale} lines={2} />
-          )}
+          </div>
         </>
       ) : (
-        <>
-          <div className="flex items-center gap-2 mb-1.5">
-            <span className={clsx('px-2 py-0.5 rounded-full text-[10px] font-bold uppercase tracking-wide', actionTone(row.item.action))}>
-              {row.item.action}
+        <div className="flex items-center gap-2">
+          <span className={clsx('px-2 py-0.5 rounded-full text-[10px] font-bold uppercase tracking-wide shrink-0', actionTone(row.item.action))}>
+            {row.item.action}
+          </span>
+          <span className="text-sm font-bold text-gray-900 dark:text-white shrink-0">
+            {row.item.assets?.symbol ?? '—'}
+          </span>
+          <span className="min-w-0 flex-1 truncate text-[11px] text-gray-400">
+            {row.item.assets?.company_name}
+          </span>
+          {row.item.proposed_weight != null && (
+            <span className="shrink-0 text-xs font-semibold tabular-nums text-gray-700 dark:text-gray-200">
+              {row.item.proposed_weight}%
             </span>
-            <span className="text-sm font-bold text-gray-900 dark:text-white">
-              {row.item.assets?.symbol ?? '—'}
-            </span>
-            <span className="min-w-0 flex-1 truncate text-[11px] text-gray-400">
-              {row.item.assets?.company_name}
-            </span>
-            {row.item.proposed_weight != null && (
-              <span className="shrink-0 text-xs font-semibold tabular-nums text-gray-700 dark:text-gray-200">
-                {row.item.proposed_weight}%
-              </span>
-            )}
-          </div>
-
-          {row.item.rationale && <ExpandableText text={row.item.rationale} lines={2} />}
-        </>
+          )}
+          <ChevronRight className="h-4 w-4 shrink-0 text-gray-300" />
+        </div>
       )}
 
       <p className="mt-1.5 text-[11px] text-gray-400 truncate">
         {subject?.portfolios?.name ?? 'No portfolio'}
-        {subject?.users &&
-          ' · ' + [subject.users.first_name, subject.users.last_name].filter(Boolean).join(' ')}
-        {!showMoveControls && row.status && ' · ' + String(row.status).replace(/_/g, ' ')}
+        {subject?.users && ' · ' + [subject.users.first_name, subject.users.last_name].filter(Boolean).join(' ')}
       </p>
+    </button>
+  )
+}
 
-      {showMoveControls && (
-        <div className="mt-2.5 flex items-center gap-1.5">
-          <button
-            type="button"
-            disabled={!movable || !prev || busy}
-            onClick={() => prev && onStep(prev)}
-            className="h-9 w-9 shrink-0 flex items-center justify-center rounded-lg border border-gray-200 dark:border-gray-700 text-gray-500 disabled:opacity-30 no-touch-target"
-            aria-label={prev ? 'Move back to ' + RESEARCH_STAGE_CONFIG[prev].shortLabel : 'No earlier stage'}
-          >
-            <ChevronLeft className="h-4 w-4" />
-          </button>
+/** One labelled figure in the detail grid. Omitted entirely when unset. */
+function Fact({ label, value }: { label: string; value: React.ReactNode }) {
+  if (value == null || value === '') return null
+  return (
+    <div>
+      <dt className="text-[10px] font-semibold uppercase tracking-wider text-gray-400">{label}</dt>
+      <dd className="mt-0.5 text-sm text-gray-900 dark:text-gray-100">{value}</dd>
+    </div>
+  )
+}
 
+/**
+ * The whole idea, full screen.
+ *
+ * A pipeline card at 390px can hold an action, a symbol and a line of
+ * rationale. Everything that decides whether an idea should advance — the
+ * thesis, the target, the sizing, who owns it — did not fit, so the reader was
+ * being asked to move ideas they could not read.
+ */
+function IdeaDetail({
+  row,
+  readOnly,
+  movable,
+  onClose,
+  onRequestMove,
+}: {
+  row: PipelineRow
+  readOnly: boolean
+  movable: boolean
+  onClose: () => void
+  onRequestMove: () => void
+}) {
+  if (typeof document === 'undefined') return null
+
+  const subject: any = row.kind === 'pair' ? row.legs[0] : row.item
+  const stageCfg = RESEARCH_STAGE_CONFIG[row.stage as ResearchStage]
+
+  return createPortal(
+    <div className="fixed inset-0 z-[90] flex flex-col bg-white dark:bg-gray-900">
+      <div className="flex-shrink-0 flex items-center gap-2 px-3 h-14 pt-safe border-b border-gray-200 dark:border-gray-700">
+        <span className="min-w-0 flex-1 truncate text-base font-bold text-gray-900 dark:text-white">
+          {row.kind === 'pair'
+            ? row.pair?.name || 'Pair trade'
+            : `${row.item.assets?.symbol ?? '—'}`}
+        </span>
+        <button
+          type="button"
+          onClick={onClose}
+          className="h-10 w-10 shrink-0 flex items-center justify-center rounded-full text-gray-500 dark:text-gray-400 no-touch-target"
+          aria-label="Close"
+        >
+          <X className="h-5 w-5" />
+        </button>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto px-4 py-3 space-y-4">
+        <div className="flex items-center gap-2">
+          {stageCfg && (
+            <span className={clsx('px-2 py-0.5 rounded-full text-[10px] font-bold uppercase tracking-wide', stageCfg.color)}>
+              {stageCfg.label}
+            </span>
+          )}
+          {row.status && (
+            <span className="text-[11px] text-gray-400 capitalize">
+              {String(row.status).replace(/_/g, ' ')}
+            </span>
+          )}
+        </div>
+
+        {row.kind === 'pair' ? (
+          <div className="space-y-2">
+            {row.legs.map((leg: any) => (
+              <div key={leg.id} className="rounded-xl border border-gray-200 dark:border-gray-700 p-3">
+                <div className="flex items-center gap-2 mb-1">
+                  <span className={clsx('px-1.5 py-0.5 rounded text-[10px] font-bold uppercase', actionTone(leg.action))}>
+                    {leg.pair_leg_type || leg.action}
+                  </span>
+                  <span className="text-sm font-bold text-gray-900 dark:text-white">{leg.assets?.symbol}</span>
+                  <span className="min-w-0 flex-1 truncate text-[11px] text-gray-400">
+                    {leg.assets?.company_name}
+                  </span>
+                </div>
+                <dl className="grid grid-cols-3 gap-2">
+                  <Fact label="Weight" value={leg.proposed_weight != null ? `${leg.proposed_weight}%` : null} />
+                  <Fact label="Shares" value={leg.proposed_shares != null ? Number(leg.proposed_shares).toLocaleString() : null} />
+                  <Fact label="Target" value={leg.target_price != null ? `$${Number(leg.target_price).toFixed(2)}` : null} />
+                </dl>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <dl className="grid grid-cols-3 gap-3">
+            <Fact label="Action" value={<span className="capitalize">{row.item.action}</span>} />
+            <Fact label="Weight" value={row.item.proposed_weight != null ? `${row.item.proposed_weight}%` : null} />
+            <Fact label="Shares" value={row.item.proposed_shares != null ? Number(row.item.proposed_shares).toLocaleString() : null} />
+            <Fact label="Target" value={row.item.target_price != null ? `$${Number(row.item.target_price).toFixed(2)}` : null} />
+            <Fact label="Conviction" value={row.item.conviction ? <span className="capitalize">{row.item.conviction}</span> : null} />
+            <Fact label="Horizon" value={row.item.time_horizon?.replace(/_/g, ' ')} />
+          </dl>
+        )}
+
+        <dl className="grid grid-cols-2 gap-3 pt-1 border-t border-gray-100 dark:border-gray-800">
+          <Fact label="Portfolio" value={subject?.portfolios?.name ?? 'None'} />
+          <Fact
+            label="Owner"
+            value={
+              subject?.users
+                ? [subject.users.first_name, subject.users.last_name].filter(Boolean).join(' ') || subject.users.email
+                : null
+            }
+          />
+          <Fact label="Urgency" value={subject?.urgency ? <span className="capitalize">{subject.urgency}</span> : null} />
+          <Fact
+            label="Last moved"
+            value={
+              subject?.stage_changed_at
+                ? new Date(subject.stage_changed_at).toLocaleDateString(undefined, { day: 'numeric', month: 'short', year: 'numeric' })
+                : null
+            }
+          />
+        </dl>
+
+        {(row.kind === 'pair' ? row.pair?.rationale || subject?.rationale : row.item.rationale) && (
+          <section>
+            <h3 className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-gray-400">Why now</h3>
+            <ExpandableText
+              text={row.kind === 'pair' ? (row.pair?.rationale || subject.rationale) : row.item.rationale}
+              lines={6}
+              markdown
+            />
+          </section>
+        )}
+
+        {subject?.thesis_text && (
+          <section>
+            <h3 className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-gray-400">Trade thesis</h3>
+            <ExpandableText text={subject.thesis_text} lines={6} markdown />
+          </section>
+        )}
+      </div>
+
+      {!readOnly && (
+        <div className="flex-shrink-0 px-4 py-3 pb-safe border-t border-gray-200 dark:border-gray-700">
           <button
             type="button"
             disabled={!movable}
-            onClick={onOpenSheet}
-            className="flex-1 h-9 inline-flex items-center justify-center gap-1.5 rounded-lg border border-gray-200 dark:border-gray-700 text-sm font-medium text-gray-700 dark:text-gray-200 disabled:opacity-40 no-touch-target"
+            onClick={onRequestMove}
+            className="w-full h-11 inline-flex items-center justify-center gap-2 rounded-xl bg-primary-600 text-white text-sm font-semibold disabled:bg-gray-200 disabled:text-gray-400 dark:disabled:bg-gray-800 no-touch-target"
           >
             {movable ? (
-              <>Move<ArrowRight className="h-3.5 w-3.5" /></>
+              <>Move to another stage<ArrowRight className="h-4 w-4" /></>
             ) : (
-              <><Lock className="h-3.5 w-3.5" />Not yours to move</>
+              <><Lock className="h-4 w-4" />Only the owner or a co-analyst can move this</>
             )}
-          </button>
-
-          <button
-            type="button"
-            disabled={!movable || !next || busy}
-            onClick={() => next && onStep(next)}
-            className="h-9 w-9 shrink-0 flex items-center justify-center rounded-lg bg-primary-600 text-white disabled:opacity-30 no-touch-target"
-            aria-label={next ? 'Advance to ' + RESEARCH_STAGE_CONFIG[next].shortLabel : 'Final stage'}
-          >
-            <ChevronRight className="h-4 w-4" />
           </button>
         </div>
       )}
-    </div>
+    </div>,
+    document.body
+  )
+}
+
+/**
+ * Choose a stage, then confirm it.
+ *
+ * Two steps rather than one because stage is shared state — it is the desk's
+ * view of where a name sits in its process, and a mis-tap on a phone rewrites
+ * it for everyone with no undo. The confirmation names both stages in a
+ * sentence rather than showing a generic "Are you sure?", so what is about to
+ * happen is legible without remembering what was tapped.
+ *
+ * Targets whose requirements are unmet are shown disabled with the missing
+ * fields named. The service refuses those moves anyway; surfacing the rule here
+ * turns a failed action into an unavailable one.
+ */
+function MoveSheet({
+  row,
+  busy,
+  onClose,
+  onConfirm,
+}: {
+  row: PipelineRow
+  busy: boolean
+  onClose: () => void
+  onConfirm: (target: ResearchStage) => void
+}) {
+  const [chosen, setChosen] = useState<ResearchStage | null>(null)
+  const fromCfg = RESEARCH_STAGE_CONFIG[row.stage as ResearchStage]
+  const label = row.kind === 'pair' ? (row.pair?.name || 'this pair') : (row.item.assets?.symbol ?? 'this idea')
+
+  return (
+    <BottomSheet open onClose={onClose} title={chosen ? 'Confirm move' : `Move ${label}`} fitContent>
+      {chosen ? (
+        <div className="px-4 pb-4">
+          <p className="text-[15px] leading-relaxed text-gray-900 dark:text-gray-100">
+            Move <span className="font-semibold">{label}</span> from{' '}
+            <span className="font-semibold">{fromCfg?.label ?? row.stage}</span> to{' '}
+            <span className="font-semibold">{RESEARCH_STAGE_CONFIG[chosen].label}</span>?
+          </p>
+          <p className="mt-2 text-[12px] text-gray-500 dark:text-gray-400">
+            {row.kind === 'pair'
+              ? 'Both legs move together. This changes the stage for everyone on the desk and is recorded in the audit trail.'
+              : 'This changes the stage for everyone on the desk and is recorded in the audit trail.'}
+          </p>
+
+          <div className="mt-4 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setChosen(null)}
+              className="flex-1 h-11 rounded-xl border border-gray-200 dark:border-gray-700 text-sm font-medium text-gray-700 dark:text-gray-200 no-touch-target"
+            >
+              Back
+            </button>
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => onConfirm(chosen)}
+              className="flex-1 h-11 inline-flex items-center justify-center gap-1.5 rounded-xl bg-primary-600 text-white text-sm font-semibold disabled:opacity-50 no-touch-target"
+            >
+              {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <Check className="h-4 w-4" />}
+              Move
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="px-3 pb-3 space-y-1">
+          {row.kind === 'pair' && (
+            <p className="px-1 pb-1 text-[11px] text-gray-500 dark:text-gray-400">Both legs move together.</p>
+          )}
+          {RESEARCH_STAGES.map(s => {
+            const cfg = RESEARCH_STAGE_CONFIG[s]
+            const isCurrent = row.stage === s
+            const missing = isForwardMove(row.stage, s) ? missingForStage(row, s) : []
+            const blocked = missing.length > 0
+            return (
+              <button
+                key={s}
+                type="button"
+                disabled={isCurrent || blocked || busy}
+                onClick={() => setChosen(s)}
+                className={clsx(
+                  'w-full flex items-start gap-3 rounded-xl px-3 py-3 text-left no-touch-target',
+                  isCurrent ? 'bg-gray-100 dark:bg-gray-800' : 'active:bg-gray-50 dark:active:bg-gray-800',
+                  blocked && 'opacity-60'
+                )}
+              >
+                <span className="min-w-0 flex-1">
+                  <span className="block text-sm font-semibold text-gray-900 dark:text-gray-100">{cfg.label}</span>
+                  <span className="block text-[11px] leading-snug text-gray-500 dark:text-gray-400">
+                    {blocked ? `Needs ${missing.join(' and ')} first` : cfg.description}
+                  </span>
+                </span>
+                {isCurrent ? (
+                  <span className="mt-0.5 shrink-0 inline-flex items-center gap-1 text-[11px] font-semibold text-gray-500">
+                    <Check className="h-3.5 w-3.5" /> Current
+                  </span>
+                ) : blocked ? (
+                  <Lock className="mt-0.5 h-3.5 w-3.5 shrink-0 text-gray-400" />
+                ) : null}
+              </button>
+            )
+          })}
+        </div>
+      )}
+    </BottomSheet>
   )
 }

--- a/src/lib/mobile/__tests__/pipeline-rows.test.ts
+++ b/src/lib/mobile/__tests__/pipeline-rows.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 import {
   groupIntoRows,
   rowSearchText,
+  missingForStage,
+  isForwardMove,
   COMMITTED_PIPELINE_STATUSES,
   ARCHIVED_PIPELINE_STATUSES,
 } from '../pipeline-rows'
@@ -161,5 +163,73 @@ describe('terminal status buckets', () => {
       expect(COMMITTED_PIPELINE_STATUSES).not.toContain(s)
       expect(ARCHIVED_PIPELINE_STATUSES).not.toContain(s)
     }
+  })
+})
+
+/**
+ * The service throws on a forward move whose requirements are unmet, and the
+ * phone used to offer the move anyway — tap, wait, refused. These mirror
+ * validateStageRequirements so the control can be disabled before it is
+ * pressed. If the service's rule changes and this does not, the UI goes back to
+ * offering moves that fail.
+ */
+describe('missingForStage', () => {
+  const withFields = (over: Record<string, any>) =>
+    groupIntoRows([leg({ id: 'a', ...over })])[0]
+
+  it('gates ready_for_decision on rationale and thesis', () => {
+    const bare = withFields({ rationale: null, thesis_text: null })
+    expect(missingForStage(bare, 'ready_for_decision')).toEqual(['Why now', 'Trade thesis'])
+  })
+
+  it('names only what is actually missing', () => {
+    const partial = withFields({ rationale: 'Capex inflecting', thesis_text: null })
+    expect(missingForStage(partial, 'ready_for_decision')).toEqual(['Trade thesis'])
+  })
+
+  it('treats whitespace as absent, as the service does', () => {
+    const blank = withFields({ rationale: '   ', thesis_text: '\n' })
+    expect(missingForStage(blank, 'ready_for_decision')).toEqual(['Why now', 'Trade thesis'])
+  })
+
+  it('allows the move once both are present', () => {
+    const complete = withFields({ rationale: 'Capex inflecting', thesis_text: 'Supply constrained' })
+    expect(missingForStage(complete, 'ready_for_decision')).toEqual([])
+  })
+
+  it('does not gate the earlier research stages', () => {
+    const bare = withFields({ rationale: null, thesis_text: null })
+    for (const s of ['aware', 'investigate', 'deep_research', 'thesis_forming']) {
+      expect(missingForStage(bare, s)).toEqual([])
+    }
+  })
+
+  it('gates a pair on its first leg rather than throwing on an empty group', () => {
+    const pair = groupIntoRows([
+      leg({ id: 'a', pair_id: 'p1', pair_leg_type: 'long', rationale: null, thesis_text: null }),
+      leg({ id: 'b', pair_id: 'p1', pair_leg_type: 'short' }),
+    ])[0]
+    expect(missingForStage(pair, 'ready_for_decision')).toContain('Trade thesis')
+  })
+})
+
+describe('isForwardMove', () => {
+  it('recognises advancing through the research stages', () => {
+    expect(isForwardMove('aware', 'investigate')).toBe(true)
+    expect(isForwardMove('investigate', 'ready_for_decision')).toBe(true)
+  })
+
+  it('does not treat going back as forward, so backward moves stay ungated', () => {
+    expect(isForwardMove('ready_for_decision', 'aware')).toBe(false)
+    expect(isForwardMove('deep_research', 'investigate')).toBe(false)
+  })
+
+  it('is false for a move to the same stage', () => {
+    expect(isForwardMove('investigate', 'investigate')).toBe(false)
+  })
+
+  it('is false when either stage is unknown, rather than gating blindly', () => {
+    expect(isForwardMove('nonsense', 'investigate')).toBe(false)
+    expect(isForwardMove('investigate', 'nonsense')).toBe(false)
   })
 })

--- a/src/lib/mobile/pipeline-rows.ts
+++ b/src/lib/mobile/pipeline-rows.ts
@@ -82,6 +82,46 @@ export function groupIntoRows(items: any[]): PipelineRow[] {
   return rows
 }
 
+/**
+ * What a row is still missing before it can advance to `targetStage`.
+ *
+ * Mirrors validateStageRequirements in trade-idea-service, which throws on a
+ * forward move that fails it. The phone previously offered the move anyway and
+ * surfaced the throw afterwards, which is the wrong way round: the reader taps
+ * "advance", waits, and is told no. Checking the same rule up front lets the
+ * control say what is missing before it is pressed.
+ *
+ * Deliberately covers only the field gates, which are answerable from the row
+ * already in hand. The `deciding` stage additionally requires an active
+ * recommendation, which needs a query — and `deciding` is not one of the
+ * research stages this surface moves between, so it cannot arise here. If that
+ * ever changes this must grow a query rather than silently under-reporting.
+ *
+ * Backward moves are never gated, matching the service.
+ */
+export function missingForStage(row: PipelineRow, targetStage: string): string[] {
+  if (targetStage !== 'ready_for_decision' && targetStage !== 'deciding') return []
+
+  const subject = row.kind === 'pair' ? row.legs[0] : row.item
+  if (!subject) return []
+
+  const missing: string[] = []
+  if (!subject.rationale?.toString().trim()) missing.push('Why now')
+  if (!subject.thesis_text?.toString().trim()) missing.push('Trade thesis')
+  return missing
+}
+
+/** Stage order used for "is this a forward move", matching the service. */
+const FORWARD_ORDER = [
+  'aware', 'investigate', 'deep_research', 'thesis_forming', 'ready_for_decision', 'deciding',
+]
+
+export function isForwardMove(fromStage: string, toStage: string): boolean {
+  const from = FORWARD_ORDER.indexOf(fromStage)
+  const to = FORWARD_ORDER.indexOf(toStage)
+  return from >= 0 && to >= 0 && to > from
+}
+
 /** Every string a row should be searchable by. */
 export function rowSearchText(row: PipelineRow): string {
   const parts =


### PR DESCRIPTION
The error
Advancing to Ready for Decision requires a rationale and a thesis — validateStageRequirements gates every forward move and throws when they are missing. The phone offered the move regardless, so the sequence was: tap advance, wait, get refused. missingForStage mirrors that rule client-side, so an unmet target is now shown disabled with the missing fields named instead of being offered and failing.

It also failed invisibly. ToastContainer sits at z-50; bottom sheets are z-[60] and fullscreen surfaces z-[90], so the toast reporting the refusal rendered *behind* the sheet that caused it and the move simply appeared to do nothing. Raised to z-[9998], plus safe-area padding and a left inset — top-4 put it under the notch and a bare right offset let long messages run off a 390px screen. That fixes error reporting for every mobile surface, not just this one.

Moving is no longer one tap
The inline arrows are gone. Stage is the desk's shared view of where a name sits in its process, and a mis-tap rewrote it for everyone with no undo — the arrows made advancing an idea easier than opening it. A move is now chosen from a sheet and then confirmed against a sentence naming both stages, so what is about to happen is legible without remembering what was tapped.

Cards open full screen
A card at 390px holds an action, a symbol and a line of rationale. The thesis, target, sizing, conviction, horizon and provenance did not fit, so readers were being asked to advance ideas they could not read. The whole card is now a tap target onto a fullscreen detail carrying all of it, and the move action lives there — behind the reading rather than in front of it.

Stage pills replaced
The scrolling pill strip hid stages off-screen, gave no sense of position in a five-step process, and put the last stage behind a scroll. Now a single control naming the current stage with "Stage 3 of 5", paging chevrons either side, and a sheet listing all five with counts and descriptions — one tap to anywhere, no horizontal scrolling.

24 tests on the row helpers (10 new, covering the gate and forward-move detection). 982 passing overall. Production build clean.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
