### PR TITLE
fix: Projects crash (regression), trade book polish, iPhone-style cal…

### DIFF
--- a/src/components/trading/AcceptedTradesTable.tsx
+++ b/src/components/trading/AcceptedTradesTable.tsx
@@ -87,13 +87,29 @@ function signedNotional(
 }
 
 /**
- * Format a signed notional into "$120,000" or "-$120,000". Returns "—"
- * when the value is nullish, which is how empty cells render across
- * the Trade Book.
+ * Format a signed notional for the column.
+ *
+ * Fully written out, an eight-figure trade is "$34,173,518" — thirteen
+ * characters that no sane column width accommodates, so the cell either
+ * wrapped or pushed the table wider. Millions and above are abbreviated to
+ * three significant figures; below that the exact number is short enough to
+ * print. The unabbreviated value is always available via `fmtSignedNotionalFull`
+ * on the cell's `title`, so precision is never actually lost.
  */
 function fmtSignedNotional(val: number | null): string {
   if (val == null) return '—'
-  const abs = Math.abs(val).toLocaleString()
+  const sign = val < 0 ? '-' : ''
+  const abs = Math.abs(val)
+  if (abs >= 1_000_000_000) return `${sign}$${(abs / 1_000_000_000).toFixed(2)}B`
+  if (abs >= 1_000_000) return `${sign}$${(abs / 1_000_000).toFixed(1)}M`
+  if (abs >= 100_000) return `${sign}$${Math.round(abs / 1_000)}K`
+  return `${sign}$${abs.toLocaleString()}`
+}
+
+/** The exact figure, for the cell tooltip. */
+function fmtSignedNotionalFull(val: number | null): string {
+  if (val == null) return ''
+  const abs = Math.abs(val).toLocaleString(undefined, { maximumFractionDigits: 0 })
   return val < 0 ? `-$${abs}` : `$${abs}`
 }
 
@@ -549,11 +565,14 @@ export function AcceptedTradesTable({
     requestId: `trade-book-${Date.now()}`,
   }), [user])
 
