### PR TITLE
feat(mobile): outcomes ledger, real sparklines, plainer app launcher

### DIFF
--- a/src/components/mobile/MobileAssetsList.tsx
+++ b/src/components/mobile/MobileAssetsList.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react'
 import { clsx } from 'clsx'
 import { Search, TrendingUp, X } from 'lucide-react'
 import { useMarketData } from '../../hooks/useMarketData'
+import { useSparklines, type Sparkline } from '../../hooks/useSparklines'
 import { MobileAssetPreview } from './MobileAssetPreview'
 
 interface MobileAssetsListProps {
@@ -31,6 +32,15 @@ const SORTS: { key: Sort; label: string }[] = [
 const QUOTE_LIMIT = 60
 
 /**
+ * How many rows get a sparkline.
+ *
+ * One candle request per symbol, so this is tighter than the quote cap — far
+ * enough to cover the rows a thumb reaches before the next scroll, not far
+ * enough to fetch a month of history for a universe nobody has looked at.
+ */
+const SPARK_LIMIT = 30
+
+/**
  * The asset universe as a watchlist.
  *
  * Laid out like a phone brokerage watchlist because that is the shape the
@@ -40,12 +50,12 @@ const QUOTE_LIMIT = 60
  * small screen a tinted number reads as decoration until you look twice, and
  * the sign of the move is the thing being scanned for.
  *
- * There is no sparkline, deliberately. The MiniChart component this could have
- * reused builds its series with ChartDataAdapter.generateHistoricalData — a
- * seeded random walk anchored to the current quote, not price history. A drawn
- * line beside a real price reads as real, and inventing one in a finance
- * product is worse than leaving the space empty. A real sparkline needs a
- * candle request per symbol, which is a different piece of work.
+ * Sparklines are a month of real daily closes, fetched per symbol through
+ * useSparklines. MiniChart was the obvious thing to reuse and is not used here:
+ * it builds its series with ChartDataAdapter.generateHistoricalData, a seeded
+ * random walk anchored to the current quote. A drawn line beside a real price
+ * reads as real price history, so that is a correctness problem rather than a
+ * cosmetic one.
  *
  * One density. Row height that trades legibility for row count is a desk
  * affordance; here the only sensible height is the one that can be read and hit.
@@ -72,6 +82,7 @@ export function MobileAssetsList({ assets, isLoading, onAssetSelect }: MobileAss
     [filtered]
   )
   const { quotes } = useMarketData(quotedSymbols, { refreshInterval: 60_000 })
+  const sparklines = useSparklines(quotedSymbols.slice(0, SPARK_LIMIT))
 
   const visible = useMemo(() => {
     const list = [...filtered]
@@ -160,6 +171,7 @@ export function MobileAssetsList({ assets, isLoading, onAssetSelect }: MobileAss
                 key={asset.id}
                 asset={asset}
                 quote={quotes.get(String(asset.symbol).toUpperCase())}
+                spark={sparklines[asset.symbol]}
                 onSelect={() => setPreviewing(asset)}
               />
             ))}
@@ -188,10 +200,12 @@ export function MobileAssetsList({ assets, isLoading, onAssetSelect }: MobileAss
 function WatchRow({
   asset,
   quote,
+  spark,
   onSelect,
 }: {
   asset: any
   quote?: { price?: number; change?: number; changePercent?: number }
+  spark?: Sparkline
   onSelect: () => void
 }) {
   // The stored price is the fallback so a row never renders blank; it is a
@@ -216,6 +230,12 @@ function WatchRow({
         </span>
       </span>
 
+      {/* A month of real closes. Fixed width so rows stay aligned whether or
+          not a line has arrived. */}
+      <span className="shrink-0 w-16" aria-hidden>
+        {spark ? <Sparkline data={spark} /> : <span className="block h-8" />}
+      </span>
+
       <span className="shrink-0 flex flex-col items-end gap-1">
         <span className="text-[15px] font-semibold tabular-nums leading-tight text-gray-900 dark:text-white">
           {price != null ? price.toFixed(2) : '—'}
@@ -238,5 +258,43 @@ function WatchRow({
         )}
       </span>
     </button>
+  )
+}
+
+/**
+ * A month of closes as a single path.
+ *
+ * Coloured by the window's own change rather than the day's, because the line
+ * shows the month — tinting it by today would contradict the shape drawn.
+ */
+function Sparkline({ data }: { data: Sparkline }) {
+  const { closes, change } = data
+  const W = 64
+  const H = 32
+  const lo = Math.min(...closes)
+  const hi = Math.max(...closes)
+  const span = hi - lo || 1
+
+  const points = closes.map((c, i) => {
+    const x = (i / (closes.length - 1)) * W
+    // Inset by a pixel top and bottom so the extremes are not clipped by the
+    // stroke width.
+    const y = H - 1 - ((c - lo) / span) * (H - 2)
+    return `${x.toFixed(1)},${y.toFixed(1)}`
+  })
+
+  const up = (change ?? 0) >= 0
+
+  return (
+    <svg width={W} height={H} viewBox={`0 0 ${W} ${H}`} className="overflow-visible">
+      <polyline
+        points={points.join(' ')}
+        fill="none"
+        stroke={up ? '#10b981' : '#ef4444'}
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+    </svg>
   )
 }

