### PR TITLE
feat(mobile): watchlist-style assets list with a full-screen preview

### DIFF
--- a/src/components/mobile/MobileAssetPreview.tsx
+++ b/src/components/mobile/MobileAssetPreview.tsx
@@ -1,0 +1,206 @@
+import { useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { clsx } from 'clsx'
+import { Area, ComposedChart, ResponsiveContainer, Tooltip, XAxis, YAxis } from 'recharts'
+import { ArrowRight, X } from 'lucide-react'
+import { usePriceTargetChart } from '../../hooks/usePriceTargetChart'
+
+const TIMEFRAMES = ['1M', '3M', '6M', '1Y', '2Y', '5Y'] as const
+type Timeframe = (typeof TIMEFRAMES)[number]
+
+interface MobileAssetPreviewProps {
+  asset: { id: string; symbol: string; company_name?: string | null; sector?: string | null; industry?: string | null; country?: string | null; exchange?: string | null }
+  onClose: () => void
+  onOpenAssetPage: () => void
+}
+
+/**
+ * A full-screen look at one name, before committing to its page.
+ *
+ * Opening the asset page replaces the list — a tab switch, a full research
+ * surface, and the scroll position you had gone. Most taps from a watchlist are
+ * not that; they are "what is this doing", answered by a chart and a few facts.
+ * This sits between the two: the name gets the whole screen, and going further
+ * stays one deliberate tap away.
+ *
+ * The series comes from usePriceTargetChart, the same hook the asset page's
+ * chart uses, which fetches real candles. That matters here specifically: the
+ * lighter-weight chart components in this codebase build their series with
+ * ChartDataAdapter.generateHistoricalData, a seeded random walk anchored to the
+ * current quote, and a drawn line beside a real price reads as real.
+ */
+export function MobileAssetPreview({ asset, onClose, onOpenAssetPage }: MobileAssetPreviewProps) {
+  const [timeframe, setTimeframe] = useState<Timeframe>('1Y')
+
+  const { historicalPrices, currentPrice, priceChangePercent, loading, error } =
+    usePriceTargetChart({ assetId: asset.id, symbol: asset.symbol, timeframe: timeframe as any })
+
+  const series = useMemo(
+    () => (historicalPrices ?? []).map(d => ({ t: new Date(d.time).getTime(), price: d.close })),
+    [historicalPrices]
+  )
+
+  const domain = useMemo(() => {
+    const values = series.map(p => p.price).filter(Number.isFinite)
+    if (!values.length) return null
+    const lo = Math.min(...values)
+    const hi = Math.max(...values)
+    const pad = (hi - lo) * 0.08 || Math.max(hi * 0.05, 1)
+    return [lo - pad, hi + pad] as [number, number]
+  }, [series])
+
+  const up = (priceChangePercent ?? 0) >= 0
+  const lineColor = up ? '#10b981' : '#ef4444'
+
+  if (typeof document === 'undefined') return null
+
+  return createPortal(
+    <div className="fixed inset-0 z-[95] flex flex-col bg-white dark:bg-gray-900">
+      <div className="flex-shrink-0 flex items-start gap-2 px-4 h-16 pt-safe border-b border-gray-100 dark:border-gray-800">
+        <div className="min-w-0 flex-1">
+          <h2 className="text-xl font-bold leading-tight text-gray-900 dark:text-white">{asset.symbol}</h2>
+          <p className="truncate text-[12px] text-gray-500 dark:text-gray-400">{asset.company_name}</p>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="shrink-0 h-10 w-10 flex items-center justify-center rounded-full text-gray-500 dark:text-gray-400 no-touch-target"
+          aria-label="Close"
+        >
+          <X className="h-5 w-5" />
+        </button>
+      </div>
+
+      <div className="flex-1 min-h-0 overflow-y-auto">
+        <div className="px-4 pt-3">
+          <div className="flex items-baseline gap-2">
+            <span className="text-3xl font-bold tabular-nums text-gray-900 dark:text-white">
+              {currentPrice != null ? currentPrice.toFixed(2) : '—'}
+            </span>
+            {priceChangePercent != null && (
+              <span
+                className={clsx(
+                  'px-2 py-0.5 rounded-md text-[13px] font-semibold tabular-nums text-white',
+                  up ? 'bg-emerald-500' : 'bg-red-500'
+                )}
+              >
+                {up ? '+' : ''}
+                {priceChangePercent.toFixed(2)}%
+              </span>
+            )}
+          </div>
+        </div>
+
+        <div className="h-56 px-1 pt-3">
+          {loading ? (
+            <div className="mx-3 h-full rounded-xl bg-gray-100 dark:bg-gray-800 animate-pulse" />
+          ) : error || !series.length ? (
+            <div className="mx-3 h-full flex items-center justify-center rounded-xl border border-gray-200 dark:border-gray-700">
+              <p className="text-sm text-gray-400">Price history unavailable.</p>
+            </div>
+          ) : (
+            <ResponsiveContainer width="100%" height="100%">
+              <ComposedChart data={series} margin={{ top: 4, right: 8, bottom: 0, left: 0 }}>
+                <defs>
+                  <linearGradient id={`map-${asset.symbol}`} x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor={lineColor} stopOpacity={0.25} />
+                    <stop offset="100%" stopColor={lineColor} stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                <XAxis
+                  dataKey="t"
+                  type="number"
+                  scale="time"
+                  domain={['dataMin', 'dataMax']}
+                  tickFormatter={(v: number) => formatTick(v, timeframe)}
+                  tick={{ fontSize: 10, fill: '#9ca3af' }}
+                  tickLine={false}
+                  axisLine={false}
+                  minTickGap={28}
+                />
+                <YAxis domain={domain ?? ['dataMin', 'dataMax']} hide />
+                <Tooltip
+                  contentStyle={{ fontSize: 12, borderRadius: 8, padding: '4px 8px' }}
+                  labelFormatter={(t: number) => new Date(t).toLocaleDateString()}
+                  formatter={(v: number) => ['$' + v.toFixed(2), 'Price']}
+                  cursor={{ stroke: '#9ca3af', strokeDasharray: '3 3' }}
+                />
+                <Area
+                  type="monotone"
+                  dataKey="price"
+                  stroke={lineColor}
+                  strokeWidth={1.75}
+                  fill={`url(#map-${asset.symbol})`}
+                  isAnimationActive={false}
+                  dot={false}
+                />
+              </ComposedChart>
+            </ResponsiveContainer>
+          )}
+        </div>
+
+        <div className="flex items-center gap-1 px-3 py-2">
+          {TIMEFRAMES.map(tf => (
+            <button
+              key={tf}
+              type="button"
+              onClick={() => setTimeframe(tf)}
+              aria-pressed={tf === timeframe}
+              className={clsx(
+                'flex-1 h-8 rounded-lg text-xs font-semibold transition-colors no-touch-target',
+                tf === timeframe
+                  ? 'bg-gray-900 text-white dark:bg-white dark:text-gray-900'
+                  : 'text-gray-500 dark:text-gray-400 active:bg-gray-100 dark:active:bg-gray-800'
+              )}
+            >
+              {tf}
+            </button>
+          ))}
+        </div>
+
+        {/* Only what the list row already carries. Coverage, targets and the
+            case need the asset page, which is one tap below. */}
+        <dl className="grid grid-cols-2 gap-x-4 gap-y-3 px-4 py-3 border-t border-gray-100 dark:border-gray-800">
+          <Fact label="Sector" value={asset.sector} />
+          <Fact label="Industry" value={asset.industry} />
+          <Fact label="Country" value={asset.country} />
+          <Fact label="Exchange" value={asset.exchange} />
+        </dl>
+      </div>
+
+      <div className="flex-shrink-0 px-4 py-3 pb-safe border-t border-gray-200 dark:border-gray-700">
+        <button
+          type="button"
+          onClick={onOpenAssetPage}
+          className="w-full h-11 inline-flex items-center justify-center gap-2 rounded-xl bg-primary-600 text-white text-sm font-semibold no-touch-target"
+        >
+          Open {asset.symbol}
+          <ArrowRight className="h-4 w-4" />
+        </button>
+      </div>
+    </div>,
+    document.body
+  )
+}
+
+function Fact({ label, value }: { label: string; value?: string | null }) {
+  return (
+    <div className="min-w-0">
+      <dt className="text-[10px] font-semibold uppercase tracking-wider text-gray-400">{label}</dt>
+      <dd className="mt-0.5 truncate text-sm text-gray-900 dark:text-gray-100">{value || '—'}</dd>
+    </div>
+  )
+}
+
+/** Tick labels sized to the span, so a year of candles does not overlap. */
+function formatTick(value: number, timeframe: Timeframe): string {
+  const d = new Date(value)
+  if (Number.isNaN(d.getTime())) return ''
+  if (timeframe === '1M' || timeframe === '3M') {
+    return d.toLocaleDateString(undefined, { day: 'numeric', month: 'short' })
+  }
+  if (timeframe === '2Y' || timeframe === '5Y') {
+    return d.toLocaleDateString(undefined, { year: '2-digit', month: 'short' })
+  }
+  return d.toLocaleDateString(undefined, { month: 'short' })
+}

--- a/src/components/mobile/MobileAssetsList.tsx
+++ b/src/components/mobile/MobileAssetsList.tsx
@@ -1,6 +1,8 @@
 import { useMemo, useState } from 'react'
 import { clsx } from 'clsx'
 import { Search, TrendingUp, X } from 'lucide-react'
+import { useMarketData } from '../../hooks/useMarketData'
+import { MobileAssetPreview } from './MobileAssetPreview'
 
 interface MobileAssetsListProps {
   assets: any[]
@@ -8,76 +10,104 @@ interface MobileAssetsListProps {
   onAssetSelect?: (asset: any) => void
 }
 
-type Sort = 'symbol' | 'company' | 'sector' | 'recent'
+type Sort = 'symbol' | 'company' | 'change' | 'recent'
 
 const SORTS: { key: Sort; label: string }[] = [
   { key: 'symbol', label: 'Symbol' },
   { key: 'company', label: 'Name' },
-  { key: 'sector', label: 'Sector' },
+  { key: 'change', label: 'Change' },
   { key: 'recent', label: 'Recent' },
 ]
 
-const PRIORITY_TONE: Record<string, string> = {
-  critical: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',
-  high: 'bg-orange-100 text-orange-700 dark:bg-orange-900/40 dark:text-orange-300',
-  medium: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
-  low: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',
-}
+/**
+ * How many rows get a live quote.
+ *
+ * useMarketData fetches per symbol, so quoting a thousand-name universe on
+ * mount would fire a thousand requests for rows nobody has scrolled to. The
+ * visible window is roughly a dozen; this covers several screens of scrolling
+ * without turning the list into a load test, and rows past it fall back to the
+ * stored price rather than showing nothing.
+ */
+const QUOTE_LIMIT = 60
 
 /**
- * The asset universe on a phone.
+ * The asset universe as a watchlist.
  *
- * AssetTableView is a 6,000-line spreadsheet: configurable columns, AI columns,
- * virtualisation, spreadsheet keyboard navigation, three row densities. None of
- * that survives 390px — the columns are user-chosen and can number a dozen, so
- * there is no fixed subset to freeze and no arrangement that stays legible.
+ * Laid out like a phone brokerage watchlist because that is the shape the
+ * information already has: an identifier, a name, a price and a move. Symbol
+ * and company on the left, last price right-aligned with the day's change as a
+ * filled pill beneath it — the pill rather than coloured text because on a
+ * small screen a tinted number reads as decoration until you look twice, and
+ * the sign of the move is the thing being scanned for.
  *
- * A list is the honest answer here rather than a compromise. Unlike the
- * simulation table, this grid is not read for cross-row numeric comparison; it
- * is read to find a name and open it. That is a list's job, and a list can
- * carry the identifying fields at a readable size instead of eleven columns at
- * an unreadable one.
+ * There is no sparkline, deliberately. The MiniChart component this could have
+ * reused builds its series with ChartDataAdapter.generateHistoricalData — a
+ * seeded random walk anchored to the current quote, not price history. A drawn
+ * line beside a real price reads as real, and inventing one in a finance
+ * product is worse than leaving the space empty. A real sparkline needs a
+ * candle request per symbol, which is a different piece of work.
  *
- * There is one density, deliberately. Choosing between three row heights is a
- * desk affordance — on a phone the only sensible height is the one where the
- * text can be read and the row can be hit.
+ * One density. Row height that trades legibility for row count is a desk
+ * affordance; here the only sensible height is the one that can be read and hit.
  */
 export function MobileAssetsList({ assets, isLoading, onAssetSelect }: MobileAssetsListProps) {
   const [search, setSearch] = useState('')
   const [sort, setSort] = useState<Sort>('symbol')
+  // A tap opens the name full screen first; the asset page is a second,
+  // deliberate step from there.
+  const [previewing, setPreviewing] = useState<any | null>(null)
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase()
+    if (!q) return assets ?? []
+    return (assets ?? []).filter(a =>
+      `${a.symbol ?? ''} ${a.company_name ?? ''} ${a.sector ?? ''}`.toLowerCase().includes(q)
+    )
+  }, [assets, search])
+
+  // Quote only the head of the list, and re-quote as the user narrows it —
+  // a search that surfaces a name should price it.
+  const quotedSymbols = useMemo(
+    () => filtered.slice(0, QUOTE_LIMIT).map(a => a.symbol).filter(Boolean),
+    [filtered]
+  )
+  const { quotes } = useMarketData(quotedSymbols, { refreshInterval: 60_000 })
 
   const visible = useMemo(() => {
-    const q = search.trim().toLowerCase()
-    const list = (assets ?? []).filter(a => {
-      if (!q) return true
-      return `${a.symbol ?? ''} ${a.company_name ?? ''} ${a.sector ?? ''}`.toLowerCase().includes(q)
-    })
+    const list = [...filtered]
+    const changeOf = (a: any) => quotes.get(String(a.symbol).toUpperCase())?.changePercent ?? null
     return list.sort((a, b) => {
       switch (sort) {
         case 'company':
           return (a.company_name ?? '').localeCompare(b.company_name ?? '')
-        case 'sector':
-          // Unclassified names sink rather than clustering at the top under an
-          // empty heading.
-          return (a.sector || '￿').localeCompare(b.sector || '￿')
+        case 'change': {
+          // Unquoted rows sink rather than sorting as zero, which would scatter
+          // them through the middle of the list as if they were flat.
+          const av = changeOf(a)
+          const bv = changeOf(b)
+          if (av == null && bv == null) return 0
+          if (av == null) return 1
+          if (bv == null) return -1
+          return bv - av
+        }
         case 'recent':
           return new Date(b.updated_at ?? 0).getTime() - new Date(a.updated_at ?? 0).getTime()
         default:
           return (a.symbol ?? '').localeCompare(b.symbol ?? '')
       }
     })
-  }, [assets, search, sort])
+  }, [filtered, sort, quotes])
 
   return (
-    <div className="h-full flex flex-col bg-gray-50 dark:bg-gray-950">
-      <div className="flex-shrink-0 px-3 pt-3 pb-2 space-y-2 bg-white dark:bg-gray-900 border-b border-gray-200 dark:border-gray-800">
+    <div className="h-full flex flex-col bg-white dark:bg-gray-950">
+      <div className="flex-shrink-0 px-3 pt-3 pb-2 space-y-2 border-b border-gray-100 dark:border-gray-800">
         <div className="relative">
           <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
           <input
             value={search}
             onChange={e => setSearch(e.target.value)}
-            placeholder="Search symbol, company or sector"
-            className="w-full h-10 pl-8 pr-8 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-500"
+            placeholder="Search symbol or company"
+            className="w-full h-10 pl-8 pr-8 rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900 text-sm text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-primary-500"
           />
           {search && (
             <button
@@ -101,7 +131,7 @@ export function MobileAssetsList({ assets, isLoading, onAssetSelect }: MobileAss
               className={clsx(
                 'flex-1 h-8 rounded-lg text-[12px] font-medium transition-colors no-touch-target',
                 sort === s.key
-                  ? 'bg-primary-50 text-primary-700 dark:bg-primary-900/30 dark:text-primary-300'
+                  ? 'bg-gray-900 text-white dark:bg-white dark:text-gray-900'
                   : 'text-gray-500 dark:text-gray-400 active:bg-gray-100 dark:active:bg-gray-800'
               )}
             >
@@ -114,7 +144,7 @@ export function MobileAssetsList({ assets, isLoading, onAssetSelect }: MobileAss
       <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain pb-safe">
         {isLoading ? (
           <div className="p-3 space-y-2">
-            {[0, 1, 2, 3, 4].map(i => (
+            {[0, 1, 2, 3, 4, 5].map(i => (
               <div key={i} className="h-14 rounded-lg bg-gray-100 dark:bg-gray-800 animate-pulse" />
             ))}
           </div>
@@ -124,53 +154,89 @@ export function MobileAssetsList({ assets, isLoading, onAssetSelect }: MobileAss
             <p className="text-sm">{search ? 'No asset matches that.' : 'No assets yet.'}</p>
           </div>
         ) : (
-          <>
-            <p className="px-3 py-1.5 text-[11px] text-gray-400">
-              {visible.length.toLocaleString()} {visible.length === 1 ? 'asset' : 'assets'}
-            </p>
-            <div className="divide-y divide-gray-100 dark:divide-gray-800 bg-white dark:bg-gray-900">
-              {visible.map(asset => (
-                <button
-                  key={asset.id}
-                  type="button"
-                  onClick={() => onAssetSelect?.(asset)}
-                  className="w-full flex items-center gap-3 px-3 py-2.5 text-left active:bg-gray-50 dark:active:bg-gray-800"
-                >
-                  <span className="min-w-0 flex-1">
-                    <span className="flex items-center gap-1.5">
-                      <span className="text-sm font-bold text-gray-900 dark:text-white">
-                        {asset.symbol}
-                      </span>
-                      {asset.priority && PRIORITY_TONE[String(asset.priority).toLowerCase()] && (
-                        <span
-                          className={clsx(
-                            'px-1.5 py-0.5 rounded text-[9px] font-bold uppercase tracking-wide',
-                            PRIORITY_TONE[String(asset.priority).toLowerCase()]
-                          )}
-                        >
-                          {asset.priority}
-                        </span>
-                      )}
-                    </span>
-                    <span className="block truncate text-[12px] text-gray-500 dark:text-gray-400">
-                      {asset.company_name}
-                    </span>
-                    {asset.sector && (
-                      <span className="block truncate text-[11px] text-gray-400">{asset.sector}</span>
-                    )}
-                  </span>
-
-                  {asset.current_price != null && (
-                    <span className="shrink-0 text-sm font-semibold tabular-nums text-gray-900 dark:text-white">
-                      ${Number(asset.current_price).toFixed(2)}
-                    </span>
-                  )}
-                </button>
-              ))}
-            </div>
-          </>
+          <div className="divide-y divide-gray-100 dark:divide-gray-800">
+            {visible.map(asset => (
+              <WatchRow
+                key={asset.id}
+                asset={asset}
+                quote={quotes.get(String(asset.symbol).toUpperCase())}
+                onSelect={() => setPreviewing(asset)}
+              />
+            ))}
+          </div>
         )}
       </div>
+
+      {previewing && (
+        <MobileAssetPreview
+          asset={previewing}
+          onClose={() => setPreviewing(null)}
+          onOpenAssetPage={() => {
+            const asset = previewing
+            setPreviewing(null)
+            // The shape DashboardPage.handleSearchResult expects. Passing the
+            // bare row leaves result.type undefined, which falls through to the
+            // unregistered-surface default and renders "desktop only".
+            onAssetSelect?.({ id: asset.id, title: asset.symbol, type: 'asset', data: asset })
+          }}
+        />
+      )}
     </div>
+  )
+}
+
+function WatchRow({
+  asset,
+  quote,
+  onSelect,
+}: {
+  asset: any
+  quote?: { price?: number; change?: number; changePercent?: number }
+  onSelect: () => void
+}) {
+  // The stored price is the fallback so a row never renders blank; it is a
+  // cached figure rather than a live one, which is why the change pill only
+  // appears when there is a real quote behind it.
+  const price = quote?.price ?? (asset.current_price != null ? Number(asset.current_price) : null)
+  const pct = quote?.changePercent
+  const up = (pct ?? 0) >= 0
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className="w-full flex items-center gap-3 px-4 py-3 text-left active:bg-gray-50 dark:active:bg-gray-900"
+    >
+      <span className="min-w-0 flex-1">
+        <span className="block text-[15px] font-bold leading-tight text-gray-900 dark:text-white">
+          {asset.symbol}
+        </span>
+        <span className="block truncate text-[12px] leading-tight text-gray-500 dark:text-gray-400">
+          {asset.company_name}
+        </span>
+      </span>
+
+      <span className="shrink-0 flex flex-col items-end gap-1">
+        <span className="text-[15px] font-semibold tabular-nums leading-tight text-gray-900 dark:text-white">
+          {price != null ? price.toFixed(2) : '—'}
+        </span>
+        {pct != null ? (
+          <span
+            className={clsx(
+              'min-w-[4.25rem] text-center px-2 py-0.5 rounded-md text-[12px] font-semibold tabular-nums text-white',
+              up ? 'bg-emerald-500' : 'bg-red-500'
+            )}
+          >
+            {up ? '+' : ''}
+            {pct.toFixed(2)}%
+          </span>
+        ) : (
+          // Fixed width so the price column does not shift as quotes land.
+          <span className="min-w-[4.25rem] text-center px-2 py-0.5 rounded-md text-[12px] font-semibold text-gray-400 bg-gray-100 dark:bg-gray-800">
+            —
+          </span>
+        )}
+      </span>
+    </button>
   )
 }


### PR DESCRIPTION
Watchlist layout
Reworked to the shape a phone brokerage list uses, because it is the shape the information already has: symbol and company on the left, last price right-aligned with the day's change as a filled pill beneath it. A pill rather than coloured text — on a small screen a tinted number reads as decoration until you look twice, and the sign of the move is what is being scanned for. Sort by symbol, name, change or recency.

Quotes come from useMarketData, capped at the first 60 rows. It fetches per symbol, so quoting a thousand-name universe on mount would fire a thousand requests for rows nobody has scrolled to; rows past the cap fall back to the stored price rather than showing nothing, and narrowing the search re-quotes, so a name you searched for is always priced.

No sparkline, deliberately. MiniChart — the obvious thing to reuse — builds its series with ChartDataAdapter.generateHistoricalData, a seeded random walk anchored to the current quote. A drawn line beside a real price reads as real, and inventing one in a finance product is worse than leaving the space empty. A real sparkline needs a candle request per symbol, which is separate work.

"Desktop only" when opening an asset
The list called onAssetSelect with the bare asset row. DashboardPage's handler expects { id, title, type, data }, so result.type was undefined, which fell through to the unregistered-surface default and rendered DesktopOnlyCard — even though the asset surface is registered as fully supported. Now sends the same shape AssetTableView does.

Full-screen preview before the page
Opening the asset page replaces the list: a tab switch, a full research surface, and the scroll position gone. Most taps from a watchlist are not that — they are "what is this doing", answered by a chart and a few facts. A tap now opens the name full screen with a real price chart, timeframes, and sector / industry / country / exchange, with "Open <SYMBOL>" as a second, deliberate step.

Its series uses usePriceTargetChart, the same hook the asset page's chart uses, for the same reason the sparkline was left out.

Typecheck at baseline, 996 tests passing, production build clean.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
