### PR TITLE
fix(mobile): Trade Lab feedback — empty workspace, unreadable recs, h…

### DIFF
--- a/src/components/mobile/trade-lab/MobileIdeasDrawer.tsx
+++ b/src/components/mobile/trade-lab/MobileIdeasDrawer.tsx
@@ -19,13 +19,14 @@ interface DrawerItem {
 }
 
 interface MobileIdeasDrawerProps {
+  /** The lab's portfolio, so ideas belonging elsewhere can be called out. */
+  currentPortfolioId?: string | null
   items: DrawerItem[]
   proposals: any[]
   search: string
   onSearchChange: (v: string) => void
   onToggleAsset: (idea: any, isAdded: boolean) => void
   onOpenIdea: (ideaId: string) => void
-  onOpenProposal?: (proposalId: string) => void
 }
 
 const STAGE_LABEL: Record<string, string> = {
@@ -54,13 +55,13 @@ const STAGE_LABEL: Record<string, string> = {
  * stopPropagation on a small square, which on a thumb is a coin toss.
  */
 export function MobileIdeasDrawer({
+  currentPortfolioId,
   items,
   proposals,
   search,
   onSearchChange,
   onToggleAsset,
   onOpenIdea,
-  onOpenProposal,
 }: MobileIdeasDrawerProps) {
   const [tab, setTab] = useState<'ideas' | 'proposals'>(
     proposals.length > 0 ? 'proposals' : 'ideas'
@@ -115,38 +116,77 @@ export function MobileIdeasDrawer({
         ) : tab === 'ideas' ? (
           items.map((item, i) =>
             item.type === 'pair' ? (
-              <PairRow key={item.pairTrade?.id ?? `pair-${i}`} item={item} onToggleAsset={onToggleAsset} onOpenIdea={onOpenIdea} />
+              <PairRow key={item.pairTrade?.id ?? `pair-${i}`} item={item} currentPortfolioId={currentPortfolioId} onToggleAsset={onToggleAsset} onOpenIdea={onOpenIdea} />
             ) : (
-              <IdeaRow key={item.idea?.id ?? `idea-${i}`} idea={item.idea} onToggleAsset={onToggleAsset} onOpenIdea={onOpenIdea} />
+              <IdeaRow key={item.idea?.id ?? `idea-${i}`} idea={item.idea} currentPortfolioId={currentPortfolioId} onToggleAsset={onToggleAsset} onOpenIdea={onOpenIdea} />
             )
           )
         ) : (
-          proposals.map((p, i) => (
-            <button
-              key={p.proposal?.id ?? `proposal-${i}`}
-              type="button"
-              onClick={() => onOpenProposal?.(p.proposal?.id)}
-              className="w-full text-left rounded-xl border border-amber-200 dark:border-amber-900/50 bg-amber-50/60 dark:bg-amber-900/10 p-3 active:bg-amber-100/60"
-            >
-              <div className="flex items-center gap-2">
-                <Scale className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
-                <span className="text-sm font-bold text-gray-900 dark:text-white">
-                  {p.proposal?.asset?.symbol ?? p.legs?.[0]?.symbol ?? 'Recommendation'}
-                </span>
-                {p.isPairTrade && (
-                  <span className="px-1.5 py-0.5 rounded text-[10px] font-bold uppercase bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300">
-                    Pair
+          proposals.map((p, i) => {
+            const item = p.proposal?.trade_queue_items
+            const asset = item?.assets
+            const proposer = p.proposal?.users
+            return (
+              <button
+                key={p.proposal?.id ?? `proposal-${i}`}
+                type="button"
+                onClick={() => onOpenIdea(item?.id ?? p.proposal?.trade_queue_item_id)}
+                className="w-full text-left rounded-xl border border-amber-200 dark:border-amber-900/50 bg-amber-50/60 dark:bg-amber-900/10 p-3 active:bg-amber-100/60"
+              >
+                <div className="flex items-center gap-2">
+                  <Scale className="h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+                  <span className="text-sm font-bold text-gray-900 dark:text-white">
+                    {asset?.symbol ?? p.legs?.[0]?.symbol ?? '—'}
                   </span>
-                )}
-                <ChevronRight className="ml-auto h-4 w-4 shrink-0 text-gray-300" />
-              </div>
-              {p.proposal?.rationale && (
-                <p className="mt-1 text-[12px] leading-snug text-gray-600 dark:text-gray-300 line-clamp-2">
-                  {p.proposal.rationale}
+                  {(item?.action || p.legs?.[0]?.action) && (
+                    <span
+                      className={clsx(
+                        'px-1.5 py-0.5 rounded text-[10px] font-bold uppercase',
+                        (item?.action ?? p.legs?.[0]?.action) === 'buy' || (item?.action ?? p.legs?.[0]?.action) === 'add'
+                          ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300'
+                          : 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300'
+                      )}
+                    >
+                      {item?.action ?? p.legs?.[0]?.action}
+                    </span>
+                  )}
+                  {p.isPairTrade && (
+                    <span className="px-1.5 py-0.5 rounded text-[10px] font-bold uppercase bg-indigo-100 text-indigo-700 dark:bg-indigo-900/40 dark:text-indigo-300">
+                      Pair
+                    </span>
+                  )}
+                  <ChevronRight className="ml-auto h-4 w-4 shrink-0 text-gray-300" />
+                </div>
+
+                <p className="mt-0.5 min-w-0 truncate text-[11px] text-gray-500 dark:text-gray-400">
+                  {asset?.company_name}
                 </p>
-              )}
-            </button>
-          ))
+
+                {/* The recommended size is the recommendation. Without it the
+                    card names a ticker and says nothing about what is being
+                    asked for. */}
+                {(p.proposal?.weight != null || p.proposal?.shares != null) && (
+                  <p className="mt-1 text-[12px] font-semibold tabular-nums text-gray-800 dark:text-gray-100">
+                    {p.proposal.weight != null ? `${Number(p.proposal.weight).toFixed(2)}% target` : ''}
+                    {p.proposal.weight != null && p.proposal.shares != null ? ' · ' : ''}
+                    {p.proposal.shares != null ? `${Number(p.proposal.shares).toLocaleString()} sh` : ''}
+                  </p>
+                )}
+
+                {(p.proposal?.notes || item?.rationale) && (
+                  <p className="mt-1 text-[12px] leading-snug text-gray-600 dark:text-gray-300 line-clamp-2">
+                    {p.proposal?.notes || item?.rationale}
+                  </p>
+                )}
+
+                {proposer && (
+                  <p className="mt-1 text-[11px] text-gray-400 truncate">
+                    from {[proposer.first_name, proposer.last_name].filter(Boolean).join(' ') || proposer.email}
+                  </p>
+                )}
+              </button>
+            )
+          })
         )}
       </div>
     </div>
@@ -191,16 +231,24 @@ function TabButton({
  */
 function IdeaRow({
   idea,
+  currentPortfolioId,
   onToggleAsset,
   onOpenIdea,
 }: {
   idea: any
+  currentPortfolioId?: string | null
   onToggleAsset: (idea: any, isAdded: boolean) => void
   onOpenIdea: (id: string) => void
 }) {
   if (!idea) return null
   const added = !!idea.isAdded
   const stage = idea.effectiveStage || idea.stage || idea.status
+  // The drawer is not scoped to the lab's portfolio — ideas also arrive via
+  // trade_lab_idea_links, so a row can belong somewhere else entirely. Adding
+  // one still simulates it against the portfolio selected at the top, which is
+  // worth knowing before you tick it.
+  const portfolioName = idea.portfolios?.name ?? null
+  const isForeign = !!idea.portfolio_id && !!currentPortfolioId && idea.portfolio_id !== currentPortfolioId
 
   return (
     <div className="flex items-stretch gap-2 rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 overflow-hidden">
@@ -249,9 +297,30 @@ function IdeaRow({
           </span>
           <ChevronRight className="h-4 w-4 shrink-0 text-gray-300" />
         </div>
-        {stage && (
-          <p className="mt-0.5 text-[11px] text-gray-400">{STAGE_LABEL[stage] ?? String(stage).replace(/_/g, ' ')}</p>
-        )}
+        <div className="mt-0.5 flex items-center gap-1.5 text-[11px]">
+          {stage && (
+            <span className="text-gray-400">{STAGE_LABEL[stage] ?? String(stage).replace(/_/g, ' ')}</span>
+          )}
+          {portfolioName && (
+            <>
+              <span className="text-gray-300">·</span>
+              <span
+                className={clsx(
+                  'min-w-0 truncate',
+                  isForeign ? 'text-amber-600 dark:text-amber-400 font-medium' : 'text-gray-400'
+                )}
+              >
+                {portfolioName}
+              </span>
+            </>
+          )}
+          {!idea.portfolio_id && (
+            <>
+              <span className="text-gray-300">·</span>
+              <span className="text-gray-400">No portfolio</span>
+            </>
+          )}
+        </div>
       </button>
     </div>
   )
@@ -260,10 +329,12 @@ function IdeaRow({
 /** A pair, with each leg individually addable — legs can be simulated apart. */
 function PairRow({
   item,
+  currentPortfolioId,
   onToggleAsset,
   onOpenIdea,
 }: {
   item: DrawerItem
+  currentPortfolioId?: string | null
   onToggleAsset: (idea: any, isAdded: boolean) => void
   onOpenIdea: (id: string) => void
 }) {
@@ -279,7 +350,7 @@ function PairRow({
       </div>
       <div className="space-y-1.5 px-2 pb-2">
         {(item.legs ?? []).map((leg: any) => (
-          <IdeaRow key={leg.id} idea={leg} onToggleAsset={onToggleAsset} onOpenIdea={onOpenIdea} />
+          <IdeaRow key={leg.id} idea={leg} currentPortfolioId={currentPortfolioId} onToggleAsset={onToggleAsset} onOpenIdea={onOpenIdea} />
         ))}
       </div>
     </div>

--- a/src/components/mobile/trade-lab/MobileSimulationList.tsx
+++ b/src/components/mobile/trade-lab/MobileSimulationList.tsx
@@ -19,11 +19,17 @@ interface MobileSimulationListProps {
   onAddPosition?: () => void
 }
 
-type Filter = 'traded' | 'all' | 'new'
+type Filter = 'all' | 'changed' | 'new'
 
+/**
+ * Named for what the list contains, not for a state a position is in.
+ * "Trading / All positions / New" made the reader work out that the first was
+ * a subset of the second, and defaulting to it showed an empty screen on any
+ * lab where nothing had been sized yet.
+ */
 const FILTERS: { key: Filter; label: string }[] = [
-  { key: 'traded', label: 'Trading' },
-  { key: 'all', label: 'All positions' },
+  { key: 'all', label: 'Holdings' },
+  { key: 'changed', label: 'Changed' },
   { key: 'new', label: 'New' },
 ]
 
@@ -66,7 +72,7 @@ export function MobileSimulationList({
   onDeleteVariant,
   onAddPosition,
 }: MobileSimulationListProps) {
-  const [filter, setFilter] = useState<Filter>('traded')
+  const [filter, setFilter] = useState<Filter>('all')
   const [search, setSearch] = useState('')
   const [editing, setEditing] = useState<string | null>(null)
 
@@ -74,7 +80,7 @@ export function MobileSimulationList({
     const q = search.trim().toLowerCase()
     return rows.filter(r => {
       if (r.isCash) return false
-      if (filter === 'traded' && !r.variant?.sizing_input) return false
+      if (filter === 'changed' && !r.variant?.sizing_input) return false
       if (filter === 'new' && !r.isNew) return false
       if (q && !`${r.symbol} ${r.company_name}`.toLowerCase().includes(q)) return false
       return true
@@ -114,22 +120,31 @@ export function MobileSimulationList({
 
       <div className="flex-shrink-0 px-3 pt-2 pb-1 space-y-2">
         <div className="flex gap-1">
-          {FILTERS.map(f => (
-            <button
-              key={f.key}
-              type="button"
-              onClick={() => setFilter(f.key)}
-              aria-current={filter === f.key}
-              className={clsx(
-                'flex-1 h-9 rounded-lg text-sm font-medium transition-colors no-touch-target',
-                filter === f.key
-                  ? 'bg-primary-50 text-primary-700 dark:bg-primary-900/30 dark:text-primary-300'
-                  : 'text-gray-500 dark:text-gray-400 active:bg-gray-100 dark:active:bg-gray-800'
-              )}
-            >
-              {f.label}
-            </button>
-          ))}
+          {FILTERS.map(f => {
+            const count = rows.filter(r => {
+              if (r.isCash) return false
+              if (f.key === 'changed') return !!r.variant?.sizing_input
+              if (f.key === 'new') return r.isNew
+              return true
+            }).length
+            return (
+              <button
+                key={f.key}
+                type="button"
+                onClick={() => setFilter(f.key)}
+                aria-current={filter === f.key}
+                className={clsx(
+                  'flex-1 h-9 rounded-lg text-sm font-medium transition-colors no-touch-target',
+                  filter === f.key
+                    ? 'bg-primary-50 text-primary-700 dark:bg-primary-900/30 dark:text-primary-300'
+                    : 'text-gray-500 dark:text-gray-400 active:bg-gray-100 dark:active:bg-gray-800'
+                )}
+              >
+                {f.label}
+                <span className="ml-1 text-[11px] tabular-nums opacity-70">{count}</span>
+              </button>
+            )
+          })}
         </div>
 
         <div className="relative">
@@ -159,8 +174,8 @@ export function MobileSimulationList({
             <p className="text-sm text-center">
               {search
                 ? 'No position matches that.'
-                : filter === 'traded'
-                  ? 'Nothing sized yet. Switch to All positions to start one.'
+                : filter === 'changed'
+                  ? 'Nothing changed yet. Open a holding to size it.'
                   : filter === 'new'
                     ? 'No new positions in this simulation.'
                     : 'This portfolio has no holdings.'}
@@ -282,6 +297,14 @@ function PositionCard({ row, onOpen }: { row: SimulationRow; onOpen: () => void 
         <span className="text-sm tabular-nums text-gray-500 dark:text-gray-400">
           {row.currentWeight.toFixed(2)}%
         </span>
+        {/* An unsized holding otherwise shows a single number and no hint that
+            the row does anything — the whole point of the list is that it is
+            where you change a weight. */}
+        {!traded && !locked && (
+          <span className="ml-auto text-[11px] text-primary-600 dark:text-primary-400">
+            Tap to size
+          </span>
+        )}
         {traded && (
           <>
             <span className="text-gray-300">→</span>

--- a/src/pages/SimulationPage.tsx
+++ b/src/pages/SimulationPage.tsx
@@ -5345,7 +5345,7 @@ export function SimulationPage({ simulationId: propSimulationId, tabId, onClose,
             <h1 className="hidden sm:block text-lg font-semibold text-gray-900 dark:text-white">
               {isSharedView ? 'Shared Simulation' : 'Trade Lab'}
             </h1>
-            <OrgBadge />
+            <span className="hidden sm:inline-flex"><OrgBadge /></span>
             {isSharedView && sharedSimData && (
               <>
                 <span className="text-gray-300 dark:text-gray-600">|</span>
@@ -5354,11 +5354,11 @@ export function SimulationPage({ simulationId: propSimulationId, tabId, onClose,
             )}
             {!isSharedView && <span className="text-gray-300 dark:text-gray-600">|</span>}
             {/* Portfolio Selector - Searchable Dropdown — hidden in shared view */}
-            {!isSharedView && <div className="relative" ref={portfolioDropdownRef}>
+            {!isSharedView && <div className="relative flex-1 min-w-0 sm:flex-none" ref={portfolioDropdownRef}>
               <button
                 onClick={() => setPortfolioDropdownOpen(!portfolioDropdownOpen)}
                 className={clsx(
-                  "flex items-center gap-2 px-3 py-1.5 text-sm border rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white transition-colors min-w-[200px]",
+                  "flex items-center gap-2 px-3 py-1.5 text-sm border rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white transition-colors w-full sm:w-auto sm:min-w-[200px]",
                   portfolioDropdownOpen
                     ? "border-primary-500 ring-2 ring-primary-500/20"
                     : "border-gray-300 dark:border-gray-600 hover:border-gray-400 dark:hover:border-gray-500"
@@ -5481,8 +5481,9 @@ export function SimulationPage({ simulationId: propSimulationId, tabId, onClose,
                     : 'Save a snapshot of this simulation'
                 }
               >
-                <FileText className="h-4 w-4 mr-1.5" />
-                Save Snapshot
+                <FileText className="h-4 w-4 sm:mr-1.5" />
+                <span className="hidden sm:inline">Save Snapshot</span>
+                <span className="sr-only sm:hidden">Save Snapshot</span>
               </Button>
             )}
             {/* Exit shared view button */}
@@ -5813,6 +5814,7 @@ export function SimulationPage({ simulationId: propSimulationId, tabId, onClose,
 
                 {showIdeasPanel && isMobileViewport && (
                   <MobileIdeasDrawer
+                    currentPortfolioId={selectedPortfolioId}
                     items={[...filteredItems.ideas] as any}
                     proposals={filteredItems.proposals as any}
                     search={leftPaneSearch}


### PR DESCRIPTION
…eader

The empty Workspace
The position list defaulted to a "Trading" filter showing only rows that already had sizing, which on any lab where nothing has been sized yet is nothing at all — so the Simulation view looked broken rather than ready. It now opens on Holdings.

The filter names were also doing the reader's work for them: "Trading / All positions / New" required working out that the first was a subset of the second. Now Holdings / Changed / New, each carrying its count so an empty tab is visibly empty before it is opened. An unsized holding also says "Tap to size" — it previously showed one number and no hint that the row did anything, which is the whole point of the list.

Recommendations that say nothing
The proposal card read proposal.asset.symbol. That path does not exist — the asset hangs off the joined trade_queue_items — so every recommendation fell through to the literal word "Recommendation". Fixed, and the card now carries what is actually being recommended: action, company, the proposed weight or share count, the note, and who it is from. A recommendation without its size is a ticker and no request.

Which portfolio an idea is for
The drawer is not scoped to the lab's portfolio — ideas also arrive through trade_lab_idea_links, so a row can belong somewhere else entirely, and adding it still simulates against the portfolio selected at the top. Each row now names its portfolio, highlighted when it differs from the lab's, and says "No portfolio" when it has none.

Header
Org badge hidden below sm — the app shell already establishes the org, and it was spending scarce width on something unasked. The portfolio picker had min-w-[200px] plus an icon, chevron and title beside it, leaving the portfolio name a few characters; it now takes the row on a phone. Save Snapshot drops to its icon with the label kept for screen readers.

Not done: changing an idea's portfolio from the drawer. That is a write the desktop does not offer either, so it needs deciding rather than inventing.

Typecheck at baseline, 996 tests passing, production build clean.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
