### PR TITLE
fix: outcomes shows almost nothing by default; scorecard and portfoli…

### DIFF
--- a/src/components/outcomes/AnalystScorecardCard.tsx
+++ b/src/components/outcomes/AnalystScorecardCard.tsx
@@ -86,7 +86,7 @@ export function AnalystScorecardCard({
               <div className="h-4 bg-gray-200 rounded w-1/2" />
             </div>
           </div>
-          <div className="grid grid-cols-3 gap-3">
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 sm:gap-3">
             {[1, 2, 3].map(i => <div key={i} className="h-14 bg-gray-200 rounded" />)}
           </div>
         </div>
@@ -195,7 +195,7 @@ export function AnalystScorecardCard({
             <span className="text-[10px] text-gray-400 ml-auto">{scorecard.priceTargets.total} total</span>
           </div>
 
-          <div className="grid grid-cols-4 gap-2 mb-3">
+          <div className="grid grid-cols-2 gap-2 mb-3 sm:grid-cols-4">
             <StatPill icon={CheckCircle} label="Hit" value={scorecard.priceTargets.hit} iconColor="text-green-500" />
             <StatPill icon={XCircle} label="Missed" value={scorecard.priceTargets.missed} iconColor="text-red-500" />
             <StatPill icon={Clock} label="Pending" value={scorecard.priceTargets.pending} iconColor="text-amber-500" />

--- a/src/components/outcomes/PMScorecardCard.tsx
+++ b/src/components/outcomes/PMScorecardCard.tsx
@@ -151,7 +151,7 @@ export function PMScorecardCard({
         {/* ── Execution ── */}
         <div>
           <div className="text-[10px] font-bold text-gray-400 uppercase tracking-wider mb-2">Execution</div>
-          <div className="grid grid-cols-3 gap-2">
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
             <div className="p-3 bg-gray-50 rounded-lg text-center dark:bg-gray-900">
               <div className="text-lg font-bold text-gray-900 dark:text-white">{scorecard.totalDecisions}</div>
               <div className="text-[10px] text-gray-500 dark:text-gray-400">Decisions</div>

--- a/src/components/outcomes/ScorecardViews.tsx
+++ b/src/components/outcomes/ScorecardViews.tsx
@@ -46,7 +46,7 @@ function ExecutiveHeader({ verdict: v, mode }: { verdict: ScorecardVerdict; mode
 
   return (
     <div className={clsx('rounded-lg border', cfg.borderColor, cfg.bgColor, isCritical && 'border-l-4')}>
-      <div className="flex items-start gap-4 p-4 pb-2.5">
+      <div className="flex flex-wrap items-start gap-3 sm:gap-4 p-3 sm:p-4 pb-2.5">
         {/* Score */}
         <div className="shrink-0">
           <div className="relative w-[60px] h-[60px]">
@@ -78,7 +78,7 @@ function ExecutiveHeader({ verdict: v, mode }: { verdict: ScorecardVerdict; mode
 
         {/* Focus */}
         {v.focus.length > 0 && (
-          <div className="shrink-0 max-w-[260px] pl-4 border-l border-black/5">
+          <div className="w-full sm:w-auto sm:shrink-0 sm:max-w-[260px] sm:pl-4 sm:border-l border-black/5 pt-2 sm:pt-0 border-t sm:border-t-0">
             <div className="text-[9px] font-bold text-gray-400 uppercase tracking-wider mb-1">Focus</div>
             {v.focus.map((f, i) => (
               <p key={i} className="text-[10px] text-gray-600 leading-relaxed flex items-start gap-1.5 dark:text-gray-400">

--- a/src/hooks/useDecisionAccountability.ts
+++ b/src/hooks/useDecisionAccountability.ts
@@ -261,7 +261,12 @@ export function useDecisionAccountability(options: UseDecisionAccountabilityOpti
         showCancelled: !!filters?.showCancelled,
       }
       if (filters?.dateRange?.start) filterPayload.dateStart = filters.dateRange.start
-      else if (!filters?.dateRange) filterPayload.dateStart = subDays(new Date(), 90).toISOString()
+      // A year, not 90 days. This page exists to show a decision against what
+      // happened afterwards, which is a question with a long tail — and a desk
+      // that decides a few times a month has almost nothing inside a quarter.
+      // On production data 3 of 21 decisions fell inside the old window, so the
+      // default answer to "show me our decisions" was a near-empty page.
+      else if (!filters?.dateRange) filterPayload.dateStart = subDays(new Date(), 365).toISOString()
       if (filters?.dateRange?.end) filterPayload.dateEnd = filters.dateRange.end
       if (filters?.portfolioIds && filters.portfolioIds.length > 0) {
         filterPayload.portfolioIds = filters.portfolioIds
@@ -399,7 +404,7 @@ export function useDecisionAccountability(options: UseDecisionAccountabilityOpti
       if (dateStart) {
         q = q.gte('created_at', dateStart)
       } else if (!filters?.dateRange) {
-        q = q.gte('created_at', subDays(new Date(), 90).toISOString())
+        q = q.gte('created_at', subDays(new Date(), 365).toISOString())
       }
       if (filters?.dateRange?.end) {
         q = q.lte('created_at', filters.dateRange.end)

--- a/src/pages/PortfoliosListPage.tsx
+++ b/src/pages/PortfoliosListPage.tsx
@@ -357,21 +357,21 @@ export function PortfoliosListPage({ onPortfolioSelect }: PortfoliosListPageProp
 
       {/* Search and Filters */}
       <Card>
-        <div className="space-y-4">
+        <div className="space-y-2 sm:space-y-4">
           {/* Search Bar */}
           <div className="relative">
             <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400" />
             <input
               type="text"
-              placeholder="Search by portfolio name, description, or benchmark..."
+              placeholder="Search portfolios"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 dark:border-gray-600"
+              className="w-full pl-10 pr-4 h-10 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-primary-500 dark:border-gray-600"
             />
           </div>
 
-          {/* Status Filter Pills */}
-          <div className="flex items-center gap-2">
+          {/* Status Filter Pills + filter toggle, one row */}
+          <div className="flex items-center gap-2 overflow-x-auto no-scrollbar">
             {(['active', 'archived', ...(isOrgAdmin ? ['discarded'] as const : []), 'all'] as ArchiveFilter[]).map((filter) => {
               const count = archiveCounts[filter]
               const isSelected = archiveFilter === filter
@@ -402,7 +402,7 @@ export function PortfoliosListPage({ onPortfolioSelect }: PortfoliosListPageProp
           </div>
 
           {/* Filter Toggle */}
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between gap-2 flex-wrap">
             <button
               onClick={() => setShowFilters(!showFilters)}
               className="flex items-center space-x-2 text-sm text-gray-600 hover:text-gray-900 transition-colors dark:hover:text-white dark:text-gray-400"
@@ -621,12 +621,18 @@ export function PortfoliosListPage({ onPortfolioSelect }: PortfoliosListPageProp
                               'inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded',
                               isInactive ? 'bg-gray-100 text-gray-400 dark:bg-gray-800' : 'bg-gray-100 text-gray-600 dark:text-gray-400 dark:bg-gray-800',
                             )}>
-                              {counts.analysts} A
+                              {counts.analysts} An{counts.analysts > 1 ? 's' : ''}
                             </span>
                           )}
+                          {/* "+3" said nothing about what those three were.
+                              They are members holding neither the PM nor the
+                              Analyst role, so the badge now says so. */}
                           {counts.total - counts.pms - counts.analysts > 0 && (
-                            <span className="text-gray-400">
-                              +{counts.total - counts.pms - counts.analysts}
+                            <span
+                              className="text-gray-400"
+                              title={`${counts.total - counts.pms - counts.analysts} other member(s)`}
+                            >
+                              +{counts.total - counts.pms - counts.analysts} other
                             </span>
                           )}
                         </div>


### PR DESCRIPTION
…o layout

Outcomes was empty because of its own default
Not a mobile bug. The page defaults to the last 90 days, and on production data 3 of 21 decisions fall inside that window — the most recent decision is eight weeks old. So the default answer to "show me our decisions" was a near-empty page on a surface whose entire purpose is a decision against what happened afterwards, which is a question with a long tail. A desk deciding a few times a month has almost nothing inside a quarter. Default is now a year; the date filter still narrows it.

Scorecards overlapped
The header is a 60px score ring, a name, and a Focus column pinned shrink-0 at max-w-[260px]. At 390px those two fixed widths plus padding exceed the screen, so the name had nowhere to go and the columns ran into each other. The row wraps and Focus drops below with a rule above it instead of beside it. Stat grids go from four and three across to two on a phone — four pills across 390px is 85px each, narrower than the label plus its figure.

Portfolios
"3 A" read as an initial rather than a count; it is "3 Ans" now. "+3" said nothing about what those three were — they are members holding neither the PM nor the Analyst role, so the badge says "+3 other" and carries a title.

The search, the status pills and the filter toggle each took a full row inside a space-y-4 card: roughly 180px of chrome before the first portfolio. Tighter spacing on a phone, a placeholder that fits the box it is in, and the status pills scroll in place rather than wrapping to their own row.

Typecheck verified by before/after category diff: no new error categories. 996 tests passing, production build clean.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
