### PR TITLE
fix(mobile): outcomes header collision, condensed Priorities, Portfol…

### DIFF
--- a/src/pages/DecisionAccountabilityPage.tsx
+++ b/src/pages/DecisionAccountabilityPage.tsx
@@ -323,15 +323,15 @@ function FilterBar({
   }
 
   return (
-    <div className="flex items-center gap-2.5">
+    <div className="flex flex-wrap items-center gap-2 sm:gap-2.5 min-w-0">
       {/* Date range */}
-      <div className="relative">
-        <div className="inline-flex items-center gap-0.5 p-0.5 bg-gray-100 rounded-lg dark:bg-gray-800">
+      <div className="relative min-w-0 max-w-full">
+        <div className="flex sm:inline-flex items-center gap-0.5 p-0.5 bg-gray-100 rounded-lg dark:bg-gray-800 max-w-full overflow-x-auto no-scrollbar">
           {(['7d', '30d', '90d', 'QTD', 'YTD', '1Y', 'ALL'] as DatePreset[]).map(p => (
             <button
               key={p}
               onClick={() => handlePreset(p)}
-              className={`px-2 py-1 text-[11px] font-medium rounded-md transition-colors ${
+              className={`shrink-0 px-2 py-1 text-[11px] font-medium rounded-md transition-colors ${
                 activePreset === p ? 'bg-white text-gray-900 shadow-sm dark:text-white dark:bg-gray-800' : 'text-gray-500 hover:text-gray-700 dark:hover:text-gray-200 dark:text-gray-400'
               }`}
             >
@@ -340,7 +340,7 @@ function FilterBar({
           ))}
           <button
             onClick={() => handlePreset('custom')}
-            className={`px-2 py-1 text-[11px] font-medium rounded-md transition-colors ${
+            className={`shrink-0 px-2 py-1 text-[11px] font-medium rounded-md transition-colors ${
               showCustom || activePreset === 'custom' ? 'bg-white text-gray-900 shadow-sm dark:text-white dark:bg-gray-800' : 'text-gray-500 hover:text-gray-700 dark:hover:text-gray-200 dark:text-gray-400'
             }`}
           >
@@ -3386,7 +3386,7 @@ export function DecisionAccountabilityPage({ onItemSelect }: DecisionAccountabil
           const hasNarrative = processHealth.narrative && processHealth.narrative !== processHealth.headline
           return (
             <div className="pb-2">
-              <div className={`flex items-center gap-3 rounded ${isSevere ? `border ${hd.borderColor} ${hd.bgColor} px-3 py-1.5` : 'py-0.5'}`}>
+              <div className={`flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-3 rounded ${isSevere ? `border ${hd.borderColor} ${hd.bgColor} px-3 py-2` : 'py-0.5'}`}>
                 <div className="flex-1 min-w-0">
                   {/* Single-line headline — label + breakdown + headline
                       all inline so the banner reads as one strip,
@@ -3396,17 +3396,17 @@ export function DecisionAccountabilityPage({ onItemSelect }: DecisionAccountabil
                     {processHealth.primaryBreakdown && (
                       <span className={`text-[10px] font-semibold ${isSevere ? 'text-gray-700 dark:text-gray-300' : 'text-gray-500 dark:text-gray-400'} flex-shrink-0`}>· {processHealth.primaryBreakdown}</span>
                     )}
-                    <span className={`text-[11px] leading-snug ${isSevere ? 'text-gray-800 dark:text-gray-100' : 'text-gray-500 dark:text-gray-400'} truncate`}>
+                    <span className={`text-[11px] leading-snug min-w-0 ${isSevere ? 'text-gray-800 dark:text-gray-100' : 'text-gray-500 dark:text-gray-400'} line-clamp-2 sm:truncate`}>
                       {processHealth.headline}
                     </span>
                   </div>
                   {hasNarrative && (
-                    <p className={`text-[10px] leading-snug mt-0.5 ${isSevere ? 'text-gray-500 dark:text-gray-400' : 'text-gray-400'}`}>
+                    <p className={`hidden sm:block text-[10px] leading-snug mt-0.5 ${isSevere ? 'text-gray-500 dark:text-gray-400' : 'text-gray-400'}`}>
                       {processHealth.narrative}
                     </p>
                   )}
                 </div>
-                <div className="shrink-0">
+                <div className="w-full sm:w-auto sm:shrink-0 min-w-0">
                   <FilterBar filters={filters} onChange={setFilters} />
                 </div>
               </div>

--- a/src/pages/PortfoliosListPage.tsx
+++ b/src/pages/PortfoliosListPage.tsx
@@ -16,6 +16,7 @@ import { useToast } from '../components/common/Toast'
 import { logOrgActivity } from '../lib/org-activity-log'
 import { formatDistanceToNow } from 'date-fns'
 import { clsx } from 'clsx'
+import { useIsMobile } from '../hooks/useMediaQuery'
 
 type ArchiveFilter = 'active' | 'archived' | 'discarded' | 'all'
 
@@ -24,6 +25,9 @@ interface PortfoliosListPageProps {
 }
 
 export function PortfoliosListPage({ onPortfolioSelect }: PortfoliosListPageProps) {
+  // Creating a portfolio needs team, benchmark and mandate; it is a setup act,
+  // not something to start on a phone and abandon half-configured.
+  const isMobileViewport = useIsMobile()
   const { user } = useAuth()
   const { currentOrgId } = useOrganization()
   const queryClient = useQueryClient()
@@ -327,7 +331,7 @@ export function PortfoliosListPage({ onPortfolioSelect }: PortfoliosListPageProp
           </p>
         </div>
         <div className="flex items-center gap-2">
-          {canCreate ? (
+          {canCreate && !isMobileViewport ? (
             <button
               onClick={() => setShowNewModal(true)}
               className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 rounded-lg transition-colors shadow-sm"
@@ -335,7 +339,7 @@ export function PortfoliosListPage({ onPortfolioSelect }: PortfoliosListPageProp
               <Plus className="w-4 h-4" />
               New Portfolio
             </button>
-          ) : (
+          ) : isMobileViewport ? null : (
             <div className="relative group">
               <button
                 disabled
@@ -380,9 +384,9 @@ export function PortfoliosListPage({ onPortfolioSelect }: PortfoliosListPageProp
                   key={filter}
                   onClick={() => setArchiveFilter(filter)}
                   className={clsx(
-                    'inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-full transition-colors',
+                    'inline-flex shrink-0 items-center gap-1.5 px-2.5 h-8 text-xs font-medium rounded-lg transition-colors',
                     isSelected
-                      ? 'bg-indigo-100 text-indigo-700 ring-1 ring-indigo-300'
+                      ? 'bg-indigo-600 text-white'
                       : 'bg-gray-100 text-gray-600 hover:bg-gray-200 dark:text-gray-400 dark:bg-gray-800',
                   )}
                 >
@@ -390,9 +394,12 @@ export function PortfoliosListPage({ onPortfolioSelect }: PortfoliosListPageProp
                   {filter === 'archived' && 'Archived'}
                   {filter === 'discarded' && 'Discarded'}
                   {filter === 'all' && 'All'}
+                  {/* The count is part of the label, not a badge inside a
+                      badge — a pill inside a pill reads as two overlapping
+                      shapes at this size. */}
                   <span className={clsx(
-                    'text-[10px] px-1.5 py-0.5 rounded-full',
-                    isSelected ? 'bg-indigo-200/70 text-indigo-800' : 'bg-gray-200 text-gray-500 dark:text-gray-400',
+                    'text-[10px] tabular-nums',
+                    isSelected ? 'text-white/80' : 'text-gray-400',
                   )}>
                     {count}
                   </span>
@@ -519,9 +526,9 @@ export function PortfoliosListPage({ onPortfolioSelect }: PortfoliosListPageProp
                         : 'hover:bg-gray-50',
                   )}
                 >
-                  <div className="grid grid-cols-1 gap-2 sm:grid-cols-12 sm:gap-4 sm:items-center">
+                  <div className="grid grid-cols-2 gap-x-3 gap-y-2 sm:grid-cols-12 sm:gap-4 sm:items-center">
                     {/* Portfolio Info */}
-                    <div className="col-span-4">
+                    <div className="col-span-2 sm:col-span-4 min-w-0">
                       <div className="flex items-center space-x-3">
                         <div className={clsx(
                           'w-10 h-10 rounded-lg flex items-center justify-center shrink-0',

--- a/src/pages/PrioritizerPage.tsx
+++ b/src/pages/PrioritizerPage.tsx
@@ -175,7 +175,7 @@ export function PrioritizerPage({ onItemSelect }: PrioritizerPageProps) {
 
   return (
     <div className="h-full overflow-auto bg-gray-50 dark:bg-gray-900">
-      <div className="max-w-6xl mx-auto px-3 sm:px-6 py-5 space-y-5">
+      <div className="max-w-6xl mx-auto px-3 sm:px-6 py-3 sm:py-5 space-y-2.5 sm:space-y-5">
 
         {/* ═══ HEADER ═══ */}
         {/* Refresh sits on the title line, not below it. Wrapping the whole
@@ -209,8 +209,9 @@ export function PrioritizerPage({ onItemSelect }: PrioritizerPageProps) {
           )}
         </div>
 
-        {/* ═══ SUMMARY STRIP ═══ */}
-        <div className="flex items-center gap-3 flex-wrap">
+        {/* ═══ SUMMARY STRIP — the counts are also on the chips below,
+            so this is desktop-only rather than a third place to read them ═══ */}
+        <div className="hidden sm:flex items-center gap-3 flex-wrap">
           {counts.decision_required > 0 && (
             <SummaryBadge icon={Scale} count={counts.decision_required} label="decisions" severity="critical" />
           )}
@@ -225,7 +226,8 @@ export function PrioritizerPage({ onItemSelect }: PrioritizerPageProps) {
           )}
         </div>
 
-        {/* ═══ SCOPE ═══ */}
+        {/* ═══ SCOPE + FILTERS — pinned ═══ */}
+        <div className="sticky top-0 z-20 -mx-3 sm:-mx-6 px-3 sm:px-6 py-2 bg-gray-50/95 dark:bg-gray-900/95 backdrop-blur border-b border-gray-200/70 dark:border-gray-700/70 space-y-2">
         <div className="flex items-center gap-1 p-1 bg-gray-100 dark:bg-gray-800 rounded-lg">
           {([
             { id: 'mine' as Scope, label: 'Mine', icon: CheckCircle, count: mineCount },
@@ -276,6 +278,7 @@ export function PrioritizerPage({ onItemSelect }: PrioritizerPageProps) {
           })}
         </div>
         )}
+        </div>
 
         {/* ═══ SECTIONS ═══ */}
         {scopeCount === 0 ? (


### PR DESCRIPTION
…ios layout

Outcomes: the horizon selector and the health banner were one bug Eight date presets plus Custom sat in an inline-flex that could neither wrap nor scroll, in the same row as a process-health headline that also could not shrink. Two things demanding more width than exists, side by side — which is why the selector looked broken and the banner text ran into it. The presets scroll in place, the banner stacks above them on a phone, and the headline uses two lines rather than truncating to nothing.

The narrative under the headline restates it in 10px grey. On a phone that is a third row of small text above the thing you came to read, so it is desktop-only now.

Priorities: condensed and pinned
space-y-5 between title, summary badges, scope and filters is four 20px gaps before the first item; down to 10px on a phone. The summary badges are desktop-only — the same counts are already on the scope and filter chips, so on a phone they were a third place to read the same numbers.

Scope and filters are sticky. A filter you have to scroll back up to reach is a filter you stop using, which defeats the point of having them.

Portfolios
No New Portfolio button on a phone. Creating one needs team, benchmark and mandate; it is a setup act, not something to start on a phone and abandon half-configured.

The status pills were a rounded-full count badge inside a rounded-full pill carrying its own ring — at that size two radii read as overlapping shapes. Now one rounded-lg pill with the count as part of the label.

The card stacked five unlabelled full-width blocks per portfolio: as tall as a card and as bare as a table row. Identity spans the width, and benchmark, teams, members and updated sit two-up beneath it.

Typecheck verified by before/after category diff: no new error categories. 996 tests passing, production build clean.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
