### PR TITLE
fix(mobile): notes list and the note editor's left pane

### DIFF
--- a/src/components/notes/UniversalNoteEditor.tsx
+++ b/src/components/notes/UniversalNoteEditor.tsx
@@ -4,7 +4,7 @@ import {
   Plus, Search, Share2, MoreHorizontal, Trash2, Copy, ChevronDown, Users, History, Pin,
   Save, Check, AlertCircle, ArrowUpDown, X, FileText, HelpCircle, AtSign, DollarSign, Hash, FileCode, BarChart3, Sparkles,
   WifiOff, CloudOff, RefreshCw, Download, FileDown, Loader2, Paperclip, Link2, ExternalLink, FileSpreadsheet, Image, FileVideo, File,
-  PanelLeftClose, PanelLeft, CornerDownRight
+  PanelLeftClose, PanelLeft, CornerDownRight, Menu
 } from 'lucide-react'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
@@ -29,6 +29,7 @@ import { ObjectLinkPicker } from './ObjectLinkPicker'
 import { LinkedObjectsPanel } from './LinkedObjectsPanel'
 import { InlineReferencePopup } from './InlineReferencePopup'
 import { clsx } from 'clsx'
+import { useIsMobile } from '../../hooks/useMediaQuery'
 import { stripHtml } from '../../utils/stripHtml'
 
 export type EntityType = 'asset' | 'portfolio' | 'theme'