-  const SortHeader = ({ label, k, align }: { label: string; k: SortKey; align?: string }) => (
+  const SortHeader = ({ label, k, align, sticky }: { label: string; k: SortKey; align?: string; sticky?: boolean }) => (
     <th
       className={clsx(
         'py-2 px-3 text-[10px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-400 cursor-pointer hover:text-gray-700 dark:hover:text-gray-300 select-none',
-        align === 'right' ? 'text-right' : 'text-left'
+        align === 'right' ? 'text-right' : 'text-left',
+        // Frozen symbol column. It carries its own background because a
+        // transparent sticky cell lets the scrolling columns show through it.
+        sticky && 'sticky left-8 z-20 bg-white dark:bg-gray-900 border-r border-gray-200 dark:border-gray-700',
       )}
       onClick={() => toggleSort(k)}
     >
@@ -657,9 +676,11 @@ export function AcceptedTradesTable({
       <table className="w-full min-w-[720px] sm:min-w-0">
         <thead className="border-b border-gray-200 dark:border-gray-700">
           <tr>
-            {/* expand column */}
-            <th className="w-8" />
-            <SortHeader label="Symbol" k="symbol" />
+            {/* expand column — frozen with the symbol so the two travel
+                together; the ticker is what identifies the row you are
+                reading numbers off, so it must not scroll away. */}
+            <th className="w-8 sticky left-0 z-20 bg-white dark:bg-gray-900" />
+            <SortHeader label="Symbol" k="symbol" sticky />
             <SortHeader label="Action" k="action" />
             {/* Sizing column merged into Tgt Wt: target weight is the
                 canonical display and the raw sizing_input is only shown
@@ -681,6 +702,14 @@ export function AcceptedTradesTable({
           {sorted.map((trade, idx) => {
             const isSelected = selectedTradeId === trade.id
             const SourceIcon = SOURCE_ICONS[trade.source] || PenLine
+            // The frozen cells need an opaque fill of their own: the row's
+            // banding is translucent, and a see-through sticky cell lets the
+            // scrolling columns slide visibly underneath the ticker.
+            const stickyBg = isSelected
+              ? 'bg-primary-50 dark:bg-primary-950'
+              : idx % 2 === 0
+                ? 'bg-gray-50 dark:bg-gray-900'
+                : 'bg-white dark:bg-gray-900'
             return (
               <React.Fragment key={trade.id}>
                 <tr
@@ -695,7 +724,7 @@ export function AcceptedTradesTable({
                       : 'hover:bg-gray-50/70 dark:hover:bg-gray-800/40',
                   )}
                 >
-                  <td className="pl-2 py-2">
+                  <td className={clsx('pl-2 py-2 sticky left-0 z-10', stickyBg)}>
                     <ChevronRight
                       className={clsx(
                         'w-3.5 h-3.5 text-gray-400 transition-transform',
@@ -703,7 +732,11 @@ export function AcceptedTradesTable({
                       )}
                     />
                   </td>
-                  <td className="py-2 px-3 text-sm font-medium text-gray-900 dark:text-white">
+                  <td className={clsx(
+                    'py-2 px-3 text-sm font-medium text-gray-900 dark:text-white',
+                    'sticky left-8 z-10 border-r border-gray-100 dark:border-gray-800',
+                    stickyBg,
+                  )}>
                     <span className="inline-flex items-center gap-1.5 flex-wrap">
                       <span>{trade.asset?.symbol || 'Unknown'}</span>
                       {pairInfoByAsset.get(trade.asset_id) && (
@@ -833,12 +866,15 @@ export function AcceptedTradesTable({
                       with a leading minus so reductions are visually
                       distinct from adds. Source magnitude comes from
                       accepted_trades.notional_value which is unsigned. */}
-                  <td className={clsx(
-                    'py-2 px-3 text-sm font-mono text-right',
-                    trade.action === 'sell' || trade.action === 'trim'
-                      ? 'text-red-600 dark:text-red-400'
-                      : 'text-gray-600 dark:text-gray-300',
-                  )}>
+                  <td
+                    className={clsx(
+                      'py-2 px-3 text-sm font-mono text-right whitespace-nowrap tabular-nums',
+                      trade.action === 'sell' || trade.action === 'trim'
+                        ? 'text-red-600 dark:text-red-400'
+                        : 'text-gray-600 dark:text-gray-300',
+                    )}
+                    title={fmtSignedNotionalFull(signedNotional(trade.notional_value, trade.action))}
+                  >
                     {fmtSignedNotional(signedNotional(trade.notional_value, trade.action))}
                   </td>
                   <td className="py-2 px-3">

--- a/src/components/trading/BatchListView.tsx
+++ b/src/components/trading/BatchListView.tsx
@@ -795,12 +795,18 @@ function BatchDetailPanel({
   const isCancelledBatch = batch.status === 'cancelled'
 
   return (
-    <div className="h-full overflow-auto">
-      <div className="px-6 py-4 space-y-4">
-        {/* Header — compact: title + cancellation chip + escape hatch. Date
-            and source breakdown moved into the stats row so the header is
-            purely identity + primary action. */}
-        <div className="flex items-start justify-between gap-3">
+    <div className="h-full overflow-auto overscroll-contain">
+      <div className="px-3 sm:px-6 py-3 sm:py-4 space-y-3 sm:space-y-4">
+        {/* Header — identity on one line, the escape hatch under it on a
+            phone rather than beside it.
+
+            Held side by side, the name (an inline editor that grows with its
+            text) and a bordered "Open in Trades" button fought for the same
+            row: the button kept its width, so the name wrapped to two or three
+            lines beside it and the icon, chip and button all sat at different
+            heights. Baseline-aligning the identity cluster and letting the
+            action own its own row fixes both. */}
+        <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-2 sm:gap-3">
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2 flex-wrap">
               <Layers className="w-4 h-4 text-blue-600 dark:text-blue-400 flex-shrink-0" />
@@ -814,7 +820,7 @@ function BatchDetailPanel({
           </div>
           <button
             onClick={onViewInTradesView}
-            className="flex-shrink-0 inline-flex items-center gap-1.5 text-[11px] font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 px-2 py-1 rounded border border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 transition-colors"
+            className="self-start flex-shrink-0 inline-flex items-center gap-1.5 text-[11px] font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 px-2 py-1 rounded border border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 transition-colors"
             title="Open this batch in the full Trades view (for filtering, sorting, corrections)"
           >
             Open in Trades
@@ -1336,26 +1342,31 @@ function BatchNameEditor({
     )
   }
 
+  // The name is the rename control, with the pencil as its affordance.
+  //
+  // It used to be a separate bordered "Rename" button revealed on hover. The
+  // app's base layer reveals opacity-0 hover controls outright on touch and
+  // forces buttons to a 44px minimum, so on a phone that landed as a bordered
+  // block inline with the title — taller than the heading it sat beside, and
+  // pushing the name into a truncate at the width it left behind.
   return (
-    <div className="group inline-flex items-center gap-1.5 min-w-0">
+    <button
+      type="button"
+      onClick={() => setEditing(true)}
+      title="Rename batch"
+      className="group inline-flex items-baseline gap-1.5 min-w-0 text-left rounded hover:bg-gray-50 dark:hover:bg-gray-800 px-1 -mx-1"
+    >
       <h2
         className={clsx(
-          'text-lg font-semibold text-gray-900 dark:text-white truncate',
+          'text-base sm:text-lg font-semibold text-gray-900 dark:text-white truncate',
           isCancelledBatch && 'line-through text-gray-400 dark:text-gray-500',
           !batch.name && 'text-gray-400 dark:text-gray-500 italic',
         )}
       >
         {batch.name || 'Untitled batch'}
       </h2>
-      <button
-        onClick={() => setEditing(true)}
-        className="opacity-0 group-hover:opacity-100 transition-opacity inline-flex items-center gap-1 text-[11px] font-medium text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200 bg-white/80 dark:bg-gray-900/80 rounded-md border border-gray-200 dark:border-gray-700 px-1.5 py-0.5"
-        title="Rename batch"
-      >
-        <Pencil className="w-3 h-3" />
-        Rename
-      </button>
-    </div>
+      <Pencil className="w-3 h-3 shrink-0 self-center text-gray-300 dark:text-gray-600 group-hover:text-gray-500 dark:group-hover:text-gray-400 transition-colors" />
+    </button>
   )
 }
 

--- a/src/pages/CalendarPage.tsx
+++ b/src/pages/CalendarPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useRef } from 'react'
+﻿import { useState, useMemo, useEffect, useRef } from 'react'
 import { useIsMobile } from '../hooks/useMediaQuery'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {
@@ -20,7 +20,6 @@ import { Input } from '../components/ui/Input'
 import { Select } from '../components/ui/Select'
 import { PriorityBadge } from '../components/ui/PriorityBadge'
 import { CalendarSettings } from '../components/calendar/CalendarSettings'
-import { BottomSheet } from '../components/mobile/BottomSheet'
 import { useOrganization } from '../contexts/OrganizationContext'
 import { buildOrgQueryKey } from '../hooks/useOrgQueryKey'
 import { useOrgMembers } from '../hooks/useOrgMembers'
@@ -51,7 +50,7 @@ interface CalendarPageProps {
 
 type ViewMode = 'month' | 'week' | 'agenda'
 
-/** `dotColor` is the phone month-view rendering — see the day cell. */
+/** `dotColor` is the phone month-view rendering â€” see the day cell. */
 const EVENT_TYPE_CONFIG: Record<string, { label: string; color: string; bgColor: string; dotColor: string; icon: React.ReactNode }> = {
   earnings_call: { label: 'Earnings Call', color: 'text-green-700', bgColor: 'bg-green-100 border-green-300', dotColor: 'bg-green-500', icon: <TrendingUp className="h-3 w-3" /> },
   conference: { label: 'Conference', color: 'text-purple-700', bgColor: 'bg-purple-100 border-purple-300', dotColor: 'bg-purple-500', icon: <CalendarClock className="h-3 w-3" /> },
@@ -75,16 +74,16 @@ export function CalendarPage({ onItemSelect }: CalendarPageProps) {
   const queryClient = useQueryClient()
   const { currentOrgId } = useOrganization()
   const [currentDate, setCurrentDate] = useState(new Date())
-  // The month grid is seven columns of 55px at 390px — a cell too small for a
+  // The month grid is seven columns of 55px at 390px â€” a cell too small for a
   // date plus an event title. The agenda view already existed and is the shape
   // a phone wants: days as a list, with what is on them underneath. Month and
   // week remain selectable; they are just not the default where they do not fit.
   const isMobileViewport = useIsMobile()
   const [viewMode, setViewMode] = useState<ViewMode>(isMobileViewport ? 'agenda' : 'month')
-  const [selectedDate, setSelectedDate] = useState<Date | null>(null)
+  // Today, so the phone month view lands on a populated list rather than
+  // "tap a day"; the desktop grid ignores the selection until you click.
+  const [selectedDate, setSelectedDate] = useState<Date | null>(() => new Date())
   const [showEventModal, setShowEventModal] = useState(false)
-  /** Phone month view: the day whose events are listed in the sheet. */
-  const [daySheetDate, setDaySheetDate] = useState<Date | null>(null)
   const [editingEvent, setEditingEvent] = useState<CalendarEvent | null>(null)
   const [filterEventType, setFilterEventType] = useState<string>('all')
   const [filterPriority, setFilterPriority] = useState<string>('all')
@@ -354,15 +353,6 @@ export function CalendarPage({ onItemSelect }: CalendarPageProps) {
       start_date: format(date, 'yyyy-MM-dd'),
       end_date: format(date, 'yyyy-MM-dd'),
     }))
-    // On a phone the month cell shows dots rather than titles, so a tap has to
-    // be able to answer "what is on this day" — going straight to the create
-    // form would make those events unreadable anywhere in the month view. The
-    // sheet lists them and offers Add; an empty day still goes straight to
-    // create, since there is nothing to read.
-    if (isMobileViewport && viewMode === 'month' && getEventsForDay(date).length > 0) {
-      setDaySheetDate(date)
-      return
-    }
     setShowEventModal(true)
   }
 
@@ -473,7 +463,7 @@ export function CalendarPage({ onItemSelect }: CalendarPageProps) {
     <div className="h-full flex flex-col">
       {/* Header */}
       <div className="flex flex-wrap items-center justify-between gap-2 mb-3 sm:mb-6">
-        {/* The outer header wraps, but this inner group did not — title, three
+        {/* The outer header wraps, but this inner group did not â€” title, three
             nav buttons, the month heading and two fixed-width selects were
             locked on one line well past 390px. It wraps too now, and the
             filters lose their rule and left indent when they fall to their own
@@ -693,6 +683,140 @@ export function CalendarPage({ onItemSelect }: CalendarPageProps) {
               </div>
             )}
           </div>
+        ) : isMobileViewport && viewMode === 'month' ? (
+          /* Phone month view, laid out the way a phone calendar is: a compact
+             grid of dates carrying dots, and the selected day's events listed
+             underneath it on the same screen. Titles are unreadable inside a
+             55px cell, so the grid answers "which days have things" and the
+             list below answers "what things" â€” without a modal in between. */
+          <div className="h-full flex flex-col overflow-hidden">
+            <div className="grid grid-cols-7 px-1 pt-2 shrink-0">
+              {['S', 'M', 'T', 'W', 'T', 'F', 'S'].map((d, i) => (
+                <div key={i} className="py-1 text-center text-[11px] font-semibold text-gray-400 dark:text-gray-500">
+                  {d}
+                </div>
+              ))}
+            </div>
+
+            <div className="grid grid-cols-7 px-1 pb-2 shrink-0 border-b border-gray-200 dark:border-gray-700">
+              {calendarDays.map(day => {
+                const dayEvents = getEventsForDay(day)
+                const isCurrentMonth = isSameMonth(day, currentDate)
+                const isSel = selectedDate && isSameDay(day, selectedDate)
+                const today = isToday(day)
+                return (
+                  <button
+                    key={day.toISOString()}
+                    onClick={() => setSelectedDate(day)}
+                    className="no-touch-target flex flex-col items-center justify-start py-1 gap-1"
+                    aria-label={format(day, 'EEEE, MMMM d')}
+                    aria-pressed={!!isSel}
+                  >
+                    <span className={clsx(
+                      'w-8 h-8 flex items-center justify-center rounded-full text-[15px] tabular-nums',
+                      isSel && today && 'bg-primary-600 text-white font-semibold',
+                      isSel && !today && 'bg-gray-900 text-white font-semibold dark:bg-white dark:text-gray-900',
+                      !isSel && today && 'text-primary-600 font-bold',
+                      !isSel && !today && (isCurrentMonth
+                        ? 'text-gray-900 dark:text-gray-100'
+                        : 'text-gray-300 dark:text-gray-600'),
+                    )}>
+                      {format(day, 'd')}
+                    </span>
+                    {/* One dot per event, to three â€” the count past that is
+                        not information you act on from a grid. */}
+                    <span className="flex items-center gap-0.5 h-1">
+                      {dayEvents.slice(0, 3).map(ev => (
+                        <span
+                          key={ev.id}
+                          className={clsx(
+                            'w-1 h-1 rounded-full',
+                            (EVENT_TYPE_CONFIG[ev.event_type] || EVENT_TYPE_CONFIG.other).dotColor,
+                          )}
+                        />
+                      ))}
+                    </span>
+                  </button>
+                )
+              })}
+            </div>
+
+            {/* Selected day's events */}
+            <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain">
+              <div className="flex items-center justify-between px-4 py-2 sticky top-0 bg-white dark:bg-gray-900 border-b border-gray-100 dark:border-gray-800">
+                <span className="text-sm font-semibold text-gray-900 dark:text-white">
+                  {selectedDate
+                    ? (isToday(selectedDate) ? 'Today' : format(selectedDate, 'EEEE, MMMM d'))
+                    : 'Select a day'}
+                </span>
+                <button
+                  onClick={() => {
+                    const d = selectedDate ?? new Date()
+                    setEditingEvent(null)
+                    setEventForm(prev => ({
+                      ...prev,
+                      start_date: format(d, 'yyyy-MM-dd'),
+                      end_date: format(d, 'yyyy-MM-dd'),
+                    }))
+                    setShowEventModal(true)
+                  }}
+                  className="text-sm font-medium text-primary-600 dark:text-primary-400"
+                >
+                  Add
+                </button>
+              </div>
+
+              {(() => {
+                const list = selectedDate ? getEventsForDay(selectedDate) : []
+                if (list.length === 0) {
+                  return (
+                    <p className="px-4 py-8 text-center text-sm text-gray-400">
+                      {selectedDate ? 'No events' : 'Tap a day to see its events'}
+                    </p>
+                  )
+                }
+                return (
+                  <div className="divide-y divide-gray-100 dark:divide-gray-800">
+                    {list.map(event => {
+                      const config = EVENT_TYPE_CONFIG[event.event_type] || EVENT_TYPE_CONFIG.other
+                      return (
+                        <button
+                          key={event.id}
+                          onClick={() => {
+                            if (!(event as any).isProjectDeliverable) {
+                              handleEditEvent(event as CalendarEvent)
+                            } else if (onItemSelect) {
+                              onItemSelect({
+                                id: (event as any).projectId,
+                                title: event.title,
+                                type: 'project',
+                                data: { id: (event as any).projectId },
+                              })
+                            }
+                          }}
+                          className="w-full text-left flex items-start gap-3 px-4 py-3 active:bg-gray-50 dark:active:bg-gray-800"
+                        >
+                          <span className={clsx('w-2 h-2 rounded-full mt-1.5 shrink-0', config.dotColor)} />
+                          <span className="flex-1 min-w-0">
+                            <span className="block font-medium text-gray-900 dark:text-white truncate">
+                              {event.title}
+                            </span>
+                            <span className="block text-xs text-gray-500 dark:text-gray-400 mt-0.5">
+                              {event.all_day
+                                ? 'All day'
+                                : format(parseISO(event.start_date), 'h:mm a')}
+                              {' Â· '}{config.label}
+                            </span>
+                          </span>
+                          <PriorityBadge priority={event.priority} size="sm" />
+                        </button>
+                      )
+                    })}
+                  </div>
+                )
+              })()}
+            </div>
+          </div>
         ) : (
           /* Month/Week View */
           <div className="h-full flex flex-col overflow-hidden">
@@ -738,39 +862,17 @@ export function CalendarPage({ onItemSelect }: CalendarPageProps) {
                     )}>
                       {format(day, 'd')}
                     </div>
-                    {/* A month cell is ~55px wide on a phone, so a titled chip
-                        renders as one or two clipped characters — it reads as
-                        noise rather than as an event. Phones get dots: how many
-                        events, and their type by colour. Tapping the day opens
-                        it, which is where the titles are legible. Week view has
-                        seven columns of a full screen, so it keeps the chips. */}
-                    {isMobileViewport && viewMode === 'month' ? (
-                      <div className="flex-1 min-h-0 flex flex-wrap content-start gap-0.5 pt-0.5">
-                        {dayEvents.slice(0, 6).map(event => (
-                          <span
-                            key={event.id}
-                            className={clsx(
-                              'w-1.5 h-1.5 rounded-full',
-                              (EVENT_TYPE_CONFIG[event.event_type] || EVENT_TYPE_CONFIG.other).dotColor,
-                            )}
-                          />
-                        ))}
-                        {dayEvents.length > 6 && (
-                          <span className="text-[9px] leading-none text-gray-400 tabular-nums">
-                            +{dayEvents.length - 6}
-                          </span>
-                        )}
-                      </div>
-                    ) : (
-                      <div className="flex-1 space-y-0.5 overflow-y-auto min-h-0">
-                        {dayEvents.slice(0, viewMode === 'week' ? 10 : 4).map(event => renderEventChip(event, true))}
-                        {dayEvents.length > (viewMode === 'week' ? 10 : 4) && (
-                          <div className="text-xs text-gray-500 px-1 dark:text-gray-400">
-                            +{dayEvents.length - (viewMode === 'week' ? 10 : 4)} more
-                          </div>
-                        )}
-                      </div>
-                    )}
+                    {/* This path is desktop, plus week view on a phone â€” seven
+                        columns of a full screen is enough for titles. The phone
+                        month view is its own branch above. */}
+                    <div className="flex-1 space-y-0.5 overflow-y-auto min-h-0">
+                      {dayEvents.slice(0, viewMode === 'week' ? 10 : 4).map(event => renderEventChip(event, true))}
+                      {dayEvents.length > (viewMode === 'week' ? 10 : 4) && (
+                        <div className="text-xs text-gray-500 px-1 dark:text-gray-400">
+                          +{dayEvents.length - (viewMode === 'week' ? 10 : 4)} more
+                        </div>
+                      )}
+                    </div>
                   </div>
                 )
               })}
@@ -797,67 +899,6 @@ export function CalendarPage({ onItemSelect }: CalendarPageProps) {
           isDeleting={deleteEventMutation.isPending}
         />
       )}
-
-      {/* Day sheet — the phone month view's way of reading a day. */}
-      <BottomSheet
-        open={!!daySheetDate}
-        onClose={() => setDaySheetDate(null)}
-        title={daySheetDate ? (isToday(daySheetDate) ? 'Today' : format(daySheetDate, 'EEEE, MMMM d')) : ''}
-        snapPoints={[0.5, 0.9]}
-        headerAccessory={
-          <button
-            onClick={() => {
-              setDaySheetDate(null)
-              setEditingEvent(null)
-              setShowEventModal(true)
-            }}
-            className="text-sm font-medium text-primary-600 dark:text-primary-400"
-          >
-            Add
-          </button>
-        }
-      >
-        <div className="px-4 py-2 pb-safe space-y-2">
-          {(daySheetDate ? getEventsForDay(daySheetDate) : []).map(event => {
-            const config = EVENT_TYPE_CONFIG[event.event_type] || EVENT_TYPE_CONFIG.other
-            return (
-              <button
-                key={event.id}
-                onClick={() => {
-                  setDaySheetDate(null)
-                  if (!(event as any).isProjectDeliverable) {
-                    handleEditEvent(event as CalendarEvent)
-                  } else if (onItemSelect) {
-                    onItemSelect({
-                      id: (event as any).projectId,
-                      title: event.title,
-                      type: 'project',
-                      data: { id: (event as any).projectId },
-                    })
-                  }
-                }}
-                className="w-full text-left flex items-start gap-3 p-3 rounded-lg border border-gray-100 dark:border-gray-700 active:bg-gray-50 dark:active:bg-gray-800"
-              >
-                <span className={clsx('w-2 h-2 rounded-full mt-1.5 shrink-0', config.dotColor)} />
-                <span className="flex-1 min-w-0">
-                  <span className="block font-medium text-gray-900 dark:text-white truncate">
-                    {event.title}
-                  </span>
-                  <span className="flex items-center gap-2 mt-0.5 text-xs text-gray-500 dark:text-gray-400">
-                    <span className={clsx('px-1.5 py-0.5 rounded-full', config.bgColor, config.color)}>
-                      {config.label}
-                    </span>
-                    {!event.all_day && (
-                      <span>{format(parseISO(event.start_date), 'h:mm a')}</span>
-                    )}
-                  </span>
-                </span>
-                <PriorityBadge priority={event.priority} size="sm" />
-              </button>
-            )
-          })}
-        </div>
-      </BottomSheet>
 
       {/* Calendar Settings Panel */}
       <CalendarSettings
@@ -1191,7 +1232,7 @@ function EventModal({
   const [showMoreOptions, setShowMoreOptions] = useState(false)
   const [attendeeSearch, setAttendeeSearch] = useState('')
 
-  // Attendees picker — org-scoped. Previously queried users globally.
+  // Attendees picker â€” org-scoped. Previously queried users globally.
   // Same defense-in-depth swap as the other pickers in commit 868ee2f.
   const { data: users = [] } = useOrgMembers({ enabled: isOpen })
 
@@ -1483,7 +1524,7 @@ function EventModal({
 
                   {/* Location & URL */}
                   {/* Location and a URL side by side leave ~160px each with an
-                      inset icon — a pasted link shows about four characters. */}
+                      inset icon â€” a pasted link shows about four characters. */}
                   <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                     <div>
                       <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">

--- a/src/pages/FilesPage.tsx
+++ b/src/pages/FilesPage.tsx
@@ -143,7 +143,7 @@ export function FilesPage({ onItemSelect }: FilesPageProps) {
   return (
     <div className="h-full flex flex-col bg-gray-50 dark:bg-gray-900">
       {/* Header */}
-      <div className="bg-white border-b border-gray-200 px-3 sm:px-6 py-4 dark:border-gray-700 dark:bg-gray-800">
+      <div className="bg-white border-b border-gray-200 px-3 sm:px-6 py-2.5 sm:py-4 dark:border-gray-700 dark:bg-gray-800">
         {/* Identity and actions wrap; the standing description is desktop-only
             — it explains the page once and costs a line of every visit. */}
         <div className="flex flex-wrap items-center justify-between gap-2 mb-3 sm:mb-4">
@@ -176,7 +176,7 @@ export function FilesPage({ onItemSelect }: FilesPageProps) {
             is never generated and the selected chip rendered with no background
             at all — the row gave no indication of which category was active.
             The classes are looked up whole now. */}
-        <div className="flex items-center gap-2 sm:gap-3 mb-3 sm:mb-4 overflow-x-auto no-scrollbar pb-1.5">
+        <div className="flex items-center gap-2 sm:gap-3 mb-2 sm:mb-4 overflow-x-auto no-scrollbar pb-1">
           {categoryStats.map(cat => {
             const Icon = cat.icon
             const tone = CATEGORY_TONES[cat.color] ?? CATEGORY_TONES.gray
@@ -203,16 +203,21 @@ export function FilesPage({ onItemSelect }: FilesPageProps) {
           })}
         </div>
 
-        {/* Filters & Search. A category select, a view switch and a 256px
-            search field come to ~470px, so search drops to its own full-width
-            line on a phone. */}
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-          <div className="flex items-center gap-2 min-w-0">
-            {/* Category Filter */}
+        {/* Filters & Search — one row: search takes the width, the view
+            switch sits beside it. */}
+        <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 min-w-0 shrink-0">
+            {/* Category Filter.
+
+                Hidden on a phone: the chip row above is already the category
+                control, and two controls setting the same value — one of them
+                a chrome-drawn select listing the same seven options — is the
+                thing that made the filters read as unclear. The chips stay
+                because they also carry counts. */}
             <select
               value={categoryFilter}
               onChange={(e) => setCategoryFilter(e.target.value as CategoryFilter)}
-              className="px-3 py-1.5 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-violet-500 dark:border-gray-700"
+              className="hidden sm:block px-3 py-1.5 text-sm border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-violet-500 dark:border-gray-700"
             >
               <option value="all">All Categories</option>
               <option value="models">Models</option>
@@ -242,7 +247,7 @@ export function FilesPage({ onItemSelect }: FilesPageProps) {
           </div>
 
           {/* Search */}
-          <div className="relative w-full sm:w-auto">
+          <div className="relative flex-1 min-w-0 sm:flex-none order-first sm:order-none">
             <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-4 h-4 text-gray-400" />
             <input
               type="text"
@@ -256,7 +261,7 @@ export function FilesPage({ onItemSelect }: FilesPageProps) {
       </div>
 
       {/* Content */}
-      <div className="flex-1 overflow-auto p-3 sm:p-6">
+      <div className="flex-1 overflow-auto overscroll-contain p-2.5 sm:p-6">
         {isLoading ? (
           <div className="flex items-center justify-center h-64">
             <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-violet-600"></div>

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react'
+import { useState, useMemo, useEffect } from 'react'
 import React from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import {

--- a/src/pages/TradeBookPage.tsx
+++ b/src/pages/TradeBookPage.tsx
@@ -463,8 +463,13 @@ export function TradeBookPage({ initialPortfolioId, highlightTradeIds, highlight
           <div className="hidden sm:block h-5 w-px bg-gray-200 dark:bg-gray-700 mx-1" />
         </div>
 
-        {/* Portfolio selector */}
-        <div className="relative order-3 sm:order-2 min-w-0 max-sm:flex-1" ref={portfolioDropdownRef}>
+        {/* Portfolio selector and the view toggle share a line. The selector
+            had `flex-1`, so on a phone it consumed the whole row and pushed
+            the toggle onto a third one; grouping them guarantees they stay
+            together, with the selector giving up width and the toggle keeping
+            its natural size. */}
+        <div className="order-3 sm:order-2 flex items-center gap-2 w-full sm:w-auto min-w-0">
+        <div className="relative min-w-0 flex-1 sm:flex-none" ref={portfolioDropdownRef}>
             <button
               onClick={() => setPortfolioDropdownOpen(!portfolioDropdownOpen)}
               className="w-full sm:w-auto flex items-center gap-2 px-3 py-1.5 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors text-sm"
@@ -529,11 +534,11 @@ export function TradeBookPage({ initialPortfolioId, highlightTradeIds, highlight
         </div>
 
         {/* Separator */}
-        <div className="hidden sm:block h-5 w-px bg-gray-200 dark:bg-gray-700 mx-1 order-2" />
+        <div className="hidden sm:block h-5 w-px bg-gray-200 dark:bg-gray-700 mx-1" />
 
         {/* View toggle — Batches first because it's the default
             (reading surface), Trades second (operations surface). */}
-        <div className="flex items-center bg-gray-100 dark:bg-gray-800 rounded-lg p-0.5 order-4 sm:order-3 shrink-0">
+        <div className="flex items-center bg-gray-100 dark:bg-gray-800 rounded-lg p-0.5 shrink-0">
           <button
             onClick={() => setView('batches')}
             className={clsx(
@@ -559,6 +564,7 @@ export function TradeBookPage({ initialPortfolioId, highlightTradeIds, highlight
             Trades
           </button>
         </div>
+        </div>
 
         {/* Right side: shortcut to Outcomes — the natural next step
             after looking at committed trades. Reuses the existing
@@ -582,14 +588,15 @@ export function TradeBookPage({ initialPortfolioId, highlightTradeIds, highlight
               }))
             } catch { /* ignore */ }
           }}
-          className="order-2 sm:order-4 ml-auto shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold text-teal-700 dark:text-teal-300 bg-teal-50 dark:bg-teal-900/20 hover:bg-teal-100 dark:hover:bg-teal-900/40 border border-teal-200 dark:border-teal-800/60 rounded-lg transition-colors"
+          className="order-2 sm:order-4 ml-auto shrink-0 inline-flex items-center gap-1 px-2 py-1 text-[11px] font-semibold text-teal-700 dark:text-teal-300 bg-teal-50 dark:bg-teal-900/20 hover:bg-teal-100 dark:hover:bg-teal-900/40 border border-teal-200 dark:border-teal-800/60 rounded-md transition-colors"
           title="See how these decisions are performing"
         >
-          <Target className="w-3.5 h-3.5 shrink-0" />
-          {/* "View" is implied by a button on a phone; the word costs width
-              the portfolio name needs on the line below. */}
-          <span className="hidden sm:inline">View </span>Outcomes
-          <ArrowRight className="w-3 h-3 opacity-70 shrink-0" />
+          {/* A quiet shortcut in the corner, not a call to action — it is the
+              step after this page, not the reason you are on it. "View" is
+              implied by a button. */}
+          <Target className="w-3 h-3 shrink-0" />
+          Outcomes
+          <ArrowRight className="w-2.5 h-2.5 opacity-70 shrink-0" />
         </button>
       </div>
 


### PR DESCRIPTION
…endar, files

Projects — my regression
- ProjectsPage used useEffect without importing it, so opening the app threw and rendered the error boundary. Introduced in the collections-drawer commit.

  It got through because `npx tsc --noEmit` on the root tsconfig checks nothing: that config is `"files": []` plus project references, which tsc ignores without `--build`. Every "typecheck clean" reported on this branch was vacuous. The real command is `tsc -p tsconfig.app.json`, which the codebase does not pass today (hundreds of pre-existing unused-symbol and Supabase `never` errors), so it is used filtered to touched files.

Trade Book
- Outcomes is a small quiet shortcut in the top-right corner rather than a call to action: it is the step after this page, not the reason you are here.
- The portfolio selector had `flex-1`, so on a phone it took the whole row and pushed the Batches/Trades toggle onto a third line. They are grouped now, so they stay on one line with the selector giving up the width.
- Batch detail: the name (an inline editor that grows with its text) and the bordered "Open in Trades" button shared a row, so the name wrapped beside it and icon, chip and button sat at three different heights. The action drops below on a phone. The separate hover-revealed "Rename" button is gone — the base layer reveals opacity-0 controls on touch and forces 44px, so it landed as a block taller than the heading next to it; the title is the control now, with the pencil as its affordance.
- Notional: "$34,173,518" is thirteen characters no column width accommodates, so it wrapped or widened the table. Millions and above abbreviate to three significant figures, with the exact value on the cell's title.
- The expand and symbol columns freeze, so the ticker stays put while the numbers scroll. They carry an opaque per-row fill: the row banding is translucent, and a see-through sticky cell lets columns slide visibly under the ticker.

Calendar — phone month view rebuilt
- Dots in a grid answer "which days have something"; they cannot answer "what". The previous pass added dots but left the tap opening the create form, so titles were unreachable. It now follows the phone-calendar shape: single letter day headers, a compact date grid with today/selected as filled circles and up to three dots per day, and the selected day's events listed underneath on the same screen. No modal in between. Selection defaults to today so it lands populated. The day sheet added last pass is removed as superseded. Week view and desktop are untouched.

Files
- The category chip row and a category select were two controls setting the same value, the select listing the same seven options. That is what made the filters unclear; the select is desktop-only now and the chips (which carry counts) are the control. Search and the view switch share the remaining row.
- Header, chip row and content padding tightened.

## What

<!-- One-sentence summary of the change. -->

## Why

<!-- Why is this change needed? Link to issue / Slack thread / customer report
if relevant. Focus on the user / business motivation, not the implementation. -->

## How

<!-- Brief technical summary if the diff isn't self-explanatory. Skip if
the diff speaks for itself. -->

## Test plan

<!-- What did you do to verify this works?
- [ ] Ran `npm test -- --run`
- [ ] Verified the affected page in the dev server / staging
- [ ] (UI changes) Screenshot below
- [ ] (DB changes) Applied migration to staging, verified, then to prod
-->

## Risk

<!-- One of: low / medium / high. If medium or high, explain the blast radius
and how it'd be rolled back. -->

## Screenshots

<!-- For UI changes. Before / after, or a quick GIF if motion matters. -->

---

- [ ] PR title follows Conventional Commits (`feat:`, `fix:`, `chore:`, etc.)
- [ ] No secrets in the diff (`.env*`, API keys, DB passwords)
- [ ] CI is green
- [ ] (If risky) verified on `staging` before targeting `main`
