### PR TITLE
feat(mobile): Trade Lab — sizing you can actually do with a thumb

### DIFF
--- a/src/components/mobile/trade-lab/MobileSimulationList.tsx
+++ b/src/components/mobile/trade-lab/MobileSimulationList.tsx
@@ -1,0 +1,325 @@
+import { useMemo, useState } from 'react'
+import { clsx } from 'clsx'
+import { AlertTriangle, Lock, Plus, Search, X } from 'lucide-react'
+import type { SimulationRow, SimulationRowSummary } from '../../../hooks/useSimulationRows'
+import type { TradeAction } from '../../../types/trading'
+import { MobileSizingSheet } from './MobileSizingSheet'
+
+interface MobileSimulationListProps {
+  rows: SimulationRow[]
+  summary: SimulationRowSummary
+  portfolioTotalValue: number
+  hasBenchmark: boolean
+  readOnly?: boolean
+  onUpdateVariant: (variantId: string, updates: { action?: TradeAction; sizingInput?: string }) => void
+  /** Matches the desktop table's signature; 'add' is the neutral seed action,
+   *  and the real action is derived from the deltas once sizing is entered. */
+  onCreateVariant: (assetId: string, action: TradeAction) => void
+  onDeleteVariant?: (variantId: string) => void
+  onAddPosition?: () => void
+}
+
+type Filter = 'traded' | 'all' | 'new'
+
+const FILTERS: { key: Filter; label: string }[] = [
+  { key: 'traded', label: 'Trading' },
+  { key: 'all', label: 'All positions' },
+  { key: 'new', label: 'New' },
+]
+
+const ACTION_TONE: Record<string, string> = {
+  buy: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
+  add: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
+  sell: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',
+  trim: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',
+}
+
+/**
+ * The simulation as a list, for a phone.
+ *
+ * The desktop surface is an eleven-column keyboard-driven table. That does not
+ * degrade to 390px — it is not a matter of hiding columns, because the columns
+ * *are* the product: current versus simulated, in weight and in shares, with
+ * both deltas. Reflowed to a phone it becomes a horizontally scrolling grid
+ * whose headers leave the screen, which is worse than useless for numbers whose
+ * meaning comes from their label.
+ *
+ * So each position becomes a card carrying the one comparison that matters —
+ * where the weight is now and where the sizing takes it — and the rest moves
+ * into the editor, which is a full sheet with room to show it. What is lost is
+ * scanning twenty rows at once. What is gained is being able to change one
+ * without a keyboard, which is the thing this surface is for on a phone: an
+ * idea tested during a meeting, not a book rebalanced at a desk.
+ *
+ * Every write goes back through the props the desktop table already receives,
+ * so the sync, convergence and ordering machinery in SimulationPage is
+ * untouched and both surfaces stay one implementation deep.
+ */
+export function MobileSimulationList({
+  rows,
+  summary,
+  portfolioTotalValue,
+  hasBenchmark,
+  readOnly,
+  onUpdateVariant,
+  onCreateVariant,
+  onDeleteVariant,
+  onAddPosition,
+}: MobileSimulationListProps) {
+  const [filter, setFilter] = useState<Filter>('traded')
+  const [search, setSearch] = useState('')
+  const [editing, setEditing] = useState<string | null>(null)
+
+  const visible = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    return rows.filter(r => {
+      if (r.isCash) return false
+      if (filter === 'traded' && !r.variant?.sizing_input) return false
+      if (filter === 'new' && !r.isNew) return false
+      if (q && !`${r.symbol} ${r.company_name}`.toLowerCase().includes(q)) return false
+      return true
+    })
+  }, [rows, filter, search])
+
+  // Kept resolved from `rows` rather than held as an object: the row is
+  // recomputed on every variant change, and a captured copy would show the
+  // pre-edit numbers in the sheet that just edited them.
+  const editingRow = editing ? rows.find(r => r.asset_id === editing) ?? null : null
+
+  return (
+    <div className="h-full flex flex-col bg-gray-50 dark:bg-gray-950">
+      {/* What this simulation does, in three numbers. On the desktop this is a
+          footer of column totals; a footer is unreachable on a phone, and this
+          is the first thing you want, not the last. */}
+      <div className="flex-shrink-0 px-3 pt-3">
+        <div className="grid grid-cols-3 gap-2 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-3">
+          <Stat label="Trades" value={String(summary.tradedCount)} />
+          <Stat
+            label="Net Δ wt"
+            value={`${summary.netDeltaWeight >= 0 ? '+' : ''}${summary.netDeltaWeight.toFixed(2)}%`}
+            tone={summary.netDeltaWeight >= 0 ? 'up' : 'down'}
+          />
+          <Stat label="Turnover" value={formatCompactUsd(Math.abs(summary.totalNotional))} />
+        </div>
+
+        {summary.conflictCount > 0 && (
+          <div className="mt-2 flex items-center gap-2 rounded-lg border border-amber-200 dark:border-amber-900/50 bg-amber-50 dark:bg-amber-900/20 px-3 py-2">
+            <AlertTriangle className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+            <p className="text-[12px] text-amber-800 dark:text-amber-200">
+              {summary.conflictCount} {summary.conflictCount === 1 ? 'position conflicts' : 'positions conflict'} with the idea behind them.
+            </p>
+          </div>
+        )}
+      </div>
+
+      <div className="flex-shrink-0 px-3 pt-2 pb-1 space-y-2">
+        <div className="flex gap-1">
+          {FILTERS.map(f => (
+            <button
+              key={f.key}
+              type="button"
+              onClick={() => setFilter(f.key)}
+              aria-current={filter === f.key}
+              className={clsx(
+                'flex-1 h-9 rounded-lg text-sm font-medium transition-colors no-touch-target',
+                filter === f.key
+                  ? 'bg-primary-50 text-primary-700 dark:bg-primary-900/30 dark:text-primary-300'
+                  : 'text-gray-500 dark:text-gray-400 active:bg-gray-100 dark:active:bg-gray-800'
+              )}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+
+        <div className="relative">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <input
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            placeholder="Find a position"
+            className="w-full h-9 pl-8 pr-8 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-500"
+          />
+          {search && (
+            <button
+              type="button"
+              onClick={() => setSearch('')}
+              className="absolute right-1.5 top-1/2 -translate-y-1/2 h-6 w-6 flex items-center justify-center rounded-full text-gray-400"
+              aria-label="Clear"
+            >
+              <X className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain px-3 pb-24 space-y-2">
+        {visible.length === 0 ? (
+          <div className="flex flex-col items-center justify-center gap-2 py-16 text-gray-400">
+            <p className="text-sm text-center">
+              {search
+                ? 'No position matches that.'
+                : filter === 'traded'
+                  ? 'Nothing sized yet. Switch to All positions to start one.'
+                  : filter === 'new'
+                    ? 'No new positions in this simulation.'
+                    : 'This portfolio has no holdings.'}
+            </p>
+          </div>
+        ) : (
+          visible.map(row => (
+            <PositionCard
+              key={row.asset_id}
+              row={row}
+              onOpen={() => {
+                // An untraded row has no variant to edit yet. Creating it here
+                // mirrors the desktop's click-to-create, and the sheet opens on
+                // the row that comes back from the recompute.
+                if (!row.variant) onCreateVariant(row.asset_id, 'add')
+                setEditing(row.asset_id)
+              }}
+            />
+          ))
+        )}
+      </div>
+
+      {!readOnly && onAddPosition && (
+        <button
+          type="button"
+          onClick={onAddPosition}
+          className="absolute bottom-5 right-5 h-14 w-14 flex items-center justify-center rounded-full bg-primary-600 text-white shadow-lg no-touch-target"
+          aria-label="Add a position to the simulation"
+        >
+          <Plus className="h-6 w-6" />
+        </button>
+      )}
+
+      {editingRow && (
+        <MobileSizingSheet
+          row={editingRow}
+          portfolioTotalValue={portfolioTotalValue}
+          hasBenchmark={hasBenchmark}
+          readOnly={readOnly || editingRow.isCommittedPending}
+          onCommit={sizingInput => {
+            if (editingRow.variant) onUpdateVariant(editingRow.variant.id, { sizingInput })
+          }}
+          onRemove={
+            onDeleteVariant && editingRow.variant
+              ? () => {
+                  onDeleteVariant(editingRow.variant!.id)
+                  setEditing(null)
+                }
+              : undefined
+          }
+          onClose={() => setEditing(null)}
+        />
+      )}
+    </div>
+  )
+}
+
+function Stat({ label, value, tone }: { label: string; value: string; tone?: 'up' | 'down' }) {
+  return (
+    <div>
+      <div className="text-[10px] font-semibold uppercase tracking-wider text-gray-400">{label}</div>
+      <div
+        className={clsx(
+          'mt-0.5 text-base font-bold tabular-nums',
+          tone === 'up' ? 'text-emerald-600 dark:text-emerald-400'
+            : tone === 'down' ? 'text-red-600 dark:text-red-400'
+            : 'text-gray-900 dark:text-white'
+        )}
+      >
+        {value}
+      </div>
+    </div>
+  )
+}
+
+/**
+ * One position: where it is, where the sizing takes it, and what that costs.
+ *
+ * Untraded rows are deliberately quieter rather than hidden — the whole
+ * portfolio has to stay reachable, because sizing a position you do not
+ * currently hold starts from finding it.
+ */
+function PositionCard({ row, onOpen }: { row: SimulationRow; onOpen: () => void }) {
+  const traded = !!row.variant?.sizing_input
+  const locked = row.isCommittedPending
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      disabled={locked}
+      className={clsx(
+        'w-full text-left rounded-xl border bg-white dark:bg-gray-900 p-3 active:bg-gray-50 dark:active:bg-gray-800 disabled:opacity-60',
+        traded
+          ? row.deltaWeight >= 0
+            ? 'border-l-[3px] border-l-emerald-500 border-gray-200 dark:border-gray-700'
+            : 'border-l-[3px] border-l-red-500 border-gray-200 dark:border-gray-700'
+          : 'border-gray-200 dark:border-gray-700'
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <span className="text-sm font-bold text-gray-900 dark:text-white">{row.symbol}</span>
+        {traded && (
+          <span className={clsx('px-1.5 py-0.5 rounded text-[10px] font-bold uppercase', ACTION_TONE[row.derivedAction] ?? 'bg-gray-100 text-gray-600')}>
+            {row.derivedAction}
+          </span>
+        )}
+        {row.isNew && (
+          <span className="px-1.5 py-0.5 rounded text-[10px] font-bold uppercase bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300">
+            New
+          </span>
+        )}
+        {row.hasConflict && <AlertTriangle className="h-3.5 w-3.5 text-amber-500" />}
+        {locked && <Lock className="h-3.5 w-3.5 text-gray-400" />}
+        <span className="min-w-0 flex-1 truncate text-[11px] text-gray-400">{row.company_name}</span>
+      </div>
+
+      <div className="mt-1.5 flex items-baseline gap-2">
+        <span className="text-sm tabular-nums text-gray-500 dark:text-gray-400">
+          {row.currentWeight.toFixed(2)}%
+        </span>
+        {traded && (
+          <>
+            <span className="text-gray-300">→</span>
+            <span className="text-sm font-bold tabular-nums text-gray-900 dark:text-white">
+              {row.simWeight.toFixed(2)}%
+            </span>
+            <span
+              className={clsx(
+                'ml-auto text-sm font-semibold tabular-nums',
+                row.deltaWeight >= 0
+                  ? 'text-emerald-600 dark:text-emerald-400'
+                  : 'text-red-600 dark:text-red-400'
+              )}
+            >
+              {row.deltaWeight >= 0 ? '+' : ''}
+              {row.deltaWeight.toFixed(2)}%
+            </span>
+          </>
+        )}
+      </div>
+
+      {traded && (
+        <div className="mt-1 flex items-center justify-between text-[11px] text-gray-500 dark:text-gray-400 tabular-nums">
+          <span>
+            {row.currentShares.toLocaleString()} → {row.simShares.toLocaleString()} sh
+          </span>
+          <span>
+            {row.notional >= 0 ? '+' : '−'}
+            {formatCompactUsd(Math.abs(row.notional))}
+          </span>
+        </div>
+      )}
+    </button>
+  )
+}
+
+function formatCompactUsd(value: number): string {
+  if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}m`
+  if (value >= 1_000) return `$${(value / 1_000).toFixed(0)}k`
+  return `$${value.toFixed(0)}`
+}

--- a/src/components/mobile/trade-lab/MobileSizingSheet.tsx
+++ b/src/components/mobile/trade-lab/MobileSizingSheet.tsx
@@ -1,0 +1,312 @@
+import { useEffect, useMemo, useState } from 'react'
+import { clsx } from 'clsx'
+import { AlertTriangle, Check, Trash2 } from 'lucide-react'
+import { parseSizingInput } from '../../../lib/trade-lab/sizing-parser'
+import { applyStep, type SizingMode } from '../../../lib/mobile/sizing-steps'
+import type { SimulationRow } from '../../../hooks/useSimulationRows'
+import { BottomSheet } from '../BottomSheet'
+
+/**
+ * Sizing modes offered as a segmented control.
+ *
+ * The desktop input infers the framework from the syntax — bare numbers are
+ * weight, `#` prefixes shares, `@` prefixes active. That is fast to type and
+ * invisible to discover, which is fine at a keyboard and wrong on a phone
+ * where the user cannot see a help popover and a `#` costs a keyboard switch.
+ * The mode is explicit here and writes the prefix for them.
+ */
+
+/** Deltas offered as one-tap chips, in the units of the active mode. */
+const WEIGHT_STEPS = [-1, -0.5, -0.25, 0.25, 0.5, 1]
+const SHARE_STEPS = [-1000, -500, -100, 100, 500, 1000]
+
+interface MobileSizingSheetProps {
+  row: SimulationRow
+  portfolioTotalValue: number
+  hasBenchmark: boolean
+  readOnly?: boolean
+  /** Commits a canonical sizing string, e.g. "2.5", "+0.5", "#500", "@t0.5". */
+  onCommit: (sizingInput: string) => void
+  /** Drops the position from the simulation entirely. */
+  onRemove?: () => void
+  onClose: () => void
+}
+
+/**
+ * The sizing editor, built for a thumb.
+ *
+ * This is the one screen where a phone can genuinely beat the desktop. Sizing
+ * a position is arithmetic against a number you already know — "take it to
+ * three", "add a quarter point" — and on a phone that is a tap, where at a
+ * keyboard it is a syntax. The chips are the primary control; the text field
+ * is the escape hatch for anything they do not cover, and still accepts the
+ * full desktop syntax so muscle memory transfers.
+ *
+ * The before/after readout is the other half. A sizing input alone tells you
+ * what you typed, not what it does — the whole reason to open this on a phone
+ * mid-meeting is to see where the position lands.
+ */
+export function MobileSizingSheet({
+  row,
+  portfolioTotalValue,
+  hasBenchmark,
+  readOnly,
+  onCommit,
+  onRemove,
+  onClose,
+}: MobileSizingSheetProps) {
+  const existing = row.variant?.sizing_input ?? ''
+  const [value, setValue] = useState(existing)
+  const [mode, setMode] = useState<SizingMode>(() =>
+    existing.startsWith('#') ? 'shares' : existing.startsWith('@') ? 'active' : 'weight'
+  )
+
+  // Reopening on a different row must not carry the previous row's draft.
+  useEffect(() => {
+    setValue(row.variant?.sizing_input ?? '')
+  }, [row.asset_id, row.variant?.id])
+
+  const price = row.baseline?.price ?? (row.simShares > 0 ? row.simNotional / row.simShares : 0)
+
+  const parsed = useMemo(
+    () => (value.trim() ? parseSizingInput(value.trim(), { has_benchmark: hasBenchmark }) : null),
+    [value, hasBenchmark]
+  )
+
+  /**
+   * What the position becomes, computed locally.
+   *
+   * The server recomputes on commit and is the authority; this exists so the
+   * readout tracks the chips at tap speed rather than after a round trip. It
+   * covers the frameworks the chips can produce — anything else falls back to
+   * showing no projection rather than a wrong one.
+   */
+  const projected = useMemo(() => {
+    if (!parsed?.is_valid || parsed.value == null || !price || !portfolioTotalValue) return null
+    const cur = row.currentWeight
+    switch (parsed.framework) {
+      case 'weight_target':
+        return parsed.value
+      case 'weight_delta':
+        return cur + (parsed.input_sign === '-' ? -parsed.value : parsed.value)
+      case 'shares_target':
+        return ((parsed.value * price) / portfolioTotalValue) * 100
+      case 'shares_delta': {
+        const delta = parsed.input_sign === '-' ? -parsed.value : parsed.value
+        return (((row.currentShares + delta) * price) / portfolioTotalValue) * 100
+      }
+      default:
+        // Active-space sizing needs the benchmark weight to resolve; the server
+        // does that. Showing nothing beats showing a number that ignores it.
+        return null
+    }
+  }, [parsed, price, portfolioTotalValue, row.currentWeight, row.currentShares])
+
+  const deltaWeight = projected != null ? projected - row.currentWeight : null
+  const deltaNotional =
+    deltaWeight != null ? (deltaWeight / 100) * portfolioTotalValue : null
+
+  /** Apply a chip. Chips are always deltas — a target is what the field is for. */
+  const step = (amount: number) => setValue(v => applyStep(v, mode, amount))
+
+  const modeChips = mode === 'shares' ? SHARE_STEPS : WEIGHT_STEPS
+  const invalid = !!value.trim() && parsed && !parsed.is_valid
+
+  return (
+    <BottomSheet open onClose={onClose} title={`${row.symbol} · sizing`} snapPoints={[0.75, 0.95]}>
+      <div className="px-4 pb-4 space-y-4">
+        {/* Where it lands. The headline, because it is the question being asked. */}
+        <div className="rounded-xl border border-gray-200 dark:border-gray-700 p-3">
+          <div className="flex items-baseline gap-2">
+            <span className="text-2xl font-bold tabular-nums text-gray-900 dark:text-white">
+              {(projected ?? row.simWeight).toFixed(2)}%
+            </span>
+            <span className="text-sm text-gray-400 tabular-nums">
+              from {row.currentWeight.toFixed(2)}%
+            </span>
+            {deltaWeight != null && Math.abs(deltaWeight) > 0.001 && (
+              <span
+                className={clsx(
+                  'ml-auto text-sm font-semibold tabular-nums',
+                  deltaWeight > 0
+                    ? 'text-emerald-600 dark:text-emerald-400'
+                    : 'text-red-600 dark:text-red-400'
+                )}
+              >
+                {deltaWeight > 0 ? '+' : ''}
+                {deltaWeight.toFixed(2)}%
+              </span>
+            )}
+          </div>
+
+          <WeightBar from={row.currentWeight} to={projected ?? row.simWeight} />
+
+          <div className="mt-2 flex items-center justify-between text-[11px] text-gray-500 dark:text-gray-400">
+            <span className="tabular-nums">
+              {row.currentShares.toLocaleString()} sh
+              {projected != null && price > 0 && (
+                <>
+                  {' → '}
+                  <span className="font-semibold text-gray-700 dark:text-gray-200">
+                    {Math.round((projected / 100 * portfolioTotalValue) / price).toLocaleString()} sh
+                  </span>
+                </>
+              )}
+            </span>
+            {deltaNotional != null && Math.abs(deltaNotional) > 1 && (
+              <span className="tabular-nums">
+                {deltaNotional > 0 ? '+' : '−'}
+                {formatCompactUsd(Math.abs(deltaNotional))}
+              </span>
+            )}
+          </div>
+        </div>
+
+        {!readOnly && (
+          <>
+            {/* Mode writes the prefix, so the syntax never has to be recalled. */}
+            <div className="flex gap-1">
+              {(['weight', 'shares', ...(hasBenchmark ? ['active' as const] : [])] as SizingMode[]).map(m => (
+                <button
+                  key={m}
+                  type="button"
+                  onClick={() => { setMode(m); setValue('') }}
+                  className={clsx(
+                    'flex-1 h-9 rounded-lg text-sm font-medium capitalize no-touch-target',
+                    mode === m
+                      ? 'bg-gray-900 text-white dark:bg-white dark:text-gray-900'
+                      : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300'
+                  )}
+                >
+                  {m}
+                </button>
+              ))}
+            </div>
+
+            {/* The primary control. Sizing on a phone should be tapping, not typing. */}
+            <div className="grid grid-cols-6 gap-1.5">
+              {modeChips.map(s => (
+                <button
+                  key={s}
+                  type="button"
+                  onClick={() => step(s)}
+                  className={clsx(
+                    'h-11 rounded-lg text-sm font-semibold tabular-nums border no-touch-target',
+                    s > 0
+                      ? 'border-emerald-200 text-emerald-700 dark:border-emerald-900/60 dark:text-emerald-400'
+                      : 'border-red-200 text-red-700 dark:border-red-900/60 dark:text-red-400'
+                  )}
+                >
+                  {s > 0 ? '+' : ''}
+                  {mode === 'shares' ? compactShares(s) : s}
+                </button>
+              ))}
+            </div>
+
+            <div>
+              <label className="block text-[10px] font-semibold uppercase tracking-wider text-gray-400 mb-1">
+                Or type it
+              </label>
+              <input
+                type="text"
+                inputMode={mode === 'shares' ? 'numeric' : 'decimal'}
+                value={value}
+                onChange={e => setValue(e.target.value)}
+                placeholder={mode === 'shares' ? '#500 or #+100' : mode === 'active' ? '@t0.5' : '2.5 or +0.5'}
+                className={clsx(
+                  'w-full h-11 px-3 rounded-lg border bg-white dark:bg-gray-800 text-[15px] tabular-nums text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2',
+                  invalid
+                    ? 'border-red-400 focus:ring-red-400'
+                    : 'border-gray-300 dark:border-gray-600 focus:ring-primary-500'
+                )}
+              />
+              <p className="mt-1 text-[11px] text-gray-400">
+                {invalid
+                  ? parsed?.error || 'That is not a sizing this field understands.'
+                  : 'A bare number is a target; a signed one is a change.'}
+              </p>
+            </div>
+
+            {row.hasConflict && row.conflict && (
+              <div className="flex items-start gap-2 rounded-lg border border-amber-200 dark:border-amber-900/50 bg-amber-50 dark:bg-amber-900/20 px-3 py-2">
+                <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+                <p className="text-[12px] text-amber-800 dark:text-amber-200">
+                  {row.conflict.message ?? 'This sizing works against the idea it came from.'}
+                </p>
+              </div>
+            )}
+
+            <div className="flex items-center gap-2">
+              {onRemove && row.variant && (
+                <button
+                  type="button"
+                  onClick={onRemove}
+                  className="h-11 w-11 shrink-0 flex items-center justify-center rounded-xl border border-gray-200 dark:border-gray-700 text-red-600 dark:text-red-400 no-touch-target"
+                  aria-label={`Remove ${row.symbol} from the simulation`}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </button>
+              )}
+              <button
+                type="button"
+                disabled={!!invalid}
+                onClick={() => { onCommit(value.trim()); onClose() }}
+                className="flex-1 h-11 inline-flex items-center justify-center gap-1.5 rounded-xl bg-primary-600 text-white text-sm font-semibold disabled:opacity-40 no-touch-target"
+              >
+                <Check className="h-4 w-4" />
+                {value.trim() ? 'Apply' : 'Clear sizing'}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </BottomSheet>
+  )
+}
+
+/**
+ * Current weight and simulated weight on one track.
+ *
+ * Two numbers a line apart do not convey how big a change is relative to the
+ * position. Shown as a bar, "2.4 to 3.1" is visibly a quarter more rather than
+ * arithmetic the reader has to do.
+ */
+function WeightBar({ from, to }: { from: number; to: number }) {
+  const max = Math.max(from, to, 0.1) * 1.15
+  const pct = (v: number) => Math.max(0, Math.min(100, (v / max) * 100))
+  const growing = to >= from
+
+  return (
+    <div className="mt-2 h-2 w-full rounded-full bg-gray-100 dark:bg-gray-800 overflow-hidden relative">
+      <span
+        className="absolute inset-y-0 left-0 bg-gray-300 dark:bg-gray-600"
+        style={{ width: `${pct(Math.min(from, to))}%` }}
+        aria-hidden
+      />
+      <span
+        className={clsx(
+          'absolute inset-y-0',
+          growing ? 'bg-emerald-500' : 'bg-red-500'
+        )}
+        style={{
+          left: `${pct(Math.min(from, to))}%`,
+          width: `${Math.max(0, pct(Math.max(from, to)) - pct(Math.min(from, to)))}%`,
+        }}
+        aria-hidden
+      />
+    </div>
+  )
+}
+
+
+
+function compactShares(n: number): string {
+  const abs = Math.abs(n)
+  return abs >= 1000 ? `${abs / 1000}k` : String(abs)
+}
+
+function formatCompactUsd(value: number): string {
+  if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}m`
+  if (value >= 1_000) return `$${(value / 1_000).toFixed(0)}k`
+  return `$${value.toFixed(0)}`
+}

--- a/src/lib/mobile/__tests__/sizing-steps.test.ts
+++ b/src/lib/mobile/__tests__/sizing-steps.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest'
+import { applyStep, currentDelta, prefixForMode } from '../sizing-steps'
+import { parseSizingInput } from '../../trade-lab/sizing-parser'
+
+/**
+ * Chip arithmetic on the mobile sizing sheet.
+ *
+ * The stakes: the string these produce is committed as a variant's
+ * sizing_input and resized against a real portfolio. A bug that turns a target
+ * into a delta does not error — it sizes the position to a different number
+ * than the user asked for, and the readout agrees with itself the whole way.
+ */
+
+describe('currentDelta', () => {
+  it('reads a signed weight as a delta', () => {
+    expect(currentDelta('+0.5', 'weight')).toBe(0.5)
+    expect(currentDelta('-0.25', 'weight')).toBe(-0.25)
+  })
+
+  it('refuses to treat a bare target as a delta', () => {
+    // This is the whole point. "2.5" means take the position to 2.5%; stepping
+    // from it would silently reinterpret it as "add 2.5%".
+    expect(currentDelta('2.5', 'weight')).toBe(0)
+    expect(currentDelta('0', 'weight')).toBe(0)
+  })
+
+  it('reads signed shares only behind the # prefix', () => {
+    expect(currentDelta('#+100', 'shares')).toBe(100)
+    expect(currentDelta('#-50', 'shares')).toBe(-50)
+    expect(currentDelta('#500', 'shares')).toBe(0)
+  })
+
+  it('reads active-space deltas only behind @d', () => {
+    expect(currentDelta('@d+0.25', 'active')).toBe(0.25)
+    expect(currentDelta('@t0.5', 'active')).toBe(0)
+  })
+
+  it('ignores a value written in another mode syntax', () => {
+    // Switching modes leaves the old string briefly in the field; stepping must
+    // not reinterpret shares as weight.
+    expect(currentDelta('#+100', 'weight')).toBe(0)
+    expect(currentDelta('@d+0.5', 'weight')).toBe(0)
+    expect(currentDelta('+0.5', 'shares')).toBe(0)
+  })
+
+  it('returns zero for empty and unparseable input', () => {
+    expect(currentDelta('', 'weight')).toBe(0)
+    expect(currentDelta('   ', 'weight')).toBe(0)
+    expect(currentDelta('abc', 'weight')).toBe(0)
+    expect(currentDelta('+', 'weight')).toBe(0)
+  })
+})
+
+describe('applyStep', () => {
+  it('accumulates repeated taps', () => {
+    let v = ''
+    v = applyStep(v, 'weight', 0.25)
+    v = applyStep(v, 'weight', 0.25)
+    v = applyStep(v, 'weight', 0.25)
+    expect(v).toBe('+0.75')
+  })
+
+  it('clears the field when the deltas cancel out', () => {
+    const up = applyStep('', 'weight', 0.5)
+    expect(applyStep(up, 'weight', -0.5)).toBe('')
+  })
+
+  it('crosses zero into a negative delta', () => {
+    expect(applyStep('+0.25', 'weight', -0.5)).toBe('-0.25')
+  })
+
+  it('replaces rather than accumulates when the field holds a target', () => {
+    // Starting from a target, one +0.5 tap means "+0.5", never "3".
+    expect(applyStep('2.5', 'weight', 0.5)).toBe('+0.5')
+  })
+
+  it('keeps the mode prefix', () => {
+    expect(applyStep('', 'shares', 500)).toBe('#+500')
+    expect(applyStep('#+500', 'shares', -100)).toBe('#+400')
+    expect(applyStep('', 'active', 0.25)).toBe('@d+0.25')
+  })
+
+  it('does not accumulate floating point noise', () => {
+    let v = ''
+    for (let i = 0; i < 3; i++) v = applyStep(v, 'weight', 0.1)
+    expect(v).toBe('+0.3')
+  })
+
+  /**
+   * The contract that matters most: whatever the chips emit must be something
+   * the production parser accepts. If these drift, the sheet produces strings
+   * that fail validation only once committed.
+   */
+  it('emits strings the real sizing parser accepts', () => {
+    const cases: [string, 'weight' | 'shares' | 'active', number][] = [
+      ['', 'weight', 0.25],
+      ['', 'weight', -1],
+      ['', 'shares', 500],
+      ['', 'shares', -1000],
+      ['', 'active', 0.5],
+    ]
+    for (const [start, mode, step] of cases) {
+      const out = applyStep(start, mode, step)
+      const parsed = parseSizingInput(out, { has_benchmark: true })
+      expect(parsed.is_valid, `${mode} step ${step} produced "${out}"`).toBe(true)
+    }
+  })
+})
+
+describe('prefixForMode', () => {
+  it('matches the syntax the parser expects', () => {
+    expect(prefixForMode('weight')).toBe('')
+    expect(prefixForMode('shares')).toBe('#')
+    expect(prefixForMode('active')).toBe('@d')
+  })
+})

--- a/src/lib/mobile/sizing-steps.ts
+++ b/src/lib/mobile/sizing-steps.ts
@@ -1,0 +1,69 @@
+/**
+ * Quick-adjust chip arithmetic for the mobile sizing sheet.
+ *
+ * The chips accumulate: tapping +0.25 three times should read "+0.75", not
+ * replace the field each time. That requires reading the number already there,
+ * which is where the danger is — a bare "2.5" is a *target weight*, and adding
+ * a chip to it would silently convert the user's target into a delta and size
+ * the position to something they never asked for.
+ *
+ * Extracted from the sheet so that rule is pinned by tests rather than living
+ * inside a component. Every failure here is silent and lands in a real trade.
+ */
+
+export type SizingMode = 'weight' | 'shares' | 'active'
+
+/** The prefix a mode's delta syntax carries. */
+export function prefixForMode(mode: SizingMode): string {
+  return mode === 'shares' ? '#' : mode === 'active' ? '@d' : ''
+}
+
+/**
+ * The signed delta currently expressed by `value`, or 0 if it is not a delta.
+ *
+ * Returns 0 — meaning "start from nothing" — for a bare target, for an empty
+ * field, for unparseable text, and for a value written in a different mode's
+ * syntax. In every one of those cases the alternative is inventing a base the
+ * user did not type.
+ */
+export function currentDelta(value: string, mode: SizingMode): number {
+  const raw = value.trim()
+  if (!raw) return 0
+
+  const prefix = prefixForMode(mode)
+  if (prefix) {
+    if (!raw.startsWith(prefix)) return 0
+    const body = raw.slice(prefix.length).trim()
+    return signedOrZero(body)
+  }
+
+  // Weight mode owns the unprefixed syntax, so anything carrying another
+  // mode's marker belongs to that mode and must not be stepped here.
+  if (raw.startsWith('#') || raw.startsWith('@')) return 0
+  return signedOrZero(raw)
+}
+
+function signedOrZero(body: string): number {
+  // Only an explicitly signed number is a delta. "2.5" is a target.
+  if (!/^[+-]/.test(body)) return 0
+  const n = parseFloat(body)
+  return Number.isFinite(n) ? n : 0
+}
+
+/**
+ * Apply a chip, returning the new field value.
+ *
+ * Returns '' when the accumulated delta lands back on zero, so tapping +0.5
+ * then −0.5 clears the field rather than leaving a "+0" that reads as a
+ * deliberate no-change instruction.
+ */
+export function applyStep(value: string, mode: SizingMode, amount: number): string {
+  const prefix = prefixForMode(mode)
+  const next = round2(currentDelta(value, mode) + amount)
+  if (next === 0) return ''
+  return `${prefix}${next > 0 ? '+' : ''}${next}`
+}
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100
+}

--- a/src/pages/SimulationPage.tsx
+++ b/src/pages/SimulationPage.tsx
@@ -92,6 +92,8 @@ import { TradeSheetPanel } from '../components/trading/TradeSheetPanel'
 import { TradeSheetReadinessPanel } from '../components/trading/TradeSheetReadinessPanel'
 import { UnifiedSizingInput, type CurrentPosition as UnifiedCurrentPosition } from '../components/trading/UnifiedSizingInput'
 import { InlineConflictBadge, SummaryBarConflicts, CardConflictRow } from '../components/trading/TradeCardConflictBadge'
+import { useIsMobile } from '../hooks/useMediaQuery'
+import { MobileSimulationList } from '../components/mobile/trade-lab/MobileSimulationList'
 import { HoldingsSimulationTable } from '../components/trading/HoldingsSimulationTable'
 import { PilotTradeLabIntroBanner } from '../components/pilot/PilotTradeLabIntroBanner'
 import { SharedSimulationBanner } from '../components/trading/SharedSimulationBanner'
@@ -387,6 +389,8 @@ export function SimulationPage({ simulationId: propSimulationId, tabId, onClose,
   const canCollaborate = isSharedView && sharedSimData?.access_level === 'collaborate' && sharedSimData?.share_mode === 'live'
   // Suggest mode = read-only table + suggest overlay; Collaborate = full editing
   const tableReadOnly = isReadOnly || canSuggest
+  // Phones render MobileSimulationList in place of the eleven-column table.
+  const isMobileViewport = useIsMobile()
 
   // Suggestion review panel state (owner-side)
   const [suggestionReviewOpen, setSuggestionReviewOpen] = useState(false)
@@ -2182,6 +2186,130 @@ export function SimulationPage({ simulationId: propSimulationId, tabId, onClose,
       hasBenchmark,
     })
   }, [simulation, priceMap, tradeLab?.id, queryClient, v3CreateVariant, getActiveWeightConfig, hasBenchmark])
+
+  /**
+   * Sizing write and variant removal, shared by the desktop table and the
+   * phone list. Both were inline on the table; the mobile surface needs the
+   * identical path — temp-variant handling, optimistic cache write, pending
+   * sizing hand-off — and duplicating a hundred lines of it would guarantee
+   * the two drift.
+   */
+  const handleVariantSizingUpdate = (variantId: string, updates: { action?: TradeAction; sizingInput?: string }) => {
+    // Temp variants: apply cache update for instant display, store
+    // pending sizing so it's used when the real variant arrives.
+    if (variantId.startsWith('temp-')) {
+      const tempAssetId = variantId.replace('temp-', '')
+      if (updates.sizingInput !== undefined) {
+        pendingSizingRef.current.set(tempAssetId, updates.sizingInput)
+      }
+      if (tradeLab?.id) {
+        // Cancel in-flight refetches so they don't overwrite our optimistic update
+        queryClient.cancelQueries({ queryKey: ['intent-variants', tradeLab.id] })
+        queryClient.setQueryData<IntentVariant[]>(
+          ['intent-variants', tradeLab.id, null],
+          (old) => old?.map(v => v.id === variantId
+            ? {
+                ...v,
+                ...(updates.sizingInput !== undefined ? {
+                  sizing_input: updates.sizingInput,
+                  sizing_spec: null,
+                  computed: null,
+                } : {}),
+                ...(updates.action !== undefined ? { action: updates.action } : {}),
+              }
+            : v
+          ) ?? []
+        )
+      }
+      return
+    }
+    const variant = intentVariants.find(v => v.id === variantId)
+    const assetId = variant?.asset_id || ''
+    const baselineHoldings = simulation.baseline_holdings as BaselineHolding[]
+    const holding = baselineHoldings.find(h => h.asset_id === assetId)
+    const currentPosition = holding ? {
+      shares: holding.shares,
+      weight: holding.weight,
+      cost_basis: null,
+      active_weight: null,
+    } : null
+    const assetPrice = {
+      asset_id: assetId,
+      price: priceMap?.[assetId] || holding?.price || 100,
+      timestamp: new Date().toISOString(),
+      source: 'realtime' as const,
+    }
+
+    // Optimistic: update variant in cache immediately so the row
+    // shows the new value before the server round-trip completes.
+    // This also prevents cleanupEmptyVariant from deleting a variant
+    // whose sizing_input was '' in the stale cache.
+    if (tradeLab?.id) {
+      // Cancel in-flight refetches so they don't overwrite our optimistic update
+      queryClient.cancelQueries({ queryKey: ['intent-variants', tradeLab.id] })
+      queryClient.setQueryData<IntentVariant[]>(
+        ['intent-variants', tradeLab.id, null],
+        (old) => old?.map(v => v.id === variantId
+          ? {
+              ...v,
+              ...(updates.sizingInput !== undefined ? {
+                sizing_input: updates.sizingInput,
+                sizing_spec: null,  // Clear stale spec so hook uses quick estimate
+                computed: null,     // Clear stale computed so deltas recompute
+              } : {}),
+              ...(updates.action !== undefined ? { action: updates.action } : {}),
+            }
+          : v
+        ) ?? []
+      )
+    }
+
+    v3UpdateVariant({
+      variantId,
+      updates,
+      currentPosition,
+      price: assetPrice,
+      portfolioTotalValue: simulation.baseline_total_value || 0,
+      roundingConfig: { lot_size: 1, min_lot_behavior: 'round', round_direction: 'toward_zero' },
+      activeWeightConfig: getActiveWeightConfig(assetId),
+      hasBenchmark,
+    })
+
+    // If this variant has no matching simulation_trade (created via
+    // direct click on baseline position), create one so the dual-write
+    // invariant holds and the trade appears in the Trades tab.
+    if (updates.sizingInput && assetId && simulation?.simulation_trades) {
+      const hasTrade = simulation.simulation_trades.some(t => t.asset_id === assetId)
+      if (!hasTrade) {
+        supabase.from('simulation_trades')
+          .upsert({
+            simulation_id: simulation.id,
+            asset_id: assetId,
+            action: updates.action || variant?.action || 'add',
+            price: priceMap?.[assetId] || holding?.price || 100,
+            sort_order: simulation.simulation_trades.length,
+          }, { onConflict: 'simulation_id,asset_id' })
+          .select()
+          .single()
+          .then(({ error }) => {
+            if (!error) queryClient.invalidateQueries({ queryKey: ['simulation', simulation.id] })
+          })
+      }
+    }
+  }
+
+  const handleVariantDelete = (variantId: string) => {
+    // If deleting a temp variant from a direct edit (user escaped
+    // before server responded), track the cancellation so the
+    // follow-up effect can delete the real variant when it arrives.
+    if (variantId.startsWith('temp-')) {
+      const assetId = variantId.replace('temp-', '')
+      cancelledDirectEditsRef.current.add(assetId)
+      // Also clear any pending sizing for this asset
+      pendingSizingRef.current.delete(assetId)
+    }
+    v3DeleteVariant({ variantId })
+  }
 
   // Pro-rata cash rebalance. User clicks the CASH_USD sim wt cell and
   // enters a target cash weight (0-100). We then scale every non-cash
@@ -6346,6 +6474,27 @@ export function SimulationPage({ simulationId: propSimulationId, tabId, onClose,
                           </div>
                         </div>
                       )}
+                      {/* Phones get a list, not the table. Eleven columns do not
+                          degrade to 390px — the columns are the product, and
+                          reflowed they become a horizontally scrolling grid whose
+                          headers leave the screen. MobileSimulationList takes the
+                          same rows and the same write handlers, so the sync,
+                          convergence and ordering machinery above is untouched and
+                          both surfaces stay one implementation deep. */}
+                      {isMobileViewport ? (
+                        <div className="relative flex-1 min-w-0 overflow-hidden">
+                          <MobileSimulationList
+                            rows={simulationRows.rows}
+                            summary={simulationRows.summary}
+                            portfolioTotalValue={effectiveTotalValue}
+                            hasBenchmark={hasBenchmark}
+                            readOnly={tableReadOnly}
+                            onUpdateVariant={handleVariantSizingUpdate}
+                            onCreateVariant={handleCreateVariantForHolding}
+                            onDeleteVariant={handleVariantDelete}
+                          />
+                        </div>
+                      ) : (
                       <div className="flex-1 min-w-0 rounded-2xl border border-gray-200 dark:border-gray-700 overflow-hidden bg-white dark:bg-gray-800">
                         <HoldingsSimulationTable
                           rows={simulationRows.rows}
@@ -6364,123 +6513,10 @@ export function SimulationPage({ simulationId: propSimulationId, tabId, onClose,
                           pendingSuggestionsByAsset={pendingSuggestionsByAsset}
                           pendingSuggestionCount={!isSharedView ? pendingSuggestionCount : undefined}
                           onOpenSuggestionReview={!isSharedView ? () => setSuggestionReviewOpen(true) : undefined}
-                          onUpdateVariant={(variantId, updates) => {
-                            // Temp variants: apply cache update for instant display, store
-                            // pending sizing so it's used when the real variant arrives.
-                            if (variantId.startsWith('temp-')) {
-                              const tempAssetId = variantId.replace('temp-', '')
-                              if (updates.sizingInput !== undefined) {
-                                pendingSizingRef.current.set(tempAssetId, updates.sizingInput)
-                              }
-                              if (tradeLab?.id) {
-                                // Cancel in-flight refetches so they don't overwrite our optimistic update
-                                queryClient.cancelQueries({ queryKey: ['intent-variants', tradeLab.id] })
-                                queryClient.setQueryData<IntentVariant[]>(
-                                  ['intent-variants', tradeLab.id, null],
-                                  (old) => old?.map(v => v.id === variantId
-                                    ? {
-                                        ...v,
-                                        ...(updates.sizingInput !== undefined ? {
-                                          sizing_input: updates.sizingInput,
-                                          sizing_spec: null,
-                                          computed: null,
-                                        } : {}),
-                                        ...(updates.action !== undefined ? { action: updates.action } : {}),
-                                      }
-                                    : v
-                                  ) ?? []
-                                )
-                              }
-                              return
-                            }
-                            const variant = intentVariants.find(v => v.id === variantId)
-                            const assetId = variant?.asset_id || ''
-                            const baselineHoldings = simulation.baseline_holdings as BaselineHolding[]
-                            const holding = baselineHoldings.find(h => h.asset_id === assetId)
-                            const currentPosition = holding ? {
-                              shares: holding.shares,
-                              weight: holding.weight,
-                              cost_basis: null,
-                              active_weight: null,
-                            } : null
-                            const assetPrice = {
-                              asset_id: assetId,
-                              price: priceMap?.[assetId] || holding?.price || 100,
-                              timestamp: new Date().toISOString(),
-                              source: 'realtime' as const,
-                            }
-
-                            // Optimistic: update variant in cache immediately so the row
-                            // shows the new value before the server round-trip completes.
-                            // This also prevents cleanupEmptyVariant from deleting a variant
-                            // whose sizing_input was '' in the stale cache.
-                            if (tradeLab?.id) {
-                              // Cancel in-flight refetches so they don't overwrite our optimistic update
-                              queryClient.cancelQueries({ queryKey: ['intent-variants', tradeLab.id] })
-                              queryClient.setQueryData<IntentVariant[]>(
-                                ['intent-variants', tradeLab.id, null],
-                                (old) => old?.map(v => v.id === variantId
-                                  ? {
-                                      ...v,
-                                      ...(updates.sizingInput !== undefined ? {
-                                        sizing_input: updates.sizingInput,
-                                        sizing_spec: null,  // Clear stale spec so hook uses quick estimate
-                                        computed: null,     // Clear stale computed so deltas recompute
-                                      } : {}),
-                                      ...(updates.action !== undefined ? { action: updates.action } : {}),
-                                    }
-                                  : v
-                                ) ?? []
-                              )
-                            }
-
-                            v3UpdateVariant({
-                              variantId,
-                              updates,
-                              currentPosition,
-                              price: assetPrice,
-                              portfolioTotalValue: simulation.baseline_total_value || 0,
-                              roundingConfig: { lot_size: 1, min_lot_behavior: 'round', round_direction: 'toward_zero' },
-                              activeWeightConfig: getActiveWeightConfig(assetId),
-                              hasBenchmark,
-                            })
-
-                            // If this variant has no matching simulation_trade (created via
-                            // direct click on baseline position), create one so the dual-write
-                            // invariant holds and the trade appears in the Trades tab.
-                            if (updates.sizingInput && assetId && simulation?.simulation_trades) {
-                              const hasTrade = simulation.simulation_trades.some(t => t.asset_id === assetId)
-                              if (!hasTrade) {
-                                supabase.from('simulation_trades')
-                                  .upsert({
-                                    simulation_id: simulation.id,
-                                    asset_id: assetId,
-                                    action: updates.action || variant?.action || 'add',
-                                    price: priceMap?.[assetId] || holding?.price || 100,
-                                    sort_order: simulation.simulation_trades.length,
-                                  }, { onConflict: 'simulation_id,asset_id' })
-                                  .select()
-                                  .single()
-                                  .then(({ error }) => {
-                                    if (!error) queryClient.invalidateQueries({ queryKey: ['simulation', simulation.id] })
-                                  })
-                              }
-                            }
-                          }}
+                          onUpdateVariant={handleVariantSizingUpdate}
                           onRemoveAsset={handleRemoveAsset}
                           recentlyRemovedAssetIds={recentlyRemovedAssetIds}
-                          onDeleteVariant={(variantId) => {
-                            // If deleting a temp variant from a direct edit (user escaped
-                            // before server responded), track the cancellation so the
-                            // follow-up effect can delete the real variant when it arrives.
-                            if (variantId.startsWith('temp-')) {
-                              const assetId = variantId.replace('temp-', '')
-                              cancelledDirectEditsRef.current.add(assetId)
-                              // Also clear any pending sizing for this asset
-                              pendingSizingRef.current.delete(assetId)
-                            }
-                            v3DeleteVariant({ variantId })
-                          }}
+                          onDeleteVariant={handleVariantDelete}
                           onCreateVariant={handleCreateVariantForHolding}
                           onSetCashTarget={!isSharedView ? handleSetCashTarget : undefined}
                           onClearAllTrades={!isSharedView ? handleClearAllTrades : undefined}
@@ -6511,6 +6547,7 @@ export function SimulationPage({ simulationId: propSimulationId, tabId, onClose,
                           decisionConfirmationOpen={!!decisionRecord}
                         />
                       </div>
+                      )}
                       {/* Suggestion Review Panel (owner-side) */}
                       {suggestionReviewOpen && !isSharedView && (
                         <SuggestionReviewPanel


### PR DESCRIPTION
The desktop surface is an eleven-column keyboard-driven table. It does not degrade to 390px, and not because of width: the columns *are* the product — current versus simulated, in weight and in shares, with both deltas — so reflowing them gives a horizontally scrolling grid whose headers leave the screen, which is worse than useless for numbers that mean nothing without their label.

MobileSimulationList
One card per position carrying the single comparison that matters: where the weight is now, where the sizing takes it, the delta, and what it costs. Traded rows take a coloured left edge and an action badge; untraded rows stay quiet but reachable, because sizing a position you do not hold starts with finding it. Filters are Trading / All positions / New.

The three summary numbers — trade count, net delta weight, turnover — move to the top. On the desktop they are a table footer, which on a phone is a scroll away from the thing it summarises and is the first question, not the last.

MobileSizingSheet
This is the one screen where a phone can beat the desktop. Sizing is arithmetic against a number you already know — "take it to three", "add a quarter point" — which at a keyboard is a syntax and on a phone is a tap. Six delta chips are the primary control, a mode switch writes the #/@d prefix so the syntax never has to be recalled, and the text field remains for anything the chips do not cover, still accepting the full desktop grammar so muscle memory transfers.

A before/after readout with a two-tone weight bar sits above it, projected locally so it tracks taps at tap speed. It covers only the frameworks the chips produce; active-space sizing needs the benchmark to resolve, so it shows nothing there rather than a number that ignores it. The server recomputes on commit and remains the authority.

Shared, not forked
The list takes the same rows and the same write handlers the desktop table already receives, so the sync, convergence and row-ordering machinery in SimulationPage is untouched. The two inline handlers the table used — temp-variant cache writes, pending-sizing hand-off — are hoisted to handleVariantSizingUpdate / handleVariantDelete and shared, rather than duplicating a hundred lines that would certainly drift.

Chip arithmetic is extracted and tested
applyStep/currentDelta live in lib/mobile/sizing-steps.ts because their failure mode is silent and lands in a real trade: a bare "2.5" is a target weight, and accumulating a chip onto it would quietly reinterpret it as a delta and size the position to something nobody asked for. 14 tests pin that, plus mode-prefix isolation, zero-crossing, float noise, and a round-trip asserting every string the chips emit parses as valid under the production parser.

42 test files, 996 passing. Production build clean. Typecheck at baseline.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
