### PR TITLE
fix(mobile): assets list, and one density on a phone

### DIFF
--- a/src/components/mobile/MobileAssetsList.tsx
+++ b/src/components/mobile/MobileAssetsList.tsx
@@ -1,0 +1,176 @@
+import { useMemo, useState } from 'react'
+import { clsx } from 'clsx'
+import { Search, TrendingUp, X } from 'lucide-react'
+
+interface MobileAssetsListProps {
+  assets: any[]
+  isLoading?: boolean
+  onAssetSelect?: (asset: any) => void
+}
+
+type Sort = 'symbol' | 'company' | 'sector' | 'recent'
+
+const SORTS: { key: Sort; label: string }[] = [
+  { key: 'symbol', label: 'Symbol' },
+  { key: 'company', label: 'Name' },
+  { key: 'sector', label: 'Sector' },
+  { key: 'recent', label: 'Recent' },
+]
+
+const PRIORITY_TONE: Record<string, string> = {
+  critical: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',
+  high: 'bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300',
+  medium: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+  low: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',
+}
+
+/**
+ * The asset universe on a phone.
+ *
+ * AssetTableView is a 6,000-line spreadsheet: configurable columns, AI columns,
+ * virtualisation, spreadsheet keyboard navigation, three row densities. None of
+ * that survives 390px — the columns are user-chosen and can number a dozen, so
+ * there is no fixed subset to freeze and no arrangement that stays legible.
+ *
+ * A list is the honest answer here rather than a compromise. Unlike the
+ * simulation table, this grid is not read for cross-row numeric comparison; it
+ * is read to find a name and open it. That is a list's job, and a list can
+ * carry the identifying fields at a readable size instead of eleven columns at
+ * an unreadable one.
+ *
+ * There is one density, deliberately. Choosing between three row heights is a
+ * desk affordance — on a phone the only sensible height is the one where the
+ * text can be read and the row can be hit.
+ */
+export function MobileAssetsList({ assets, isLoading, onAssetSelect }: MobileAssetsListProps) {
+  const [search, setSearch] = useState('')
+  const [sort, setSort] = useState<Sort>('symbol')
+
+  const visible = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    const list = (assets ?? []).filter(a => {
+      if (!q) return true
+      return `${a.symbol ?? ''} ${a.company_name ?? ''} ${a.sector ?? ''}`.toLowerCase().includes(q)
+    })
+    return list.sort((a, b) => {
+      switch (sort) {
+        case 'company':
+          return (a.company_name ?? '').localeCompare(b.company_name ?? '')
+        case 'sector':
+          // Unclassified names sink rather than clustering at the top under an
+          // empty heading.
+          return (a.sector || '￿').localeCompare(b.sector || '￿')
+        case 'recent':
+          return new Date(b.updated_at ?? 0).getTime() - new Date(a.updated_at ?? 0).getTime()
+        default:
+          return (a.symbol ?? '').localeCompare(b.symbol ?? '')
+      }
+    })
+  }, [assets, search, sort])
+
+  return (
+    <div className="h-full flex flex-col bg-gray-50 dark:bg-gray-950">
+      <div className="flex-shrink-0 px-3 pt-3 pb-2 space-y-2 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800">
+        <div className="relative">
+          <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+          <input
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+            placeholder="Search symbol, company or sector"
+            className="w-full h-10 pl-8 pr-8 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-500"
+          />
+          {search && (
+            <button
+              type="button"
+              onClick={() => setSearch('')}
+              className="absolute right-1.5 top-1/2 -translate-y-1/2 h-7 w-7 flex items-center justify-center rounded-full text-gray-400"
+              aria-label="Clear search"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          )}
+        </div>
+
+        <div className="flex items-center gap-1">
+          {SORTS.map(s => (
+            <button
+              key={s.key}
+              type="button"
+              onClick={() => setSort(s.key)}
+              aria-current={sort === s.key}
+              className={clsx(
+                'flex-1 h-8 rounded-lg text-[12px] font-medium transition-colors no-touch-target',
+                sort === s.key
+                  ? 'bg-primary-50 text-primary-700 dark:bg-primary-900/30 dark:text-primary-300'
+                  : 'text-gray-500 dark:text-gray-400 active:bg-gray-100 dark:active:bg-gray-800'
+              )}
+            >
+              {s.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain pb-safe">
+        {isLoading ? (
+          <div className="p-3 space-y-2">
+            {[0, 1, 2, 3, 4].map(i => (
+              <div key={i} className="h-14 rounded-lg bg-gray-100 dark:bg-gray-800 animate-pulse" />
+            ))}
+          </div>
+        ) : visible.length === 0 ? (
+          <div className="flex flex-col items-center justify-center gap-2 py-16 text-gray-400">
+            <TrendingUp className="h-8 w-8 opacity-50" />
+            <p className="text-sm">{search ? 'No asset matches that.' : 'No assets yet.'}</p>
+          </div>
+        ) : (
+          <>
+            <p className="px-3 py-1.5 text-[11px] text-gray-400">
+              {visible.length.toLocaleString()} {visible.length === 1 ? 'asset' : 'assets'}
+            </p>
+            <div className="divide-y divide-gray-100 dark:divide-gray-800 bg-white dark:bg-gray-900">
+              {visible.map(asset => (
+                <button
+                  key={asset.id}
+                  type="button"
+                  onClick={() => onAssetSelect?.(asset)}
+                  className="w-full flex items-center gap-3 px-3 py-2.5 text-left active:bg-gray-50 dark:active:bg-gray-800"
+                >
+                  <span className="min-w-0 flex-1">
+                    <span className="flex items-center gap-1.5">
+                      <span className="text-sm font-bold text-gray-900 dark:text-white">
+                        {asset.symbol}
+                      </span>
+                      {asset.priority && PRIORITY_TONE[String(asset.priority).toLowerCase()] && (
+                        <span
+                          className={clsx(
+                            'px-1.5 py-0.5 rounded text-[9px] font-bold uppercase tracking-wide',
+                            PRIORITY_TONE[String(asset.priority).toLowerCase()]
+                          )}
+                        >
+                          {asset.priority}
+                        </span>
+                      )}
+                    </span>
+                    <span className="block truncate text-[12px] text-gray-500 dark:text-gray-400">
+                      {asset.company_name}
+                    </span>
+                    {asset.sector && (
+                      <span className="block truncate text-[11px] text-gray-400">{asset.sector}</span>
+                    )}
+                  </span>
+
+                  {asset.current_price != null && (
+                    <span className="shrink-0 text-sm font-semibold tabular-nums text-gray-900 dark:text-white">
+                      ${Number(asset.current_price).toFixed(2)}
+                    </span>
+                  )}
+                </button>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/table/AssetTableView.tsx
+++ b/src/components/table/AssetTableView.tsx
@@ -35,6 +35,7 @@ import { formatDistanceToNow, format } from 'date-fns'
 import { clsx } from 'clsx'
 import { DENSITY_CONFIG } from '../../contexts/TableContext'
 import { DensityToggle } from './DensityToggle'
+import { useIsMobile } from '../../hooks/useMediaQuery'
 import { useSpreadsheetNavigation } from '../../hooks/useSpreadsheetNavigation'
 import { useAssetFlags, FLAG_COLORS, type FlagColor } from '../../hooks/useAssetFlags'
 import { MetricPopover } from './MetricPopover'
@@ -433,6 +434,14 @@ export function AssetTableView({
     return (saved as DensityMode) || 'comfortable'
   })
 
+  // Row density is a desk affordance: it trades legibility for how many rows
+  // fit, which is a choice worth having on a wide screen and not on a phone,
+  // where the only sensible height is the one you can read and hit. Wherever
+  // this grid still renders on a phone it uses one density and does not offer
+  // the switch.
+  const isMobileViewport = useIsMobile()
+  const effectiveDensity: DensityMode = isMobileViewport ? 'comfortable' : density
+
   // Listen for density changes via custom event (dispatched by DensityToggle)
   useEffect(() => {
     const handleDensityChange = (e: CustomEvent<{ density: DensityMode }>) => {
@@ -442,9 +451,9 @@ export function AssetTableView({
     return () => window.removeEventListener('density-change', handleDensityChange as EventListener)
   }, [])
 
-  const densityConfig = DENSITY_CONFIG[density]
+  const densityConfig = DENSITY_CONFIG[effectiveDensity]
   const densityRowHeight = densityConfig.rowHeight
-  const expandedRowHeight = expandedRowHeightS[density]
+  const expandedRowHeight = expandedRowHeightS[effectiveDensity]
 
   // Filter state
   const [searchQuery, setSearchQuery] = useState('')
@@ -2333,7 +2342,7 @@ export function AssetTableView({
         {/* Right side controls */}
         <div className="flex items-center gap-1">
           {/* Density toggle (table mode only) */}
-          {viewMode === 'table' && <DensityToggle />}
+          {viewMode === 'table' && !isMobileViewport && <DensityToggle />}
 
           {/* Divider */}
           {viewMode === 'table' && <div className="h-4 w-px bg-gray-200 mx-1" />}
@@ -3237,9 +3246,9 @@ export function AssetTableView({
                                     return <span className="pro-empty-cell">—</span>
                                   }
                                   const lead = coverage[0] // deterministically sorted: is_lead → role → updated_at → user_id
-                                  const isMicro = density === 'micro'
+                                  const isMicro = effectiveDensity === 'micro'
 
-                                  if (density === 'comfortable') {
+                                  if (effectiveDensity === 'comfortable') {
                                     return (
                                       <div className="flex items-center gap-1.5" title={coverage.map(c => `${c.analyst}${c.team ? ` (${c.team})` : ''}`).join('\n')}>
                                         <div className="min-w-0 flex-1">
@@ -3258,7 +3267,7 @@ export function AssetTableView({
                                   )
                                 })()}
                                 {col.id === 'workflows' && (() => {
-                                  const isMicro = density === 'micro'
+                                  const isMicro = effectiveDensity === 'micro'
 
                                   if (workflows.length === 0) {
                                     return (
@@ -3311,8 +3320,8 @@ export function AssetTableView({
                                   const priority = getPriorityForColumn(col, asset.id)
                                   const config = priority && priority !== 'none' ? PRIORITY_CONFIG[priority] : null
                                   const IconComponent = config?.icon
-                                  const isMicroOrUltra = density === 'ultra' || density === 'micro'
-                                  const isMicro = density === 'micro'
+                                  const isMicroOrUltra = effectiveDensity === 'ultra' || effectiveDensity === 'micro'
+                                  const isMicro = effectiveDensity === 'micro'
 
                                   // Only allow editing for user's own priority column
                                   const isEditable = col.prioritySource === 'my' || (col.id === 'priority' && !col.prioritySource)
@@ -3421,7 +3430,7 @@ export function AssetTableView({
                                     )
                                   }
 
-                                  const isMicro = density === 'micro'
+                                  const isMicro = effectiveDensity === 'micro'
 
                                   return (
                                     <div
@@ -3475,7 +3484,7 @@ export function AssetTableView({
                                     )
                                   }
 
-                                  const isMicro = density === 'micro'
+                                  const isMicro = effectiveDensity === 'micro'
 
                                   return (
                                     <div
@@ -3499,7 +3508,7 @@ export function AssetTableView({
                                 {col.id === 'updated' && (() => {
                                   if (!asset.updated_at) return <span className="pro-empty-cell">—</span>
                                   const freshness = getTimestampFreshness(asset.updated_at)
-                                  const isMicro = density === 'micro'
+                                  const isMicro = effectiveDensity === 'micro'
 
                                   return (
                                     <div className={clsx(
@@ -4103,8 +4112,8 @@ export function AssetTableView({
                                       {col.id === 'coverage' && (() => {
                                         if (coverage.length === 0) return <span className="pro-empty-cell">\u2014</span>
                                         const lead = coverage[0] // deterministically sorted: is_lead → role → updated_at → user_id
-                                        const isMicro = density === 'micro'
-                                        if (density === 'comfortable') {
+                                        const isMicro = effectiveDensity === 'micro'
+                                        if (effectiveDensity === 'comfortable') {
                                           return (
                                             <div className="flex items-center gap-1.5" title={coverage.map(c => `${c.analyst}${c.team ? ` (${c.team})` : ''}`).join('\n')}>
                                               <div className="min-w-0 flex-1">
@@ -4123,7 +4132,7 @@ export function AssetTableView({
                                         )
                                       })()}
                                       {col.id === 'workflows' && (() => {
-                                        const isMicro = density === 'micro'
+                                        const isMicro = effectiveDensity === 'micro'
                                         if (workflows.length === 0) {
                                           return (
                                             <button
@@ -4171,8 +4180,8 @@ export function AssetTableView({
                                         const priority = getPriorityForColumn(col, asset.id)
                                         const config = priority && priority !== 'none' ? PRIORITY_CONFIG[priority] : null
                                         const IconComponent = config?.icon
-                                        const isMicroOrUltra = density === 'ultra' || density === 'micro'
-                                        const isMicro = density === 'micro'
+                                        const isMicroOrUltra = effectiveDensity === 'ultra' || effectiveDensity === 'micro'
+                                        const isMicro = effectiveDensity === 'micro'
                                         const isEditable = col.prioritySource === 'my' || (col.id === 'priority' && !col.prioritySource)
 
                                         const content = config ? (
@@ -4212,7 +4221,7 @@ export function AssetTableView({
                                         )
                                       })()}
                                       {col.id === 'sector' && (
-                                        <span className={clsx('truncate text-gray-600 dark:text-gray-400', density === 'micro' && 'text-[9px]')}>
+                                        <span className={clsx('truncate text-gray-600 dark:text-gray-400', effectiveDensity === 'micro' && 'text-[9px]')}>
                                           {asset.sector || '\u2014'}
                                         </span>
                                       )}
@@ -4249,7 +4258,7 @@ export function AssetTableView({
                                       {col.id === 'notes' && (() => {
                                         const quickNote = asset.quick_note || ''
                                         const isEditing = editingNoteId === asset.id
-                                        const isMicro = density === 'micro'
+                                        const isMicro = effectiveDensity === 'micro'
 
                                         if (isEditing) {
                                           return (
@@ -4302,7 +4311,7 @@ export function AssetTableView({
                                         const listNote = (asset as any)._listNotes || ''
                                         const rowId = (asset as any)._rowId || asset.id
                                         const isEditing = editingListNoteRowId === rowId
-                                        const isMicro = density === 'micro'
+                                        const isMicro = effectiveDensity === 'micro'
 
                                         if (isEditing) {
                                           return (
@@ -4354,7 +4363,7 @@ export function AssetTableView({
                                       {col.id === 'updated' && (() => {
                                         if (!asset.updated_at) return <span className="pro-empty-cell">{'\u2014'}</span>
                                         const freshness = getTimestampFreshness(asset.updated_at)
-                                        const isMicro = density === 'micro'
+                                        const isMicro = effectiveDensity === 'micro'
                                         return (
                                           <div className={clsx(
                                             'pro-timestamp flex items-center',

--- a/src/lib/mobile/mobile-surfaces.ts
+++ b/src/lib/mobile/mobile-surfaces.ts
@@ -78,7 +78,7 @@ export const MOBILE_SURFACES: MobileSurface[] = [
     type: 'assets-list', title: 'Assets', icon: TrendingUp,
     color: 'text-blue-500', bg: 'bg-blue-50',
     support: 'read-only', group: 'core', inNav: true,
-    mobileNote: 'Search and read — the grid stays on desktop',
+    mobileNote: 'Search and open — column config stays on desktop',
   },
   {
     type: 'asset', title: 'Asset', icon: TrendingUp,

--- a/src/pages/AssetsListPage.tsx
+++ b/src/pages/AssetsListPage.tsx
@@ -8,6 +8,8 @@
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../lib/supabase'
 import { AssetTableView } from '../components/table/AssetTableView'
+import { MobileAssetsList } from '../components/mobile/MobileAssetsList'
+import { useIsMobile } from '../hooks/useMediaQuery'
 import { ListSkeleton } from '../components/common/LoadingSkeleton'
 
 interface AssetsListPageProps {
@@ -15,6 +17,11 @@ interface AssetsListPageProps {
 }
 
 export function AssetsListPage({ onAssetSelect }: AssetsListPageProps) {
+  // AssetTableView is a configurable spreadsheet — user-chosen columns, AI
+  // columns, three densities, spreadsheet keyboard navigation. None of that
+  // resolves to 390px, and unlike a simulation grid this one is read to find a
+  // name rather than to compare numbers across rows, which is a list's job.
+  const isMobileViewport = useIsMobile()
   // Fetch all assets
   const { data: assets, isLoading } = useQuery({
     queryKey: ['all-assets'],
@@ -35,6 +42,16 @@ export function AssetsListPage({ onAssetSelect }: AssetsListPageProps) {
       <div className="p-6">
         <ListSkeleton />
       </div>
+    )
+  }
+
+  if (isMobileViewport) {
+    return (
+      <MobileAssetsList
+        assets={assets || []}
+        isLoading={isLoading}
+        onAssetSelect={onAssetSelect}
+      />
     )
   }
 


### PR DESCRIPTION
The grid
AssetTableView is a 6,000-line spreadsheet — user-configurable columns, AI columns, virtualisation, spreadsheet keyboard navigation. None of it resolves to 390px, and unlike the simulation grid there is no fixed subset to freeze: the columns are chosen by the user and can number a dozen, so no arrangement stays legible.

A list is the honest answer rather than a compromise. This grid is read to find a name and open it, not to compare numbers across rows — that is what a list does, and it can carry symbol, company, sector, priority and price at a readable size instead of eleven columns at an unreadable one. Sort by symbol, name, sector or recency; search spans all three text fields.

One density
Row density trades legibility for how many rows fit. That is a choice worth having at a desk and not on a phone, where the only sensible height is the one you can read and hit. Wherever the grid still renders on a phone it now uses a single density and does not offer the switch — an effectiveDensity override rather than a change to the stored preference, so a user's desktop choice survives being on their phone.

mobile-surfaces said "the grid stays on desktop", which stopped being true; the note now describes what actually happens.

Typecheck at baseline, 996 tests passing, production build clean.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