--- a/src/components/mobile/MobileDecisionLedger.tsx
+++ b/src/components/mobile/MobileDecisionLedger.tsx
@@ -1,0 +1,150 @@
+import { clsx } from 'clsx'
+import { AlertTriangle, ChevronRight, Clock, Target } from 'lucide-react'
+import type { AccountabilityRow } from '../../types/decision-accountability'
+
+interface MobileDecisionLedgerProps {
+  rows: AccountabilityRow[]
+  selectedId: string | null
+  onSelect: (row: AccountabilityRow) => void
+}
+
+const EXECUTION_LABEL: Record<string, string> = {
+  executed: 'Executed',
+  pending: 'Pending',
+  possible_match: 'Likely match',
+  unmatched: 'Never executed',
+  skipped: 'Skipped',
+}
+
+const EXECUTION_TONE: Record<string, string> = {
+  executed: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
+  pending: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+  possible_match: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
+  unmatched: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',
+  skipped: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',
+}
+
+/**
+ * The decision ledger on a phone.
+ *
+ * The desktop row is a twelve-column CSS grid of fixed pixel tracks totalling
+ * over a thousand — asset, direction, stage, dates, owner, approver, execution
+ * state, decision price, current price, move, delay cost. It does not compress;
+ * at 390px the tracks simply overflow their container.
+ *
+ * A decision is read here as a sentence rather than a spreadsheet row: what was
+ * decided, whether it happened, and what the name has done since. Those three
+ * become the card, and everything else stays in the detail view — which is
+ * where the desktop puts it too, in the right-hand pane.
+ *
+ * The move is stated as a directional figure, matching the page's metric
+ * honesty note: it is (current − decision) / decision signed by the direction
+ * of the trade, a directional proxy rather than attributed P&L, so it is
+ * labelled "since decision" rather than "return".
+ */
+export function MobileDecisionLedger({ rows, selectedId, onSelect }: MobileDecisionLedgerProps) {
+  if (rows.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 py-16 px-4 text-gray-400">
+        <Target className="h-8 w-8 opacity-50" />
+        <p className="text-sm text-center">No decisions match these filters.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="divide-y divide-gray-100 dark:divide-gray-800">
+      {rows.map(row => {
+        const move = row.move_since_decision_pct
+        const positive = (move ?? 0) >= 0
+        const unmatchedAndOld =
+          row.execution_status === 'unmatched' && (row.days_since_decision ?? 0) > 30
+
+        return (
+          <button
+            key={row.decision_id}
+            type="button"
+            onClick={() => onSelect(row)}
+            className={clsx(
+              'w-full text-left px-3 py-3 active:bg-gray-50 dark:active:bg-gray-800',
+              selectedId === row.decision_id && 'bg-primary-50 dark:bg-primary-900/20',
+              unmatchedAndOld && selectedId !== row.decision_id && 'bg-red-50/40 dark:bg-red-900/10'
+            )}
+          >
+            <div className="flex items-center gap-2">
+              <span
+                className={clsx(
+                  'px-1.5 py-0.5 rounded text-[10px] font-bold uppercase tracking-wide',
+                  row.direction === 'increase'
+                    ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300'
+                    : row.direction === 'decrease'
+                      ? 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300'
+                      : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400'
+                )}
+              >
+                {row.direction === 'increase' ? 'Buy' : row.direction === 'decrease' ? 'Sell' : '—'}
+              </span>
+              <span className="text-sm font-bold text-gray-900 dark:text-white">
+                {row.asset_symbol ?? '—'}
+              </span>
+              <span className="min-w-0 flex-1 truncate text-[11px] text-gray-400">
+                {row.asset_name}
+              </span>
+
+              {move != null && (
+                <span
+                  className={clsx(
+                    'shrink-0 text-sm font-semibold tabular-nums',
+                    positive ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'
+                  )}
+                >
+                  {positive ? '+' : ''}
+                  {move.toFixed(1)}%
+                </span>
+              )}
+              <ChevronRight className="h-4 w-4 shrink-0 text-gray-300" />
+            </div>
+
+            <div className="mt-1.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px]">
+              <span
+                className={clsx(
+                  'px-1.5 py-0.5 rounded font-medium',
+                  EXECUTION_TONE[row.execution_status] ?? EXECUTION_TONE.skipped
+                )}
+              >
+                {EXECUTION_LABEL[row.execution_status] ?? row.execution_status}
+              </span>
+
+              {unmatchedAndOld && (
+                <span className="inline-flex items-center gap-1 text-red-600 dark:text-red-400">
+                  <AlertTriangle className="h-3 w-3" />
+                  {row.days_since_decision}d
+                </span>
+              )}
+
+              {row.days_since_decision != null && !unmatchedAndOld && (
+                <span className="inline-flex items-center gap-1 text-gray-400">
+                  <Clock className="h-3 w-3" />
+                  {row.days_since_decision}d ago
+                </span>
+              )}
+
+              {row.portfolio_name && (
+                <span className="min-w-0 truncate text-gray-500 dark:text-gray-400">
+                  {row.portfolio_name}
+                </span>
+              )}
+
+              {/* The move is meaningless without knowing what it is measured
+                  from, and a row with no decision-time snapshot has nothing to
+                  measure from at all. Saying so beats an empty column. */}
+              {!row.has_decision_price && (
+                <span className="ml-auto text-gray-400">no decision price</span>
+              )}
+            </div>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/components/mobile/MobileNavDrawer.tsx
+++ b/src/components/mobile/MobileNavDrawer.tsx
@@ -303,7 +303,7 @@ function NavRow({
       type="button"
       onClick={() => onSelect(surface)}
       className={clsx(
-        'w-full flex items-center gap-3 min-h-[52px] px-3 rounded-xl text-left',
+        'w-full flex items-center gap-3 min-h-[48px] px-3 rounded-xl text-left',
         'hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors',
         dimmed && 'opacity-60'
       )}
@@ -311,11 +311,13 @@ function NavRow({
       <div className={clsx('w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0', surface.bg)}>
         <Icon className={clsx('h-5 w-5', surface.color)} />
       </div>
+      {/* Name only. The per-surface note explained what a surface does before
+          you had opened it, which is a thing you need once and then never
+          again — and it doubled every row's height in a list read by scanning
+          for a name. The notes stay in mobile-surfaces.ts, where they document
+          the support level for whoever changes it. */}
       <div className="flex-1 min-w-0">
         <div className="text-sm font-medium text-gray-900 dark:text-gray-100">{surface.title}</div>
-        {surface.mobileNote && (
-          <div className="text-xs text-gray-500 dark:text-gray-400 truncate">{surface.mobileNote}</div>
-        )}
       </div>
       {dimmed ? (
         <Monitor className="h-4 w-4 text-gray-400 flex-shrink-0" />

--- a/src/hooks/useSparklines.ts
+++ b/src/hooks/useSparklines.ts
@@ -1,0 +1,67 @@
+/**
+ * useSparklines — one month of real daily closes per symbol.
+ *
+ * Deliberately not built on MiniChart / ChartDataAdapter.generateHistoricalData,
+ * which produces a seeded random walk anchored to the current quote. A drawn
+ * line beside a real price reads as real price history, and inventing one in a
+ * finance product is a correctness problem rather than a cosmetic one.
+ *
+ * Each symbol is its own query so results cache independently and a symbol
+ * already fetched for one list is free in the next. The caller is responsible
+ * for passing a bounded list — sparklines are one request per symbol, so this
+ * should be the rows actually on screen, not a whole universe.
+ */
+
+import { useQueries } from '@tanstack/react-query'
+import { supabase } from '../lib/supabase'
+
+export interface Sparkline {
+  closes: number[]
+  /** Change across the window, as a fraction. Null when there is nothing to compare. */
+  change: number | null
+}
+
+async function fetchSparkline(symbol: string): Promise<Sparkline | null> {
+  // Routed through the edge function rather than Yahoo directly: query1 blocks
+  // browser requests via CORS, which is what yahoo-chart-proxy exists for.
+  const { data, error } = await supabase.functions.invoke('yahoo-chart-proxy', {
+    body: { symbol, interval: '1d', range: '1mo' },
+  })
+  if (error) return null
+
+  const result = (data as any)?.chart?.result?.[0]
+  const closes: number[] = (result?.indicators?.quote?.[0]?.close ?? []).filter(
+    (c: unknown): c is number => typeof c === 'number' && Number.isFinite(c)
+  )
+  if (closes.length < 2) return null
+
+  const first = closes[0]
+  const last = closes[closes.length - 1]
+  return {
+    closes,
+    change: first > 0 ? (last - first) / first : null,
+  }
+}
+
+export function useSparklines(symbols: string[]) {
+  const unique = [...new Set(symbols.filter(Boolean))]
+
+  const results = useQueries({
+    queries: unique.map(symbol => ({
+      queryKey: ['sparkline', symbol],
+      queryFn: () => fetchSparkline(symbol),
+      // A month of daily closes does not change intraday in any way a
+      // 40px-wide line would show, so this is cached hard.
+      staleTime: 30 * 60_000,
+      gcTime: 60 * 60_000,
+      retry: 1,
+    })),
+  })
+
+  const map: Record<string, Sparkline> = {}
+  unique.forEach((symbol, i) => {
+    const d = results[i]?.data
+    if (d) map[symbol] = d
+  })
+  return map
+}

--- a/src/pages/DecisionAccountabilityPage.tsx
+++ b/src/pages/DecisionAccountabilityPage.tsx
@@ -29,6 +29,9 @@ import {
   Award, Users, Link2, Unlink, Sparkles,
 } from 'lucide-react'
 import { format, subDays, parseISO } from 'date-fns'
+import { clsx } from 'clsx'
+import { useIsMobile } from '../hooks/useMediaQuery'
+import { MobileDecisionLedger } from '../components/mobile/MobileDecisionLedger'
 import {
   useDecisionAccountability,
   useDecisionStory,
@@ -458,8 +461,10 @@ function SummaryStrip({ summary }: { summary: AccountabilitySummary }) {
     },
   ]
 
+  // Eight metrics across is 48px each on a phone. Two up, then four, then the
+  // full row.
   return (
-    <div className="grid grid-cols-8 gap-px bg-gray-200 rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700">
+    <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-px bg-gray-200 rounded-lg overflow-hidden border border-gray-200 dark:border-gray-700">
       {tiles.map((t, i) => {
         const Icon = t.icon
         return (
@@ -2902,7 +2907,7 @@ function ScorecardsView({ portfolioId }: { portfolioId: string | null }) {
   const [section, setSection] = useState<ScorecardSection>('analysts')
 
   return (
-    <div className="flex-1 overflow-auto p-4">
+    <div className="flex-1 overflow-auto p-3 sm:p-4">
       <div className="max-w-7xl mx-auto">
         {/* Section Toggle */}
         <div className="flex items-center gap-1 bg-gray-100 rounded-lg p-1 w-fit mb-4 dark:bg-gray-800">
@@ -3308,6 +3313,9 @@ export function DecisionAccountabilityPage({ onItemSelect }: DecisionAccountabil
     return cols
   }, [selectedPortfolioId])
 
+  // The ledger, its column headers and the 440px detail column are all
+  // desktop-shaped; the phone gets a list and a full-screen detail.
+  const isMobileViewport = useIsMobile()
   const MAIN_GRID = selectedPortfolioId ? GRID_WITHOUT_PORTFOLIO : GRID_WITH_PORTFOLIO
 
   // Unique values for dropdown filters
@@ -3433,7 +3441,7 @@ export function DecisionAccountabilityPage({ onItemSelect }: DecisionAccountabil
             {/* Left: Table rows + chart below */}
             <div className="flex-1 min-w-0 flex flex-col bg-white dark:bg-gray-800">
               {/* Column headers */}
-              <div className={`grid ${MAIN_GRID} bg-gray-50 border-b border-gray-200 shrink-0`}>
+              {!isMobileViewport && <div className={`grid ${MAIN_GRID} bg-gray-50 border-b border-gray-200 shrink-0`}>
                 {columnHeaders.map(col => (
                   <TableColHeader
                     key={col.id} col={col}
@@ -3450,7 +3458,7 @@ export function DecisionAccountabilityPage({ onItemSelect }: DecisionAccountabil
                     uniquePortfolios={uniquePortfolios} uniqueOwners={uniqueOwners}
                   />
                 ))}
-              </div>
+              </div>}
 
               {/* Rows */}
               <div className="flex-1 overflow-y-auto">
@@ -3473,6 +3481,17 @@ export function DecisionAccountabilityPage({ onItemSelect }: DecisionAccountabil
                       they will appear here with execution matching and result tracking.
                     </p>
                   </div>
+                ) : isMobileViewport ? (
+                  /* The desktop row is a twelve-track pixel grid over 1000px
+                     wide; it does not compress, it overflows. */
+                  <MobileDecisionLedger
+                    rows={displayRows.map(d => d.row)}
+                    selectedId={selectedId}
+                    onSelect={(row) => {
+                      setSelectedId(row.decision_id === selectedId ? null : row.decision_id)
+                      try { window.dispatchEvent(new CustomEvent('pilot-outcomes:result-inspected')) } catch { /* ignore */ }
+                    }}
+                  />
                 ) : (
                   displayRows.map(({ row, intel }) => (
                     <DecisionRow
@@ -3500,7 +3519,7 @@ export function DecisionAccountabilityPage({ onItemSelect }: DecisionAccountabil
                   via the page-level prefetch, so the visual delay is
                   ~16ms — imperceptible — but it guarantees the right
                   pane wins the first paint. */}
-              {selectedRow && (
+              {selectedRow && !isMobileViewport && (
                 <DeferredChartPanel
                   row={selectedRow}
                   onSelectDecision={(decisionId) => setSelectedId(decisionId)}
@@ -3510,7 +3529,12 @@ export function DecisionAccountabilityPage({ onItemSelect }: DecisionAccountabil
 
             {/* Detail Panel */}
             {selectedRow && (
-              <div className="w-[440px] shrink-0 border-l-2 border-l-primary-500 overflow-hidden">
+              <div className={clsx(
+                'overflow-hidden',
+                isMobileViewport
+                  ? 'fixed inset-0 z-[85] bg-white dark:bg-gray-800 pt-safe pb-safe'
+                  : 'w-[440px] shrink-0 border-l-2 border-l-primary-500'
+              )}>
                 <DetailPanel
                   row={selectedRow}
                   onClose={() => setSelectedId(null)}


### PR DESCRIPTION
Outcomes
The decision ledger row is a twelve-track CSS grid of fixed pixel widths totalling over a thousand. It does not compress — at 390px the tracks overflow their container. On a phone each decision becomes a card reading as a sentence: what was decided, whether it happened, and what the name has done since. Everything else stays in the detail view, which is where the desktop puts it too.

The move keeps the page's metric-honesty framing: it is signed by trade direction and labelled "since decision", not "return", and a row with no decision-time snapshot says so rather than showing an empty figure — without one there is nothing to measure from.

The detail panel is a fixed 440px column, which is wider than the screen it would sit beside, so on a phone it becomes a full-screen overlay. The summary strip goes from eight metrics across to two, then four, then eight. The bottom chart is dropped on a phone; it competed with the ledger for the only height available and the detail view carries a chart already.

Sparklines
A month of real daily closes per row, through the yahoo-chart-proxy edge function. MiniChart was the obvious thing to reuse and is deliberately not: it builds its series with ChartDataAdapter.generateHistoricalData, a seeded random walk anchored to the current quote. A drawn line beside a real price reads as real price history, which makes that a correctness problem rather than a cosmetic one.

Capped at 30 rows, tighter than the 60-row quote cap, since this is one candle request per symbol. Cached 30 minutes — a month of daily closes does not move intraday in any way a 64px line would show. Coloured by the window's own change rather than the day's, because tinting a month-long line by today would contradict the shape it draws.

App launcher
Per-surface descriptions removed. They explained what a surface does before you had opened it — something needed once and then never again — while doubling the height of every row in a list that is read by scanning for a name. The notes stay in mobile-surfaces.ts, where they document the support level for whoever changes it.

Typecheck at baseline (per-rule counts identical), 996 tests passing, production build clean.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
