### PR TITLE
fix(mobile): Trade Lab opens on the simulation; Priorities scope and …

### DIFF
--- a/src/components/attention/AttentionCard.tsx
+++ b/src/components/attention/AttentionCard.tsx
@@ -417,6 +417,9 @@ export function AttentionCard({
   compact = false,
 }: AttentionCardProps) {
   const [showDeferMenu, setShowDeferMenu] = useState(false)
+  /** Which decision is armed, if any. Cleared on scroll-away and on the other
+   *  button, so an armed Approve cannot be committed by a stray Reject tap. */
+  const [pendingDecision, setPendingDecision] = useState<'approve' | 'reject' | null>(null)
   const [showOverflowMenu, setShowOverflowMenu] = useState(false)
   const [showNotRelevantPopover, setShowNotRelevantPopover] = useState(false)
   const [isActionPending, setIsActionPending] = useState<string | null>(null)
@@ -468,6 +471,10 @@ export function AttentionCard({
   const handleApprove = async (e: React.MouseEvent) => {
     e.stopPropagation()
     if (!onApprove || isActionPending) return
+    // First tap arms, second commits. The armed state is what makes it
+    // deliberate; a confirm dialog would be dismissed by reflex just as fast.
+    if (pendingDecision !== 'approve') { setPendingDecision('approve'); return }
+    setPendingDecision(null)
     setIsActionPending('approve')
     try {
       await onApprove(item.source_id)
@@ -482,6 +489,8 @@ export function AttentionCard({
   const handleReject = async (e: React.MouseEvent) => {
     e.stopPropagation()
     if (!onReject || isActionPending) return
+    if (pendingDecision !== 'reject') { setPendingDecision('reject'); return }
+    setPendingDecision(null)
     setIsActionPending('reject')
     try {
       await onReject(item.source_id)
@@ -496,6 +505,7 @@ export function AttentionCard({
   const handleDefer = async (e: React.MouseEvent, hours: number) => {
     e.stopPropagation()
     setShowDeferMenu(false)
+    setPendingDecision(null)
 
     // For trade items, use onDefer; for others, use onSnooze
     if (item.source_type === 'trade_queue_item' && onDefer) {
@@ -635,7 +645,10 @@ export function AttentionCard({
               <button
                 onClick={handleMarkDone}
                 disabled={isActionPending === 'done'}
-                className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold text-white bg-green-600 hover:bg-green-700 rounded-md shadow-sm transition-colors disabled:opacity-50"
+                className={clsx(
+                  "flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold text-white rounded-md shadow-sm transition-colors disabled:opacity-50",
+                  pendingDecision === "approve" ? "bg-green-700 ring-2 ring-green-300 dark:ring-green-800" : "bg-green-600 hover:bg-green-700"
+                )}
               >
                 {isActionPending === 'done' ? (
                   <Loader2 className="w-3.5 h-3.5 animate-spin" />
@@ -713,7 +726,7 @@ export function AttentionCard({
                 ) : (
                   <ThumbsUp className="w-3.5 h-3.5" />
                 )}
-                Approve
+                {pendingDecision === 'approve' ? 'Confirm approve' : 'Approve'}
               </button>
             ) : (
               <button
@@ -730,14 +743,17 @@ export function AttentionCard({
               <button
                 onClick={handleReject}
                 disabled={isActionPending === 'reject'}
-                className="flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-red-600 hover:text-red-700 bg-red-50 hover:bg-red-100 rounded-md transition-colors disabled:opacity-50"
+                className={clsx(
+                  "flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium rounded-md transition-colors disabled:opacity-50",
+                  pendingDecision === "reject" ? "text-white bg-red-600 ring-2 ring-red-300 dark:ring-red-800" : "text-red-600 hover:text-red-700 bg-red-50 hover:bg-red-100"
+                )}
               >
                 {isActionPending === 'reject' ? (
                   <Loader2 className="w-3.5 h-3.5 animate-spin" />
                 ) : (
                   <ThumbsDown className="w-3.5 h-3.5" />
                 )}
-                Reject
+                {pendingDecision === 'reject' ? 'Confirm reject' : 'Reject'}
               </button>
             )}
 

--- a/src/components/mobile/MobileNavDrawer.tsx
+++ b/src/components/mobile/MobileNavDrawer.tsx
@@ -5,7 +5,6 @@ import { Check, ChevronRight, Monitor, Search, X, Lightbulb } from 'lucide-react
 import { TesseractLogo } from '../ui/TesseractLogo'
 import { useOrganization } from '../../contexts/OrganizationContext'
 import {
-  getDesktopOnlyNavSurfaces,
   getMobileNavSurfaces,
   getMobileSurface,
   type MobileSurface,
@@ -286,14 +285,6 @@ export function MobileNavDrawer({
             ))}
           </NavSection>
 
-          <NavSection title="Desktop only">
-            <p className="px-4 pb-2 text-xs text-gray-400 dark:text-gray-500">
-              These need a larger screen. Opening one explains why.
-            </p>
-            {getDesktopOnlyNavSurfaces().map(surface => (
-              <NavRow key={surface.type} surface={surface} onSelect={openSurface} dimmed />
-            ))}
-          </NavSection>
         </div>
       </div>
     </div>,

--- a/src/pages/PrioritizerPage.tsx
+++ b/src/pages/PrioritizerPage.tsx
@@ -36,15 +36,31 @@ const SECTION_ORDER: AttentionType[] = [
   'alignment',
 ]
 
+/**
+ * Mine versus the desk's, as the first cut.
+ *
+ * Team was one of five type filters, which put "what is the desk converging
+ * on" beside "what have I been asked to decide" as if they were the same kind
+ * of question. They are not: one is a queue you are answerable for clearing,
+ * the other is context you read. Splitting them first means the count in the
+ * header is a count of your own work, and the team view stops diluting it.
+ */
+type Scope = 'mine' | 'team'
+
+/** Addressed to you, and yours to clear. */
+const MINE_TYPES: AttentionType[] = ['decision_required', 'action_required', 'informational']
+/** What the desk is converging on. Read, not owed. */
+const TEAM_TYPES: AttentionType[] = ['alignment']
+
 const FILTER_TABS: { id: AttentionType | 'all'; label: string; icon: React.ElementType }[] = [
   { id: 'all', label: 'All', icon: Filter },
   { id: 'decision_required', label: 'Decisions', icon: Scale },
   { id: 'action_required', label: 'Action Needed', icon: CheckCircle },
   { id: 'informational', label: "What's New", icon: Newspaper },
-  { id: 'alignment', label: 'Team', icon: Users },
 ]
 
 export function PrioritizerPage({ onItemSelect }: PrioritizerPageProps) {
+  const [scope, setScope] = useState<Scope>('mine')
   const [filterType, setFilterType] = useState<AttentionType | 'all'>('all')
 
   const {
@@ -59,7 +75,6 @@ export function PrioritizerPage({ onItemSelect }: PrioritizerPageProps) {
     acknowledge,
     snoozeFor,
     dismiss,
-    hasItems,
     markDeliverableDone,
     approveTradeIdea,
     rejectTradeIdea,
@@ -111,7 +126,17 @@ export function PrioritizerPage({ onItemSelect }: PrioritizerPageProps) {
     window.dispatchEvent(new CustomEvent('openThoughtsCapture', { detail: { contextType, contextId, contextTitle } }))
   }
 
-  const visibleSections = filterType === 'all' ? SECTION_ORDER : SECTION_ORDER.filter(t => t === filterType)
+  const scopeTypes = scope === 'mine' ? MINE_TYPES : TEAM_TYPES
+  const visibleSections = SECTION_ORDER
+    .filter(t => scopeTypes.includes(t))
+    .filter(t => scope === 'team' || filterType === 'all' || t === filterType)
+
+  // The counts that matter are the ones for the scope you are looking at; a
+  // header claiming twelve items while the list shows three is worse than no
+  // header at all.
+  const scopeCount = scopeTypes.reduce((n, t) => n + (counts[t] ?? 0), 0)
+  const mineCount = MINE_TYPES.reduce((n, t) => n + (counts[t] ?? 0), 0)
+  const teamCount = TEAM_TYPES.reduce((n, t) => n + (counts[t] ?? 0), 0)
 
   // Compute headline from counts
   const headline = generateHeadline(counts)
@@ -153,30 +178,35 @@ export function PrioritizerPage({ onItemSelect }: PrioritizerPageProps) {
       <div className="max-w-6xl mx-auto px-3 sm:px-6 py-5 space-y-5">
 
         {/* ═══ HEADER ═══ */}
-        <div className="flex flex-wrap items-start justify-between gap-2">
-          <div className="min-w-0">
-            <h1 className="text-lg font-bold text-gray-900 dark:text-white">My Priorities</h1>
-            {headline && (
-              <p className={clsx('text-sm mt-0.5 font-medium',
-                counts.decision_required > 0 || counts.action_required > 3
-                  ? 'text-amber-700 dark:text-amber-400'
-                  : 'text-gray-500 dark:text-gray-400'
-              )}>
-                {headline}
-              </p>
-            )}
-          </div>
-          <div className="flex items-center gap-2 shrink-0 ml-auto">
+        {/* Refresh sits on the title line, not below it. Wrapping the whole
+            group moved it under a headline that runs two lines on a phone,
+            which reads as a control belonging to the headline rather than to
+            the page. */}
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <h1 className="min-w-0 flex-1 text-lg font-bold text-gray-900 dark:text-white truncate">
+              My Priorities
+            </h1>
             {generatedAt && (
-              <span className="text-[10px] text-gray-400 dark:text-gray-500">
+              <span className="hidden sm:inline text-[10px] text-gray-400 dark:text-gray-500">
                 {formatDistanceToNow(new Date(generatedAt), { addSuffix: true })}
               </span>
             )}
             <button onClick={() => refetch()} disabled={isFetching}
-              className={clsx('p-1.5 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors', isFetching && 'opacity-50')}>
+              aria-label="Refresh priorities"
+              className={clsx('shrink-0 p-1.5 rounded-lg hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors', isFetching && 'opacity-50')}>
               <RefreshCw className={clsx('w-4 h-4 text-gray-500 dark:text-gray-400', isFetching && 'animate-spin')} />
             </button>
           </div>
+          {headline && (
+            <p className={clsx('text-sm mt-0.5 font-medium',
+              counts.decision_required > 0 || counts.action_required > 3
+                ? 'text-amber-700 dark:text-amber-400'
+                : 'text-gray-500 dark:text-gray-400'
+            )}>
+              {headline}
+            </p>
+          )}
         </div>
 
         {/* ═══ SUMMARY STRIP ═══ */}
@@ -195,7 +225,34 @@ export function PrioritizerPage({ onItemSelect }: PrioritizerPageProps) {
           )}
         </div>
 
-        {/* ═══ FILTER TABS ═══ */}
+        {/* ═══ SCOPE ═══ */}
+        <div className="flex items-center gap-1 p-1 bg-gray-100 dark:bg-gray-800 rounded-lg">
+          {([
+            { id: 'mine' as Scope, label: 'Mine', icon: CheckCircle, count: mineCount },
+            { id: 'team' as Scope, label: 'Team', icon: Users, count: teamCount },
+          ]).map(s2 => {
+            const Icon = s2.icon
+            const isActive = scope === s2.id
+            return (
+              <button key={s2.id} onClick={() => setScope(s2.id)}
+                className={clsx(
+                  'flex-1 flex items-center justify-center gap-1.5 px-3 py-2 rounded-md text-sm font-semibold transition-all no-touch-target',
+                  isActive ? 'bg-white dark:bg-gray-700 text-gray-900 dark:text-white shadow-sm' : 'text-gray-500 dark:text-gray-400'
+                )}>
+                <Icon className={clsx('h-4 w-4', isActive && 'text-primary-500')} />
+                {s2.label}
+                {s2.count > 0 && (
+                  <span className={clsx('px-1.5 py-0.5 rounded-full text-[10px] font-bold',
+                    isActive ? 'bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-400' : 'bg-gray-200 dark:bg-gray-600 text-gray-600 dark:text-gray-300'
+                  )}>{s2.count}</span>
+                )}
+              </button>
+            )
+          })}
+        </div>
+
+        {/* ═══ FILTER TABS — narrowing within Mine; Team is one kind of item ═══ */}
+        {scope === 'mine' && (
         <div className="flex items-center gap-1 p-1 bg-gray-100 dark:bg-gray-800 rounded-lg w-full sm:w-fit overflow-x-auto no-scrollbar">
           {FILTER_TABS.map(tab => {
             const Icon = tab.icon
@@ -218,16 +275,21 @@ export function PrioritizerPage({ onItemSelect }: PrioritizerPageProps) {
             )
           })}
         </div>
+        )}
 
         {/* ═══ SECTIONS ═══ */}
-        {!hasItems ? (
+        {scopeCount === 0 ? (
           <div className="rounded-xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-12 text-center">
             <div className="w-14 h-14 rounded-full bg-green-100 dark:bg-green-900/30 flex items-center justify-center mx-auto mb-4">
               <CheckCircle className="w-7 h-7 text-green-500" />
             </div>
-            <h3 className="text-base font-semibold text-gray-900 dark:text-white">All clear</h3>
+            <h3 className="text-base font-semibold text-gray-900 dark:text-white">
+              {scope === 'mine' ? 'All clear' : 'Nothing from the team'}
+            </h3>
             <p className="text-sm text-gray-500 dark:text-gray-400 mt-1 max-w-sm mx-auto">
-              Nothing needs your attention right now. Decisions are resolved, work is progressing, and nothing is stale.
+              {scope === 'mine'
+                ? 'Nothing needs your attention right now. Decisions are resolved, work is progressing, and nothing is stale.'
+                : 'No names the desk is converging on, and nothing waiting on someone else.'}
             </p>
           </div>
         ) : (

--- a/src/pages/SimulationPage.tsx
+++ b/src/pages/SimulationPage.tsx
@@ -442,7 +442,13 @@ export function SimulationPage({ simulationId: propSimulationId, tabId, onClose,
     count: number
     symbols: string[]
   } | null>(null)
-  const [showIdeasPanel, setShowIdeasPanel] = useState(initialState.current.showIdeasPanel)
+  // Desktop opens with the ideas column beside the simulation. On a phone that
+  // column is a full-screen overlay, so the same default opens Trade Lab onto
+  // the ideas list with the simulation hidden behind it — the wrong thing
+  // first. Phones start on the simulation and reach ideas deliberately.
+  const [showIdeasPanel, setShowIdeasPanel] = useState(
+    isMobileViewport ? false : initialState.current.showIdeasPanel
+  )
   const [editingTradeId, setEditingTradeId] = useState<string | null>(null)
   const [editingSizingMode, setEditingSizingMode] = useState<SimpleSizingMode>('weight')
   const [editingValue, setEditingValue] = useState<string>('')


### PR DESCRIPTION
…guarded decisions

Trade Lab opened on the wrong thing
showIdeasPanel defaults true, which on desktop puts the ideas column beside the simulation. On a phone that column is a full-screen overlay, so the same default opened Trade Lab onto the ideas list with the simulation hidden behind it. Phones now start on the simulation and reach ideas deliberately.

Desktop-only section removed
Nothing is registered desktop-only any more, so the drawer rendered an empty section under a caption explaining a rule that no longer applies.

Priorities: mine versus the desk's
Team was one of five type filters, which put "what is the desk converging on" beside "what have I been asked to decide" as though they were the same kind of question. They are not — one is a queue you are answerable for clearing, the other is context you read. Scope is now the first cut, so the header count is a count of your own work and the team view stops diluting it. Type filters narrow within Mine; Team is a single kind of item and does not need them.

Refresh moved onto the title line rather than under a headline that runs two lines on a phone, where it read as belonging to the headline.

Approve and reject are now two-step
They committed a decision on someone else's work from a scrolling list, one tap from a card the reader may not have opened — the cheapest possible action for one of the least reversible. The first tap arms, the second commits, and the button says which it is. An armed state rather than a dialog, because a confirm dialog gets dismissed by reflex just as fast as a button gets tapped. Arming one decision disarms the other, and deferring clears both.

Typecheck verified by before/after category diff: no new error categories. 996 tests passing, production build clean.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