@@ -151,6 +152,9 @@ export function UniversalNoteEditor({
   const [isExporting, setIsExporting] = useState(false)
   const [showFilesLinksDropdown, setShowFilesLinksDropdown] = useState(false)
   const [isSidebarCollapsed, setIsSidebarCollapsed] = useState(false)
+  // On a phone the notes list is an overlay, not a column.
+  const isMobileViewport = useIsMobile()
+  const [mobileListOpen, setMobileListOpen] = useState(false)
   const [showLinkPicker, setShowLinkPicker] = useState(false)
   const [inlinePopup, setInlinePopup] = useState<{
     type: 'asset' | 'mention' | 'hashtag'
@@ -1648,10 +1652,17 @@ export function UniversalNoteEditor({
 
   return (
     <div className="flex h-full bg-white rounded-xl shadow-sm overflow-hidden border border-gray-200 dark:border-gray-700 dark:bg-gray-800">
-      {/* Left Sidebar - Notes List */}
-      <div className={clsx(
+      {/* Left Sidebar - Notes List.
+
+          A w-72 flex sibling leaves ~100px for the editor at 390px, which is
+          not a narrow editor, it is no editor. On a phone it becomes a
+          full-screen overlay that is absent from the layout when closed, and
+          the header carries the way back in. */}
+      {(!isMobileViewport || mobileListOpen) && <div className={clsx(
         'bg-gray-50/50 border-r border-gray-200 flex flex-col transition-all duration-300 ease-in-out dark:border-gray-700',
-        isSidebarCollapsed ? 'w-12' : 'w-72'
+        isMobileViewport
+          ? 'fixed inset-0 z-[80] w-full border-r-0 bg-white dark:bg-gray-800 pt-safe pb-safe'
+          : isSidebarCollapsed ? 'w-12' : 'w-72'
       )}>
         {/* Collapsed State */}
         {isSidebarCollapsed ? (
@@ -1679,11 +1690,19 @@ export function UniversalNoteEditor({
           <div className="flex items-center justify-between mb-3">
             <div className="flex items-center gap-2">
               <button
-                onClick={() => setIsSidebarCollapsed(true)}
-                className="w-6 h-6 flex items-center justify-center text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded transition-colors dark:hover:text-gray-300 dark:hover:bg-gray-700"
-                title="Collapse sidebar"
+                onClick={() => (isMobileViewport ? setMobileListOpen(false) : setIsSidebarCollapsed(true))}
+                className={clsx(
+                  'flex items-center justify-center text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded transition-colors dark:hover:text-gray-300 dark:hover:bg-gray-700',
+                  isMobileViewport ? 'h-9 w-9' : 'w-6 h-6'
+                )}
+                title={isMobileViewport ? 'Close' : 'Collapse sidebar'}
+                aria-label={isMobileViewport ? 'Close notes list' : 'Collapse sidebar'}
               >
-                <PanelLeftClose className="h-4 w-4" />
+                {/* A collapse-left chevron on a full-screen overlay reads as
+                    navigation rather than dismissal. */}
+                {isMobileViewport
+                  ? <X className="h-5 w-5" />
+                  : <PanelLeftClose className="h-4 w-4" />}
               </button>
               <div>
                 <h3 className="text-sm font-semibold text-gray-900 tracking-tight dark:text-white">{entityName}</h3>
@@ -1925,10 +1944,10 @@ export function UniversalNoteEditor({
         </div>
         </>
         )}
-      </div>
+      </div>}
 
       {/* Right Side - Note Editor */}
-      <div className="flex-1 flex flex-col bg-white dark:bg-gray-800">
+      <div className="flex-1 min-w-0 flex flex-col bg-white dark:bg-gray-800">
         {!selectedNote && (isLoading || isLoadingContent || createNoteMutation.isPending || (notes && notes.length > 0) || (notes?.length === 0 && !hasAutoCreatedRef.current)) ? (
           /* Loading/Creating state - show spinner whenever we don't have a selected note ready */
           <div className="flex-1 flex items-center justify-center bg-gray-50/50">
@@ -1969,9 +1988,20 @@ export function UniversalNoteEditor({
               </div>
             )}
             {/* Editor Header */}
-            <div className="px-6 py-4 border-b border-gray-100 bg-white dark:border-gray-800 dark:bg-gray-800">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center space-x-3 flex-1">
+            <div className="px-3 sm:px-6 py-3 sm:py-4 border-b border-gray-100 bg-white dark:border-gray-800 dark:bg-gray-800">
+              <div className="flex items-center justify-between gap-2">
+                <div className="flex items-center space-x-3 flex-1 min-w-0">
+                  {/* The list is an overlay on a phone, so this is the only
+                      route back to it. */}
+                  {isMobileViewport && (
+                    <button
+                      onClick={() => setMobileListOpen(true)}
+                      aria-label="All notes"
+                      className="shrink-0 h-9 w-9 -ml-1 flex items-center justify-center rounded-lg text-gray-500 dark:text-gray-400 active:bg-gray-100 dark:active:bg-gray-700"
+                    >
+                      <Menu className="h-5 w-5" />
+                    </button>
+                  )}
                   <div className="flex items-center space-x-3" ref={noteTypeDropdownRef}>
                     <div className="relative">
                       {/* Trigger: clean pill + separate chevron */}

--- a/src/pages/NotesListPage.tsx
+++ b/src/pages/NotesListPage.tsx
@@ -799,7 +799,52 @@ export function NotesListPage({ onNoteSelect }: NotesListPageProps) {
           </div>
         ) : filteredNotes.length > 0 ? (
           <div className="overflow-auto flex-1 min-h-0">
-            <table className="w-full">
+            {/* Card list — phones only.
+
+                The table's six columns are percentage-width, so at 390px they
+                do not overflow, they crush: a 35% title column is 136px and the
+                remaining five share 250px between them. Notes are text, not
+                figures — nothing here gains from column alignment the way a
+                price grid does — so each note becomes a card and the metadata
+                sits on one line beneath it. */}
+            <div className="sm:hidden divide-y divide-gray-100 dark:divide-gray-800">
+              {filteredNotes.map((note) => (
+                <button
+                  key={`m-${note.source_type}-${note.id}`}
+                  type="button"
+                  onClick={() => handleNoteClick(note)}
+                  className="w-full text-left px-3 py-3 active:bg-gray-50 dark:active:bg-gray-800"
+                >
+                  <div className="flex items-start gap-2.5">
+                    <div className="mt-0.5 w-8 h-8 rounded-lg bg-gray-100 dark:bg-gray-800 flex items-center justify-center flex-shrink-0">
+                      <FileText className="h-4 w-4 text-gray-500 dark:text-gray-400" />
+                    </div>
+                    <div className="min-w-0 flex-1">
+                      <p className="font-medium text-gray-900 dark:text-white truncate">
+                        {note.title || 'Untitled'}
+                      </p>
+                      <p className="mt-0.5 text-[13px] text-gray-500 dark:text-gray-400 line-clamp-2">
+                        {getContentPreview(note.content || '', 120)}
+                      </p>
+                      <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-gray-400">
+                        {note.source_name && (
+                          <span className="font-medium text-gray-500 dark:text-gray-400">{note.source_name}</span>
+                        )}
+                        {note.note_type && <span className="capitalize">{String(note.note_type).replace(/_/g, ' ')}</span>}
+                        {note.is_shared && (
+                          <span className="inline-flex items-center gap-1 text-primary-600 dark:text-primary-400">
+                            <Share2 className="h-3 w-3" />Shared
+                          </span>
+                        )}
+                        <span className="ml-auto">{formatDate(note.updated_at)}</span>
+                      </div>
+                    </div>
+                  </div>
+                </button>
+              ))}
+            </div>
+
+            <table className="hidden sm:table w-full">
               <thead>
                 <tr className="border-b border-gray-200 bg-gray-50 sticky top-0 z-10 dark:border-gray-700 dark:bg-gray-900">
                   <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-[35%] dark:text-gray-400">


### PR DESCRIPTION
The editor's left pane
UniversalNoteEditor's notes list is a w-72 flex sibling. At 390px that leaves roughly 100px for the editor, which is not a narrow editor — it is no editor. It becomes a full-screen overlay on a phone, absent from the layout when closed, with a menu button in the editor header as the way back in and an X rather than a collapse-left chevron to dismiss it. A chevron on a full-screen overlay reads as navigation, not dismissal.

The editor pane also gains min-w-0: without it a long note title would push the flex child past the viewport instead of truncating, which is the usual cause of a page that scrolls sideways for no visible reason.

The list table
Its six columns are percentage-width, so at 390px they do not overflow, they crush — a 35% title column is 136px and the remaining five share 250px. Notes are text, not figures, and nothing here gains from column alignment the way a price grid does, so below sm each note is a card: title, a two-line preview, and source, type, shared state and date on one line beneath. The table is unchanged and gated to sm:table.

Typecheck at baseline, 996 tests passing, production build clean.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
