### PR TITLE
fix(mobile): anchor Ideas, cap open tabs, and fix Priorities

### DIFF
--- a/src/components/attention/AttentionCard.tsx
+++ b/src/components/attention/AttentionCard.tsx
@@ -848,7 +848,7 @@ export function AttentionCard({
     <div
       onClick={handleClick}
       className={clsx(
-        'relative p-4 rounded-lg border cursor-pointer transition-all duration-200',
+        'relative p-3 sm:p-4 rounded-lg border cursor-pointer transition-all duration-200',
         'hover:shadow-md hover:border-gray-300',
         item.read_state === 'unread' ? 'bg-white border-blue-200 dark:bg-gray-800' : 'bg-white border-gray-200 dark:border-gray-700 dark:bg-gray-800',
         item.severity === 'critical' && 'border-l-4 border-l-red-500',

--- a/src/components/attention/AttentionSection.tsx
+++ b/src/components/attention/AttentionSection.tsx
@@ -134,7 +134,7 @@ export function AttentionSection({
       <button
         onClick={() => setIsExpanded(!isExpanded)}
         className={clsx(
-          'w-full flex items-center gap-3 px-4 py-3',
+          'w-full flex items-center gap-3 px-3 sm:px-4 py-3',
           config.bgColor,
           'hover:brightness-95 transition-all'
         )}
@@ -171,7 +171,7 @@ export function AttentionSection({
         <div className="bg-white dark:bg-gray-800">
           {isEmpty ? (
             // Empty state
-            <div className="px-4 py-6 text-center">
+            <div className="px-3 sm:px-4 py-6 text-center">
               <p className="text-sm text-gray-500 dark:text-gray-400">{EMPTY_MESSAGES[type]}</p>
             </div>
           ) : compact ? (
@@ -198,7 +198,7 @@ export function AttentionSection({
             </div>
           ) : (
             // Card view
-            <div className="p-4 space-y-3">
+            <div className="p-2 sm:p-4 space-y-3">
               {displayItems.map((item) => (
                 <AttentionCard
                   key={item.attention_id}
@@ -221,7 +221,7 @@ export function AttentionSection({
 
           {/* View all link */}
           {hasMore && (
-            <div className="px-4 pb-3">
+            <div className="px-3 sm:px-4 pb-3">
               <button
                 onClick={(e) => {
                   e.stopPropagation()

--- a/src/components/mobile/MobileNavDrawer.tsx
+++ b/src/components/mobile/MobileNavDrawer.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { clsx } from 'clsx'
-import { Check, ChevronRight, Monitor, Search, X } from 'lucide-react'
+import { Check, ChevronRight, Monitor, Search, X, Lightbulb } from 'lucide-react'
 import { TesseractLogo } from '../ui/TesseractLogo'
 import { useOrganization } from '../../contexts/OrganizationContext'
 import {
@@ -72,12 +72,20 @@ export function MobileNavDrawer({
     onSearchResult?.({ id: surface.type, title: surface.title, type: surface.type, data: null })
   }
 
-  // Open tabs accumulate without bound over a session, and an unbounded Recent
-  // list pushes the surface list — the thing the drawer is actually for —
-  // below the fold. Newest first, capped; anything older is still reachable
-  // through the tab bar.
+  // Ideas is anchored above Recent rather than sorted into it. It is the home
+  // surface, it cannot be closed, and a fixed position means the one row that
+  // is always present is always in the same place — which a most-recent
+  // ordering would take away exactly when the list is busiest.
+  const ideasTab = tabs.find(tab => tab.id === 'dashboard') ?? null
+
+  // Everything else, newest first and capped. DashboardPage closes tabs past
+  // this cap on a phone, so the list and the tab set stay in agreement rather
+  // than the drawer quietly hiding tabs that are still open.
   const RECENT_LIMIT = 5
-  const recentTabs = tabs.filter(tab => !tab.isBlank).slice(-RECENT_LIMIT).reverse()
+  const recentTabs = tabs
+    .filter(tab => !tab.isBlank && tab.id !== 'dashboard')
+    .slice(-RECENT_LIMIT)
+    .reverse()
 
   if (typeof document === 'undefined') return null
 
@@ -195,6 +203,26 @@ export function MobileNavDrawer({
             </div>
           )}
 
+          {ideasTab && (
+            <NavSection title="Home">
+              <button
+                type="button"
+                onClick={() => { onClose(); onTabChange(ideasTab.id) }}
+                className={clsx(
+                  'w-full flex items-center gap-3 h-12 px-3 rounded-xl text-left',
+                  ideasTab.id === activeTabId
+                    ? 'bg-primary-50 dark:bg-primary-900/20 font-semibold text-primary-700 dark:text-primary-300'
+                    : 'text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800'
+                )}
+              >
+                <Lightbulb className="h-5 w-5 text-amber-500 shrink-0" />
+                {/* The home tab renders the ideas feed on phones, so it is
+                    labelled for what it shows rather than "Dashboard". */}
+                <span className="text-sm">Ideas</span>
+              </button>
+            </NavSection>
+          )}
+
           {recentTabs.length > 0 && (
             <NavSection title="Recent">
               {recentTabs.map(tab => {
@@ -229,24 +257,17 @@ export function MobileNavDrawer({
                             : 'text-gray-700 dark:text-gray-200'
                         )}
                       >
-                        {/* The home tab renders the ideas feed on phones, so
-                            label it for what it shows rather than "Dashboard". */}
-                        {tab.id === 'dashboard' ? 'Ideas' : tab.title}
+                        {tab.title}
                       </span>
                     </button>
-                    {/* The dashboard tab cannot be closed (see
-                        DashboardPage.handleTabClose), so offering an X there
-                        is a control that does nothing. */}
-                    {tab.id !== 'dashboard' && (
-                      <button
-                        type="button"
-                        onClick={() => onTabClose(tab.id)}
-                        className="flex items-center justify-center h-11 w-11 rounded-full text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800"
-                        aria-label={`Close ${tab.title}`}
-                      >
-                        <X className="h-4 w-4" />
-                      </button>
-                    )}
+                    <button
+                      type="button"
+                      onClick={() => onTabClose(tab.id)}
+                      className="flex items-center justify-center h-11 w-11 rounded-full text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800"
+                      aria-label={`Close ${tab.title}`}
+                    >
+                      <X className="h-4 w-4" />
+                    </button>
                   </div>
                 )
               })}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -655,6 +655,30 @@ export function DashboardPage() {
     })
   }
 
+  // Phones cap the open tab set.
+  //
+  // The nav drawer only lists the five most recent, so without this the sixth
+  // tab and beyond stay open, holding their queries and their editor state,
+  // while being invisible and unreachable from the drawer. Closing them keeps
+  // what is listed and what exists in agreement.
+  //
+  // Routed through handleTabClose rather than setTabs so the empty-note cleanup
+  // and active-tab reassignment it owns still run. Dashboard is exempt — it
+  // cannot be closed — and the active tab is exempt so a tab cannot be closed
+  // out from under the person looking at it.
+  const MOBILE_TAB_LIMIT = 5
+  useEffect(() => {
+    if (!isMobile) return
+    const closable = tabs.filter(t => t.id !== 'dashboard' && !t.isBlank)
+    if (closable.length <= MOBILE_TAB_LIMIT) return
+    const excess = closable.slice(0, closable.length - MOBILE_TAB_LIMIT)
+    for (const tab of excess) {
+      if (tab.id === activeTabId) continue
+      handleTabClose(tab.id)
+    }
+  }, [isMobile, tabs, activeTabId])
+
+
   const handleCloseTabs = (tabIds: string[]) => {
     const idsToClose = new Set(tabIds.filter(id => id !== 'dashboard'))
     if (idsToClose.size === 0) return

--- a/src/pages/PrioritizerPage.tsx
+++ b/src/pages/PrioritizerPage.tsx
@@ -153,8 +153,8 @@ export function PrioritizerPage({ onItemSelect }: PrioritizerPageProps) {
       <div className="max-w-6xl mx-auto px-3 sm:px-6 py-5 space-y-5">
 
         {/* ═══ HEADER ═══ */}
-        <div className="flex items-start justify-between">
-          <div>
+        <div className="flex flex-wrap items-start justify-between gap-2">
+          <div className="min-w-0">
             <h1 className="text-lg font-bold text-gray-900 dark:text-white">My Priorities</h1>
             {headline && (
               <p className={clsx('text-sm mt-0.5 font-medium',
@@ -166,7 +166,7 @@ export function PrioritizerPage({ onItemSelect }: PrioritizerPageProps) {
               </p>
             )}
           </div>
-          <div className="flex items-center gap-2 shrink-0">
+          <div className="flex items-center gap-2 shrink-0 ml-auto">
             {generatedAt && (
               <span className="text-[10px] text-gray-400 dark:text-gray-500">
                 {formatDistanceToNow(new Date(generatedAt), { addSuffix: true })}
@@ -196,7 +196,7 @@ export function PrioritizerPage({ onItemSelect }: PrioritizerPageProps) {
         </div>
 
         {/* ═══ FILTER TABS ═══ */}
-        <div className="flex items-center gap-1 p-1 bg-gray-100 dark:bg-gray-800 rounded-lg w-fit">
+        <div className="flex items-center gap-1 p-1 bg-gray-100 dark:bg-gray-800 rounded-lg w-full sm:w-fit overflow-x-auto no-scrollbar">
           {FILTER_TABS.map(tab => {
             const Icon = tab.icon
             const isActive = filterType === tab.id
@@ -204,7 +204,7 @@ export function PrioritizerPage({ onItemSelect }: PrioritizerPageProps) {
             return (
               <button key={tab.id} onClick={() => setFilterType(tab.id)}
                 className={clsx(
-                  'flex items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-all',
+                  'flex shrink-0 items-center gap-1.5 px-3 py-1.5 rounded-md text-xs font-medium transition-all',
                   isActive ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-white shadow-sm' : 'text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white'
                 )}>
                 <Icon className={clsx('h-3.5 w-3.5', isActive && 'text-primary-500')} />


### PR DESCRIPTION
Ideas anchored
It was sorted into Recent by recency, so the one row that is always present moved around — and moved most when the list was busiest, which is when a fixed position is worth the most. It is now its own pinned section above Recent, and Recent excludes it. The two special cases that existed only because the dashboard tab sat in that list — relabelling it "Ideas", suppressing its close button — are gone with it.

Tabs past the cap close
The drawer listed the five most recent, but the sixth tab and beyond stayed open: holding their queries and editor state, invisible, and unreachable from the drawer. They now close, so what is listed and what exists agree.

Routed through handleTabClose rather than setTabs, so the empty-note cleanup and active-tab reassignment it owns still run. Dashboard is exempt because it cannot be closed, and the active tab is exempt because closing a tab out from under the person looking at it is worse than exceeding a cap.

Priorities
The filter tabs were w-fit across five pills carrying an icon, a label and a count — wider than the screen, so the row overflowed rather than fitting. They scroll now, keeping order, since the first tab is the one you want and the tail is the least used.

The header's timestamp and refresh group was shrink-0 against a headline that runs two lines, leaving the row nowhere to give; it wraps. Card and section padding drops from 16px a side to 12px and 8px, which on a 390px screen is the difference between a card and a border with some text in it.

Typecheck verified by before/after category diff: no new error categories. 996 tests passing, production build clean.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
