### PR TITLE
fix(mobile): replace the scrolling ribbon, fix the status bar overflow

### DIFF
--- a/src/components/notes/UniversalNoteEditor.tsx
+++ b/src/components/notes/UniversalNoteEditor.tsx
@@ -1963,7 +1963,7 @@ export function UniversalNoteEditor({
         ) : (isLoading || isLoadingContent) && selectedNoteId ? (
           /* Loading state when we have a selected note ID but still fetching */
           <div className="flex-1 flex flex-col">
-            <div className="px-6 py-4 border-b border-gray-100 bg-white dark:border-gray-800 dark:bg-gray-800">
+            <div className="px-3 sm:px-6 py-3 sm:py-4 border-b border-gray-100 bg-white dark:border-gray-800 dark:bg-gray-800">
               <div className="animate-pulse flex items-center space-x-3">
                 <div className="h-6 w-20 bg-gray-200 rounded" />
                 <div className="h-4 w-px bg-gray-200" />
@@ -2331,7 +2331,7 @@ export function UniversalNoteEditor({
               </div>
 
               {/* Note Content - Rich Text Editor */}
-              <div className="px-4">
+              <div className="px-1.5 sm:px-4">
                 <RichTextEditor
                   ref={richTextEditorRef}
                   value={editingContent}
@@ -2364,9 +2364,9 @@ export function UniversalNoteEditor({
             </div>
 
             {/* Status Bar */}
-            <div className="px-6 py-2.5 border-t border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
-              <div className="flex items-center justify-between text-xs">
-                <div className="flex items-center space-x-3 text-gray-400">
+            <div className="px-3 sm:px-6 py-2.5 border-t border-gray-200 bg-white dark:border-gray-700 dark:bg-gray-800">
+              <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-1 text-xs">
+                <div className="flex flex-wrap items-center gap-x-3 gap-y-1 min-w-0 text-gray-400">
                   {/* Offline Status Indicator */}
                   {!isOnline && (
                     <>
@@ -2414,15 +2414,16 @@ export function UniversalNoteEditor({
                     className="flex items-center gap-1 text-gray-400 hover:text-gray-600 transition-colors cursor-help dark:hover:text-gray-300"
                   >
                     <HelpCircle className="w-3 h-3" />
-                    <span className="text-primary-500">@</span>mention
-                    <span className="mx-1">·</span>
-                    <span className="text-emerald-500">$</span>asset
-                    <span className="mx-1">·</span>
-                    <span className="text-amber-500">#</span>tag
-                    <span className="mx-1">·</span>
-                    <span className="text-violet-500">[[</span>notes
-                    <span className="mx-1">·</span>
-                    <span className="text-purple-500">.AI</span>
+                    <span className="sm:hidden">Shortcuts</span>
+                    <span className="hidden sm:inline"><span className="text-primary-500">@</span>mention</span>
+                    <span className="hidden sm:contents"><span className="mx-1">·</span>
+                    <span className="text-emerald-500">$</span>asset</span>
+                    <span className="hidden sm:contents"><span className="mx-1">·</span>
+                    <span className="text-amber-500">#</span>tag</span>
+                    <span className="hidden sm:contents"><span className="mx-1">·</span>
+                    <span className="text-violet-500">[[</span>notes</span>
+                    <span className="hidden sm:contents"><span className="mx-1">·</span>
+                    <span className="text-purple-500">.AI</span></span>
                   </button>
                   {lastSavedAt && (
                     <>

--- a/src/components/rich-text-editor/EditorToolbar.tsx
+++ b/src/components/rich-text-editor/EditorToolbar.tsx
@@ -13,6 +13,8 @@ import {
 
 interface EditorToolbarProps {
   editor: Editor
+  /** Rendered inside the mobile format sheet rather than above the editor. */
+  inSheet?: boolean
   onInsertEvent?: () => void
   onInsertAttachment?: () => void
   contextType?: string
@@ -68,6 +70,7 @@ const HEADING_OPTIONS = [
 
 export function EditorToolbar({
   editor,
+  inSheet,
   onInsertEvent,
   onInsertAttachment,
   contextType,
@@ -331,11 +334,18 @@ export function EditorToolbar({
 
   return (
     <>
-      {/* Wrapping is right on a wide screen and wrong on a narrow one: forty
-          controls at 390px wrap to five or six rows, and the ribbon ends up
-          taller than the text it formats. Below sm it becomes a single row that
-          scrolls sideways — constant height, everything still reachable. */}
-      <div className="flex flex-nowrap overflow-x-auto no-scrollbar sm:flex-wrap items-center gap-0.5 p-2 bg-gray-50 border border-gray-200 rounded-t-lg border-b-0 dark:border-gray-700 dark:bg-gray-900">
+      {/* On a phone this whole ribbon lives inside a sheet (see
+          MobileFormatBar), where it has room to wrap. Here it is the desktop
+          ribbon, unchanged.
+
+          A previous attempt made this a single sideways-scrolling row. That
+          swapped a tall ribbon for a blind one: forty controls behind a swipe,
+          with no way to see what exists or where anything is. Height was not
+          the real problem — being always-present was. */}
+      <div className={clsx(
+        'flex flex-wrap items-center gap-0.5 p-2 bg-gray-50 border border-gray-200 dark:border-gray-700 dark:bg-gray-900',
+        inSheet ? 'rounded-lg border-b' : 'rounded-t-lg border-b-0'
+      )}>
         {/* Undo/Redo */}
         <div className="flex items-center gap-0.5 mr-1">
           <ToolButton

--- a/src/components/rich-text-editor/MobileFormatBar.tsx
+++ b/src/components/rich-text-editor/MobileFormatBar.tsx
@@ -1,0 +1,147 @@
+import { useState } from 'react'
+import { clsx } from 'clsx'
+import type { Editor } from '@tiptap/react'
+import {
+  Bold, Italic, Heading2, List, ListOrdered, CheckSquare, SlidersHorizontal, Undo2,
+} from 'lucide-react'
+import { BottomSheet } from '../mobile/BottomSheet'
+import { EditorToolbar } from './EditorToolbar'
+
+interface MobileFormatBarProps {
+  editor: Editor
+  onInsertEvent?: () => void
+  onInsertAttachment?: () => void
+  contextType?: string
+  contextId?: string
+}
+
+/**
+ * The formatting controls, on a phone.
+ *
+ * The desktop ribbon is forty controls that wrap. At 390px that is five or six
+ * rows standing permanently between the title and the first line of text —
+ * more of the screen spent on formatting than on writing, before a word is
+ * typed.
+ *
+ * Making it scroll sideways was worse: the same forty controls, but now you
+ * cannot see what exists or remember where anything is, and finding a tool
+ * means swiping blind.
+ *
+ * The actual problem was that the whole ribbon was always present. Six controls
+ * cover almost everything anyone does while writing on a phone — bold, italic,
+ * a heading, two kinds of list, a checkbox — so those stay on one row, and the
+ * complete ribbon is one tap away in a sheet where it has room to wrap and can
+ * be read rather than scrolled past.
+ */
+export function MobileFormatBar({
+  editor,
+  onInsertEvent,
+  onInsertAttachment,
+  contextType,
+  contextId,
+}: MobileFormatBarProps) {
+  const [sheetOpen, setSheetOpen] = useState(false)
+
+  const Btn = ({
+    active, onClick, label, children,
+  }: {
+    active?: boolean
+    onClick: () => void
+    label: string
+    children: React.ReactNode
+  }) => (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={label}
+      aria-pressed={active}
+      className={clsx(
+        'flex-1 h-10 flex items-center justify-center rounded-md transition-colors no-touch-target',
+        active
+          ? 'bg-white text-primary-600 shadow-sm dark:bg-gray-700 dark:text-primary-400'
+          : 'text-gray-500 dark:text-gray-400 active:bg-gray-200 dark:active:bg-gray-700'
+      )}
+    >
+      {children}
+    </button>
+  )
+
+  return (
+    <>
+      <div className="flex items-center gap-0.5 p-1 bg-gray-50 border border-gray-200 rounded-t-lg border-b-0 dark:border-gray-700 dark:bg-gray-900">
+        <Btn
+          label="Bold"
+          active={editor.isActive('bold')}
+          onClick={() => editor.chain().focus().toggleBold().run()}
+        >
+          <Bold className="w-4 h-4" />
+        </Btn>
+        <Btn
+          label="Italic"
+          active={editor.isActive('italic')}
+          onClick={() => editor.chain().focus().toggleItalic().run()}
+        >
+          <Italic className="w-4 h-4" />
+        </Btn>
+        <Btn
+          label="Heading"
+          active={editor.isActive('heading', { level: 2 })}
+          onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
+        >
+          <Heading2 className="w-4 h-4" />
+        </Btn>
+        <Btn
+          label="Bullet list"
+          active={editor.isActive('bulletList')}
+          onClick={() => editor.chain().focus().toggleBulletList().run()}
+        >
+          <List className="w-4 h-4" />
+        </Btn>
+        <Btn
+          label="Numbered list"
+          active={editor.isActive('orderedList')}
+          onClick={() => editor.chain().focus().toggleOrderedList().run()}
+        >
+          <ListOrdered className="w-4 h-4" />
+        </Btn>
+        <Btn
+          label="Checklist"
+          active={editor.isActive('taskList')}
+          onClick={() => editor.chain().focus().toggleTaskList().run()}
+        >
+          <CheckSquare className="w-4 h-4" />
+        </Btn>
+
+        <span className="w-px h-5 bg-gray-200 dark:bg-gray-700 mx-0.5" aria-hidden />
+
+        <Btn
+          label="Undo"
+          onClick={() => editor.chain().focus().undo().run()}
+        >
+          <Undo2 className="w-4 h-4" />
+        </Btn>
+        <Btn label="More formatting" onClick={() => setSheetOpen(true)}>
+          <SlidersHorizontal className="w-4 h-4" />
+        </Btn>
+      </div>
+
+      <BottomSheet
+        open={sheetOpen}
+        onClose={() => setSheetOpen(false)}
+        title="Formatting"
+        snapPoints={[0.6, 0.9]}
+      >
+        <div className="px-3 pb-4">
+          <EditorToolbar
+            editor={editor}
+            inSheet
+            onInsertEvent={onInsertEvent}
+            onInsertAttachment={onInsertAttachment}
+            contextType={contextType}
+            contextId={contextId}
+          />
+        </div>
+      </BottomSheet>
+    </>
+  )
+}

--- a/src/components/rich-text-editor/RichTextEditor.tsx
+++ b/src/components/rich-text-editor/RichTextEditor.tsx
@@ -24,6 +24,8 @@ import { TableHeader } from '@tiptap/extension-table-header'
 import { TableCell } from '@tiptap/extension-table-cell'
 import { clsx } from 'clsx'
 import { EditorToolbar } from './EditorToolbar'
+import { MobileFormatBar } from './MobileFormatBar'
+import { useIsMobile } from '../../hooks/useMediaQuery'
 import { TableControls } from './TableControls'
 import { MentionExtension, MentionList, type MentionItem } from './extensions/MentionExtension'
 import { AssetExtension, AssetList, type AssetItem } from './extensions/AssetExtension'
@@ -150,6 +152,8 @@ const RichTextEditorInner = forwardRef<RichTextEditorRef, RichTextEditorProps>((
   assetContext,
   templates = []
 }, ref) => {
+  // Phones get a compact format bar; the full ribbon moves into a sheet.
+  const isMobileViewport = useIsMobile()
   // Track if we're currently updating from parent to avoid cursor reset
   const isExternalUpdate = useRef(false)
   const lastValueRef = useRef(value)
@@ -761,7 +765,7 @@ const RichTextEditorInner = forwardRef<RichTextEditorRef, RichTextEditorProps>((
           'prose prose-sm max-w-none focus:outline-none',
           editorClassName
         ),
-        style: `min-height: ${minHeight}; padding: 0.5rem 1rem;`
+        style: `min-height: ${minHeight}; padding: 0.5rem ${isMobileViewport ? '0.5rem' : '1rem'};`
       },
       // Smart paste handling
       handlePaste: (view, event) => {
@@ -976,11 +980,19 @@ const RichTextEditorInner = forwardRef<RichTextEditorRef, RichTextEditorProps>((
       {/* Toolbar - Sticky */}
       {!readOnly && (
         <div className="sticky top-[41px] z-10 bg-white dark:bg-gray-800">
-          <EditorToolbar
-            editor={editor}
-            onInsertEvent={onInsertEvent}
-            onInsertAttachment={onInsertAttachment}
-          />
+          {isMobileViewport ? (
+            <MobileFormatBar
+              editor={editor}
+              onInsertEvent={onInsertEvent}
+              onInsertAttachment={onInsertAttachment}
+            />
+          ) : (
+            <EditorToolbar
+              editor={editor}
+              onInsertEvent={onInsertEvent}
+              onInsertAttachment={onInsertAttachment}
+            />
+          )}
         </div>
       )}
 


### PR DESCRIPTION
The ribbon
My last change made this worse and I have reverted it. Turning forty controls into one sideways-scrolling row traded a tall ribbon for a blind one: the same forty controls, but with no way to see what exists or remember where anything is, so finding a tool meant swiping and hoping.

Height was never the real problem — being always-present was. Six controls cover nearly everything anyone does while writing on a phone (bold, italic, a heading, two lists, a checkbox), so those get one row with undo and a More button beside them. The complete ribbon opens in a sheet, where it has room to wrap and can be read rather than scrolled past. EditorToolbar is reused verbatim with an inSheet flag for its border radius; the desktop ribbon is untouched.

The status bar running off the right
This was the thing going off-page, not the command reference I fixed last time. Word count, character count, the @ $ # [[ .AI legend and the save state sat in a single non-wrapping row, and at 390px it simply ran past the edge. The row wraps now, and the legend collapses to "Shortcuts" behind the same help icon — it is a reference, not a control, and the sheet behind it says the same thing with room to say it.

Margins
The editor body had a px-4 wrapper around a ProseMirror with 1rem of its own padding: 64px of a 390px screen spent on gutters before any text. Down to 6px of wrapper and 8px inside on a phone. The note header drops from px-6 to px-3.

Typecheck at baseline, 996 tests passing, production build clean.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
