### PR TITLE
fix(mobile): note editor ribbon, command reference, and suggestion po…

### DIFF
--- a/src/components/rich-text-editor/EditorToolbar.tsx
+++ b/src/components/rich-text-editor/EditorToolbar.tsx
@@ -331,7 +331,11 @@ export function EditorToolbar({
 
   return (
     <>
-      <div className="flex flex-wrap items-center gap-0.5 p-2 bg-gray-50 border border-gray-200 rounded-t-lg border-b-0 dark:border-gray-700 dark:bg-gray-900">
+      {/* Wrapping is right on a wide screen and wrong on a narrow one: forty
+          controls at 390px wrap to five or six rows, and the ribbon ends up
+          taller than the text it formats. Below sm it becomes a single row that
+          scrolls sideways — constant height, everything still reachable. */}
+      <div className="flex flex-nowrap overflow-x-auto no-scrollbar sm:flex-wrap items-center gap-0.5 p-2 bg-gray-50 border border-gray-200 rounded-t-lg border-b-0 dark:border-gray-700 dark:bg-gray-900">
         {/* Undo/Redo */}
         <div className="flex items-center gap-0.5 mr-1">
           <ToolButton

--- a/src/components/rich-text-editor/RichTextEditor.tsx
+++ b/src/components/rich-text-editor/RichTextEditor.tsx
@@ -1045,15 +1045,15 @@ const RichTextEditorInner = forwardRef<RichTextEditorRef, RichTextEditorProps>((
                 </svg>
               </button>
             </div>
-            <div className="px-6 py-4 overflow-y-auto max-h-[60vh]">
+            <div className="px-4 sm:px-6 py-4 overflow-y-auto max-h-[70vh] sm:max-h-[60vh]">
               <div className="space-y-6">
                 {/* AI Commands */}
                 <div>
                   <h3 className="text-sm font-semibold text-purple-600 mb-2">AI Commands</h3>
                   <div className="space-y-1 text-sm">
-                    <div className="flex gap-3"><span className="w-36 flex-shrink-0 font-mono text-purple-600">.AI</span><span className="text-gray-600 dark:text-gray-400">Generate content with AI (type prompt, press Enter)</span></div>
-                    <div className="flex gap-3"><span className="w-36 flex-shrink-0 font-mono text-purple-600">.AI.claude</span><span className="text-gray-600 dark:text-gray-400">Generate with Claude model</span></div>
-                    <div className="flex gap-3"><span className="w-36 flex-shrink-0 font-mono text-purple-600">.AI.gpt</span><span className="text-gray-600 dark:text-gray-400">Generate with GPT model</span></div>
+                    <div className="flex flex-col sm:flex-row sm:gap-3"><span className="sm:w-36 sm:flex-shrink-0 font-mono text-purple-600">.AI</span><span className="text-gray-600 dark:text-gray-400">Generate content with AI (type prompt, press Enter)</span></div>
+                    <div className="flex flex-col sm:flex-row sm:gap-3"><span className="sm:w-36 sm:flex-shrink-0 font-mono text-purple-600">.AI.claude</span><span className="text-gray-600 dark:text-gray-400">Generate with Claude model</span></div>
+                    <div className="flex flex-col sm:flex-row sm:gap-3"><span className="sm:w-36 sm:flex-shrink-0 font-mono text-purple-600">.AI.gpt</span><span className="text-gray-600 dark:text-gray-400">Generate with GPT model</span></div>
                   </div>
                 </div>
 
@@ -1061,12 +1061,12 @@ const RichTextEditorInner = forwardRef<RichTextEditorRef, RichTextEditorProps>((
                 <div>
                   <h3 className="text-sm font-semibold text-emerald-600 mb-2">Data Commands</h3>
                   <div className="space-y-1 text-sm">
-                    <div className="flex gap-3"><span className="w-36 flex-shrink-0 font-mono text-emerald-600">.price</span><span className="text-gray-600 dark:text-gray-400">Current stock price</span></div>
-                    <div className="flex gap-3"><span className="w-36 flex-shrink-0 font-mono text-emerald-600">.volume</span><span className="text-gray-600 dark:text-gray-400">Trading volume</span></div>
-                    <div className="flex gap-3"><span className="w-36 flex-shrink-0 font-mono text-emerald-600">.marketcap</span><span className="text-gray-600 dark:text-gray-400">Market capitalization</span></div>
-                    <div className="flex gap-3"><span className="w-36 flex-shrink-0 font-mono text-emerald-600">.change</span><span className="text-gray-600 dark:text-gray-400">Price change %</span></div>
-                    <div className="flex gap-3"><span className="w-36 flex-shrink-0 font-mono text-emerald-600">.pe</span><span className="text-gray-600 dark:text-gray-400">P/E ratio</span></div>
-                    <div className="flex gap-3"><span className="w-36 flex-shrink-0 font-mono text-emerald-600">.dividend</span><span className="text-gray-600 dark:text-gray-400">Dividend yield</span></div>
+                    <div className="flex flex-col sm:flex-row sm:gap-3"><span className="sm:w-36 sm:flex-shrink-0 font-mono text-emerald-600">.price</span><span className="text-gray-600 dark:text-gray-400">Current stock price</span></div>
+                    <div className="flex flex-col sm:flex-row sm:gap-3"><span className="sm:w-36 sm:flex-shrink-0 font-mono text-emerald-600">.volume</span><span className="text-gray-600 dark:text-gray-400">Trading volume</span></div>
+                    <div className="flex flex-col sm:flex-row sm:gap-3"><span className="sm:w-36 sm:flex-shrink-0 font-mono text-emerald-600">.marketcap</span><span className="text-gray-600 dark:text-gray-400">Market capitalization</span></div>
+                    <div className="flex flex-col sm:flex-row sm:gap-3"><span className="sm:w-36 sm:flex-shrink-0 font-mono text-emerald-600">.change</span><span className="text-gray-600 dark:text-gray-400">Price change %</span></div>
+                    <div className="flex flex-col sm:flex-row sm:gap-3"><span className="sm:w-36 sm:flex-shrink-0 font-mono text-emerald-600">.pe</span><span className="text-gray-600 dark:text-gray-400">P/E ratio</span></div>
+                    <div className="flex flex-col sm:flex-row sm:gap-3"><span className="sm:w-36 sm:flex-shrink-0 font-mono text-emerald-600">.dividend</span><span className="text-gray-600 dark:text-gray-400">Dividend yield</span></div>
                   </div>
                 </div>
 
@@ -1074,9 +1074,9 @@ const RichTextEditorInner = forwardRef<RichTextEditorRef, RichTextEditorProps>((
                 <div>
                   <h3 className="text-sm font-semibold text-violet-600 mb-2">Capture Commands</h3>
                   <div className="space-y-1 text-sm">
-                    <div className="flex gap-3"><span className="w-36 flex-shrink-0 font-mono text-violet-600">.capture</span><span className="text-gray-600 dark:text-gray-400">Capture a platform element (live or static)</span></div>
-                    <div className="flex gap-3"><span className="w-36 flex-shrink-0 font-mono text-amber-600">.screenshot</span><span className="text-gray-600 dark:text-gray-400">Take a screenshot of your screen</span></div>
-                    <div className="flex gap-3"><span className="w-36 flex-shrink-0 font-mono text-blue-600">.embed</span><span className="text-gray-600 dark:text-gray-400">Embed a URL with rich preview</span></div>
+                    <div className="flex flex-col sm:flex-row sm:gap-3"><span className="sm:w-36 sm:flex-shrink-0 font-mono text-violet-600">.capture</span><span className="text-gray-600 dark:text-gray-400">Capture a platform element (live or static)</span></div>
+                    <div className="flex flex-col sm:flex-row sm:gap-3"><span className="sm:w-36 sm:flex-shrink-0 font-mono text-amber-600">.screenshot</span><span className="text-gray-600 dark:text-gray-400">Take a screenshot of your screen</span></div>
+                    <div className="flex flex-col sm:flex-row sm:gap-3"><span className="sm:w-36 sm:flex-shrink-0 font-mono text-blue-600">.embed</span><span className="text-gray-600 dark:text-gray-400">Embed a URL with rich preview</span></div>
                   </div>
                 </div>
 
@@ -1084,12 +1084,12 @@ const RichTextEditorInner = forwardRef<RichTextEditorRef, RichTextEditorProps>((
                 <div>
                   <h3 className="text-sm font-semibold text-cyan-600 mb-2">Chart Commands</h3>
                   <div className="space-y-1 text-sm">
-                    <div className="flex gap-3"><span className="w-36 flex-shrink-0 font-mono text-cyan-600">.chart</span><span className="text-gray-600 dark:text-gray-400">Insert an embedded chart</span></div>
-                    <div className="flex gap-3"><span className="w-36 flex-shrink-0 font-mono text-cyan-600">.chart.price</span><span className="text-gray-600 dark:text-gray-400">Price chart (line/area)</span></div>
-                    <div className="flex gap-3"><span className="w-36 flex-shrink-0 font-mono text-cyan-600">.chart.volume</span><span className="text-gray-600 dark:text-gray-400">Volume chart</span></div>
-                    <div className="flex gap-3"><span className="w-36 flex-shrink-0 font-mono text-cyan-600">.chart.performance</span><span className="text-gray-600 dark:text-gray-400">Performance chart (%)</span></div>
-                    <div className="flex gap-3"><span className="w-36 flex-shrink-0 font-mono text-cyan-600">.chart.comparison</span><span className="text-gray-600 dark:text-gray-400">Multi-asset comparison</span></div>
-                    <div className="flex gap-3"><span className="w-36 flex-shrink-0 font-mono text-cyan-600">.chart.technicals</span><span className="text-gray-600 dark:text-gray-400">Chart with indicators</span></div>
+                    <div className="flex flex-col sm:flex-row sm:gap-3"><span className="sm:w-36 sm:flex-shrink-0 font-mono text-cyan-600">.chart</span><span className="text-gray-600 dark:text-gray-400">Insert an embedded chart</span></div>
+                    <div className="flex flex-col sm:flex-row sm:gap-3"><span className="sm:w-36 sm:flex-shrink-0 font-mono text-cyan-600">.chart.price</span><span className="text-gray-600 dark:text-gray-400">Price chart (line/area)</span></div>
+                    <div className="flex flex-col sm:flex-row sm:gap-3"><span className="sm:w-36 sm:flex-shrink-0 font-mono text-cyan-600">.chart.volume</span><span className="text-gray-600 dark:text-gray-400">Volume chart</span></div>
+                    <div className="flex flex-col sm:flex-row sm:gap-3"><span className="sm:w-36 sm:flex-shrink-0 font-mono text-cyan-600">.chart.performance</span><span className="text-gray-600 dark:text-gray-400">Performance chart (%)</span></div>
+                    <div className="flex flex-col sm:flex-row sm:gap-3"><span className="sm:w-36 sm:flex-shrink-0 font-mono text-cyan-600">.chart.comparison</span><span className="text-gray-600 dark:text-gray-400">Multi-asset comparison</span></div>
+                    <div className="flex flex-col sm:flex-row sm:gap-3"><span className="sm:w-36 sm:flex-shrink-0 font-mono text-cyan-600">.chart.technicals</span><span className="text-gray-600 dark:text-gray-400">Chart with indicators</span></div>
                   </div>
                 </div>
 
@@ -1097,9 +1097,9 @@ const RichTextEditorInner = forwardRef<RichTextEditorRef, RichTextEditorProps>((
                 <div>
                   <h3 className="text-sm font-semibold text-cyan-600 mb-2">Content Commands</h3>
                   <div className="space-y-1 text-sm">
-                    <div className="flex gap-3"><span className="w-36 flex-shrink-0 font-mono text-cyan-600">.task</span><span className="text-gray-600 dark:text-gray-400">Add an inline task</span></div>
-                    <div className="flex gap-3"><span className="w-36 flex-shrink-0 font-mono text-pink-600">.event</span><span className="text-gray-600 dark:text-gray-400">Add a calendar event</span></div>
-                    <div className="flex gap-3"><span className="w-36 flex-shrink-0 font-mono text-orange-600">.template</span><span className="text-gray-600 dark:text-gray-400">Insert a template</span></div>
+                    <div className="flex flex-col sm:flex-row sm:gap-3"><span className="sm:w-36 sm:flex-shrink-0 font-mono text-cyan-600">.task</span><span className="text-gray-600 dark:text-gray-400">Add an inline task</span></div>
+                    <div className="flex flex-col sm:flex-row sm:gap-3"><span className="sm:w-36 sm:flex-shrink-0 font-mono text-pink-600">.event</span><span className="text-gray-600 dark:text-gray-400">Add a calendar event</span></div>
+                    <div className="flex flex-col sm:flex-row sm:gap-3"><span className="sm:w-36 sm:flex-shrink-0 font-mono text-orange-600">.template</span><span className="text-gray-600 dark:text-gray-400">Insert a template</span></div>
                   </div>
                 </div>
 
@@ -1107,9 +1107,9 @@ const RichTextEditorInner = forwardRef<RichTextEditorRef, RichTextEditorProps>((
                 <div>
                   <h3 className="text-sm font-semibold text-amber-600 mb-2">Visibility Commands</h3>
                   <div className="space-y-1 text-sm">
-                    <div className="flex gap-3"><span className="w-36 flex-shrink-0 font-mono text-amber-600">.private</span><span className="text-gray-600 dark:text-gray-400">Private note (only you can see)</span></div>
-                    <div className="flex gap-3"><span className="w-36 flex-shrink-0 font-mono text-blue-600">.team</span><span className="text-gray-600 dark:text-gray-400">Visible to your team only</span></div>
-                    <div className="flex gap-3"><span className="w-36 flex-shrink-0 font-mono text-purple-600">.portfolio</span><span className="text-gray-600 dark:text-gray-400">Visible to portfolio members</span></div>
+                    <div className="flex flex-col sm:flex-row sm:gap-3"><span className="sm:w-36 sm:flex-shrink-0 font-mono text-amber-600">.private</span><span className="text-gray-600 dark:text-gray-400">Private note (only you can see)</span></div>
+                    <div className="flex flex-col sm:flex-row sm:gap-3"><span className="sm:w-36 sm:flex-shrink-0 font-mono text-blue-600">.team</span><span className="text-gray-600 dark:text-gray-400">Visible to your team only</span></div>
+                    <div className="flex flex-col sm:flex-row sm:gap-3"><span className="sm:w-36 sm:flex-shrink-0 font-mono text-purple-600">.portfolio</span><span className="text-gray-600 dark:text-gray-400">Visible to portfolio members</span></div>
                   </div>
                 </div>
 
@@ -1117,8 +1117,8 @@ const RichTextEditorInner = forwardRef<RichTextEditorRef, RichTextEditorProps>((
                 <div>
                   <h3 className="text-sm font-semibold text-gray-600 mb-2 dark:text-gray-400">Other Commands</h3>
                   <div className="space-y-1 text-sm">
-                    <div className="flex gap-3"><span className="w-36 flex-shrink-0 font-mono text-indigo-600">.toc</span><span className="text-gray-600 dark:text-gray-400">Insert table of contents</span></div>
-                    <div className="flex gap-3"><span className="w-36 flex-shrink-0 font-mono text-gray-500 dark:text-gray-400">.divider</span><span className="text-gray-600 dark:text-gray-400">Insert a horizontal divider</span></div>
+                    <div className="flex flex-col sm:flex-row sm:gap-3"><span className="sm:w-36 sm:flex-shrink-0 font-mono text-indigo-600">.toc</span><span className="text-gray-600 dark:text-gray-400">Insert table of contents</span></div>
+                    <div className="flex flex-col sm:flex-row sm:gap-3"><span className="sm:w-36 sm:flex-shrink-0 font-mono text-gray-500 dark:text-gray-400">.divider</span><span className="text-gray-600 dark:text-gray-400">Insert a horizontal divider</span></div>
                   </div>
                 </div>
 

--- a/src/components/rich-text-editor/extensions/AssetExtension.ts
+++ b/src/components/rich-text-editor/extensions/AssetExtension.ts
@@ -177,7 +177,16 @@ export class AssetList {
       trigger: 'manual',
       placement: 'bottom-start',
       animation: 'shift-away',
-      maxWidth: 'none'
+      maxWidth: 'none',
+      // A 280px popup anchored to the caret runs off a 390px screen the moment
+      // the caret passes the midpoint. Popper is told to shift it back into the
+      // viewport rather than letting it hang past the edge.
+      popperOptions: {
+        modifiers: [
+          { name: 'preventOverflow', options: { boundary: 'viewport', padding: 8 } },
+          { name: 'flip', options: { fallbackPlacements: ['top-start', 'bottom-end', 'top-end'] } },
+        ],
+      }
     })
   }
 
@@ -256,11 +265,11 @@ function AssetListComponent({ items, selectedIndex, onSelect }: AssetListCompone
   }
 
   return React.createElement('div', {
-    className: 'bg-white rounded-lg shadow-xl border border-gray-200 py-1 min-w-[280px] max-h-[300px] overflow-y-auto'
+    className: 'bg-white rounded-lg shadow-xl border border-gray-200 py-1 min-w-[240px] max-w-[calc(100vw-1rem)] max-h-[300px] overflow-y-auto'
   }, items.map((item, index) =>
     React.createElement('button', {
       key: item.id,
-      className: `w-full px-3 py-2 text-left flex items-center gap-3 transition-colors ${
+      className: `w-full px-3 py-2.5 min-h-[44px] text-left flex items-center gap-3 transition-colors ${
         index === selectedIndex ? 'bg-emerald-50 text-emerald-700' : 'hover:bg-gray-50'
       }`,
       onClick: () => onSelect(item)

--- a/src/components/rich-text-editor/extensions/DotCommandSuggestionExtension.ts
+++ b/src/components/rich-text-editor/extensions/DotCommandSuggestionExtension.ts
@@ -357,6 +357,15 @@ export const DotCommandSuggestionExtension = Extension.create<DotCommandSuggesti
         placement: 'bottom-start',
         animation: 'shift-away',
         maxWidth: 'none',
+      // A 280px popup anchored to the caret runs off a 390px screen the moment
+      // the caret passes the midpoint. Popper is told to shift it back into the
+      // viewport rather than letting it hang past the edge.
+      popperOptions: {
+        modifiers: [
+          { name: 'preventOverflow', options: { boundary: 'viewport', padding: 8 } },
+          { name: 'flip', options: { fallbackPlacements: ['top-start', 'bottom-end', 'top-end'] } },
+        ],
+      },
         offset: [0, 8]
       })
     }
@@ -712,7 +721,7 @@ function DotCommandList({ items, selectedIndex, onSelect }: DotCommandListProps)
   let globalIndex = 0
 
   return React.createElement('div', {
-    className: 'bg-white rounded-lg shadow-xl border border-gray-200 py-1 min-w-[280px] max-h-[320px] overflow-y-auto'
+    className: 'bg-white rounded-lg shadow-xl border border-gray-200 py-1 min-w-[240px] max-w-[calc(100vw-1rem)] max-h-[320px] overflow-y-auto'
   }, categories.map(category => {
     const categoryItems = items.filter(item => item.category === category)
     if (categoryItems.length === 0) return null
@@ -727,7 +736,7 @@ function DotCommandList({ items, selectedIndex, onSelect }: DotCommandListProps)
         const Icon = item.icon
         return React.createElement('button', {
           key: item.id,
-          className: `w-full px-3 py-2 text-left flex items-center gap-3 transition-colors ${
+          className: `w-full px-3 py-2.5 min-h-[44px] text-left flex items-center gap-3 transition-colors ${
             itemIndex === selectedIndex ? 'bg-primary-50' : 'hover:bg-gray-50'
           }`,
           onClick: () => onSelect(item)
@@ -767,7 +776,7 @@ interface AssetSearchListProps {
 function AssetSearchList({ items, selectedIndex, commandLabel, onSelect }: AssetSearchListProps) {
   if (items.length === 0) {
     return React.createElement('div', {
-      className: 'bg-white rounded-lg shadow-xl border border-gray-200 p-3 min-w-[280px]'
+      className: 'bg-white rounded-lg shadow-xl border border-gray-200 p-3 min-w-[240px] max-w-[calc(100vw-1rem)]'
     }, [
       React.createElement('div', {
         key: 'header',
@@ -780,7 +789,7 @@ function AssetSearchList({ items, selectedIndex, commandLabel, onSelect }: Asset
   }
 
   return React.createElement('div', {
-    className: 'bg-white rounded-lg shadow-xl border border-gray-200 py-1 min-w-[280px] max-h-[300px] overflow-y-auto'
+    className: 'bg-white rounded-lg shadow-xl border border-gray-200 py-1 min-w-[240px] max-w-[calc(100vw-1rem)] max-h-[300px] overflow-y-auto'
   }, [
     React.createElement('div', {
       key: 'header',
@@ -792,7 +801,7 @@ function AssetSearchList({ items, selectedIndex, commandLabel, onSelect }: Asset
     ...items.map((item, index) =>
       React.createElement('button', {
         key: item.id,
-        className: `w-full px-3 py-2 text-left flex items-center gap-3 transition-colors ${
+        className: `w-full px-3 py-2.5 min-h-[44px] text-left flex items-center gap-3 transition-colors ${
           index === selectedIndex ? 'bg-emerald-50 text-emerald-700' : 'hover:bg-gray-50'
         }`,
         onClick: () => onSelect(item)

--- a/src/components/rich-text-editor/extensions/HashtagExtension.ts
+++ b/src/components/rich-text-editor/extensions/HashtagExtension.ts
@@ -193,7 +193,16 @@ export class HashtagList {
       trigger: 'manual',
       placement: 'bottom-start',
       animation: 'shift-away',
-      maxWidth: 'none'
+      maxWidth: 'none',
+      // A 280px popup anchored to the caret runs off a 390px screen the moment
+      // the caret passes the midpoint. Popper is told to shift it back into the
+      // viewport rather than letting it hang past the edge.
+      popperOptions: {
+        modifiers: [
+          { name: 'preventOverflow', options: { boundary: 'viewport', padding: 8 } },
+          { name: 'flip', options: { fallbackPlacements: ['top-start', 'bottom-end', 'top-end'] } },
+        ],
+      }
     })
   }
 
@@ -277,7 +286,7 @@ function HashtagListComponent({ items, selectedIndex, onSelect }: HashtagListCom
 
     return React.createElement('button', {
       key: item.id,
-      className: `w-full px-3 py-2 text-left flex items-center gap-3 transition-colors ${
+      className: `w-full px-3 py-2.5 min-h-[44px] text-left flex items-center gap-3 transition-colors ${
         index === selectedIndex ? 'bg-amber-50 text-amber-700' : 'hover:bg-gray-50'
       }`,
       onClick: () => onSelect(item)

--- a/src/components/rich-text-editor/extensions/MentionExtension.ts
+++ b/src/components/rich-text-editor/extensions/MentionExtension.ts
@@ -176,7 +176,16 @@ export class MentionList {
       trigger: 'manual',
       placement: 'bottom-start',
       animation: 'shift-away',
-      maxWidth: 'none'
+      maxWidth: 'none',
+      // A 280px popup anchored to the caret runs off a 390px screen the moment
+      // the caret passes the midpoint. Popper is told to shift it back into the
+      // viewport rather than letting it hang past the edge.
+      popperOptions: {
+        modifiers: [
+          { name: 'preventOverflow', options: { boundary: 'viewport', padding: 8 } },
+          { name: 'flip', options: { fallbackPlacements: ['top-start', 'bottom-end', 'top-end'] } },
+        ],
+      }
     })
   }
 
@@ -254,11 +263,11 @@ function MentionListComponent({ items, selectedIndex, onSelect }: MentionListCom
   }
 
   return React.createElement('div', {
-    className: 'bg-white rounded-lg shadow-xl border border-gray-200 py-1 min-w-[200px] max-h-[300px] overflow-y-auto'
+    className: 'bg-white rounded-lg shadow-xl border border-gray-200 py-1 min-w-[200px] max-w-[calc(100vw-1rem)] max-h-[300px] overflow-y-auto'
   }, items.map((item, index) =>
     React.createElement('button', {
       key: item.id,
-      className: `w-full px-3 py-2 text-left flex items-center gap-3 transition-colors ${
+      className: `w-full px-3 py-2.5 min-h-[44px] text-left flex items-center gap-3 transition-colors ${
         index === selectedIndex ? 'bg-primary-50 text-primary-700' : 'hover:bg-gray-50'
       }`,
       onClick: () => onSelect(item)

--- a/src/components/rich-text-editor/extensions/NoteLinkExtension.ts
+++ b/src/components/rich-text-editor/extensions/NoteLinkExtension.ts
@@ -204,7 +204,16 @@ export class NoteLinkList {
       trigger: 'manual',
       placement: 'bottom-start',
       animation: 'shift-away',
-      maxWidth: 'none'
+      maxWidth: 'none',
+      // A 280px popup anchored to the caret runs off a 390px screen the moment
+      // the caret passes the midpoint. Popper is told to shift it back into the
+      // viewport rather than letting it hang past the edge.
+      popperOptions: {
+        modifiers: [
+          { name: 'preventOverflow', options: { boundary: 'viewport', padding: 8 } },
+          { name: 'flip', options: { fallbackPlacements: ['top-start', 'bottom-end', 'top-end'] } },
+        ],
+      }
     })
   }
 
@@ -317,7 +326,7 @@ function NoteLinkListComponent({ items, selectedIndex, onSelect }: NoteLinkListC
   }, items.map((item, index) =>
     React.createElement('button', {
       key: item.id,
-      className: `w-full px-3 py-2 text-left flex items-center gap-3 transition-colors ${
+      className: `w-full px-3 py-2.5 min-h-[44px] text-left flex items-center gap-3 transition-colors ${
         index === selectedIndex ? 'bg-blue-50 text-blue-700' : 'hover:bg-gray-50'
       }`,
       onClick: () => onSelect(item)


### PR DESCRIPTION
…pups

The ribbon
flex-wrap is right on a wide screen and wrong on a narrow one: forty controls at 390px wrap to five or six rows, so the toolbar ended up taller than the text it formats. Below sm it is a single row that scrolls sideways — constant height, nothing removed, everything still reachable.

The command reference running off the page
Each of its 26 rows was a fixed 144px monospace label beside a description in a flex row. At 390px that does not wrap, it overflows. The rows stack below sm and the panel gets phone-appropriate gutters and height.

Dot commands, mentions, tags, assets and note links All five suggestion popups set maxWidth: 'none' with no popper overflow handling, so a 280px menu anchored to the caret ran off the right edge as soon as the caret passed the midpoint — which is most of the time, since you type the trigger mid-sentence. They now cap at the viewport width and are given preventOverflow plus flip fallbacks, so a popup that will not fit below the caret goes above it. That last part matters more on a phone than anywhere else: the keyboard owns the bottom half of the screen, which is exactly where bottom-start placement was putting the menu.

Their rows were py-2, about a 32px target, picked with a thumb while the keyboard is up and with no second chance at a mis-tap. Raised to the 44px floor the rest of the app uses.

Desktop is unchanged: the ribbon still wraps above sm, the reference still sits in two columns, and the popups behave identically on a screen they already fit.

Typecheck at baseline, 996 tests passing, production build clean.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
