### PR TITLE
Org-scope the assets storage bucket; stop persisting public URLs

### DIFF
--- a/scripts/backfill-assets-bucket-org-scope.mjs
+++ b/scripts/backfill-assets-bucket-org-scope.mjs
@@ -1,0 +1,330 @@
+#!/usr/bin/env node
+/**
+ * Phase 2 of org-scoping the `assets` storage bucket.
+ *
+ * Moves existing objects under an `<organization_id>/` prefix and rewrites
+ * the database rows that point at them, so the Phase 3 policy
+ * (`(storage.foldername(name))[1] = current_org_id()`) can be applied
+ * without cutting anyone off from their own files.
+ *
+ * ─── Read this before running ────────────────────────────────────────────
+ *
+ * Not every object can be attributed to an org. Two sources cannot be
+ * resolved from the schema as it stands:
+ *
+ *   asset_models / model_versions
+ *     asset_models has no organization_id — only created_by and asset_id
+ *     (20251230000002_add_notes_models_section.sql). Its RLS is user
+ *     ownership. `assets` is the global security master, so asset_id carries
+ *     no tenant either. The creator's *current* org is not the same fact as
+ *     the org they uploaded in, and for a multi-org user it can be a
+ *     different org entirely.
+ *
+ *   asset_notes rows predating 20260603140000_notes_organization_id.sql
+ *     That migration added organization_id and states plainly that these
+ *     rows have "no reconstructable origin org" and stay NULL.
+ *
+ * Guessing here is worse than not moving the file: filing Firm A's model
+ * under Firm B's prefix hands it to Firm B under the new policy. So this
+ * script never guesses. Unattributable objects are reported and left alone,
+ * and deciding what happens to them is a separate, human call — see the
+ * summary it prints.
+ *
+ * ─── Usage ───────────────────────────────────────────────────────────────
+ *
+ *   SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... \
+ *     node scripts/backfill-assets-bucket-org-scope.mjs            # dry run
+ *
+ *   ... node scripts/backfill-assets-bucket-org-scope.mjs --apply  # execute
+ *
+ * Dry run is the default and touches nothing. Run it against staging first,
+ * read the report, and only then consider --apply. A full report lands in
+ * ./assets-backfill-report.json either way.
+ */
+
+import { createClient } from '@supabase/supabase-js'
+import { writeFileSync } from 'node:fs'
+
+const BUCKET = 'assets'
+const APPLY = process.argv.includes('--apply')
+const REPORT_PATH = './assets-backfill-report.json'
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+const url = process.env.SUPABASE_URL
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+if (!url || !key) {
+  console.error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set.')
+  process.exit(1)
+}
+const db = createClient(url, key, { auth: { persistSession: false } })
+
+/**
+ * Sources of truth for "which object belongs to which org".
+ *
+ * `resolvable: false` entries are listed deliberately rather than omitted —
+ * their objects must be *recognised* so they can be reported as
+ * unattributable instead of silently falling into the orphan bucket, which
+ * would misrepresent a schema gap as abandoned data.
+ */
+const SOURCES = [
+  {
+    table: 'asset_notes',
+    pathColumn: 'file_path',
+    orgColumn: 'organization_id',
+    resolvable: true,
+    note: 'rows predating the notes org migration have organization_id = NULL',
+  },
+  {
+    table: 'model_templates',
+    pathColumn: 'base_template_path',
+    orgColumn: 'organization_id',
+    resolvable: true,
+  },
+  {
+    table: 'asset_checklist_attachments',
+    pathColumn: 'file_path',
+    // Org arrives through asset_checklist_items → workflows.organization_id.
+    // Resolved by RPC-free join below rather than a direct column.
+    orgVia: {
+      select: 'file_path, asset_checklist_items!inner(workflows!inner(organization_id))',
+      pick: r => r?.asset_checklist_items?.workflows?.organization_id ?? null,
+    },
+    resolvable: true,
+  },
+  {
+    table: 'portfolio_checklist_attachments',
+    pathColumn: 'file_path',
+    orgVia: {
+      select: 'file_path, portfolio_checklist_items!inner(workflows!inner(organization_id))',
+      pick: r => r?.portfolio_checklist_items?.workflows?.organization_id ?? null,
+    },
+    resolvable: true,
+  },
+  {
+    table: 'asset_models',
+    pathColumn: 'file_path',
+    resolvable: false,
+    reason: 'asset_models has no organization_id; RLS is user ownership',
+  },
+  {
+    table: 'model_versions',
+    pathColumn: 'file_path',
+    resolvable: false,
+    reason: 'inherits asset_models, which has no organization_id',
+  },
+]
+
+/** Note tables whose ProseMirror content embeds fileAttachment filePath attrs. */
+const NOTE_CONTENT_TABLES = [
+  { table: 'asset_notes', orgColumn: 'organization_id' },
+  { table: 'portfolio_notes', orgColumn: 'organization_id' },
+  { table: 'theme_notes', orgColumn: 'organization_id' },
+  { table: 'custom_notebook_notes', orgColumn: 'organization_id' },
+]
+
+const isScoped = p => UUID_RE.test(String(p).split('/')[0])
+
+async function selectAll(table, select) {
+  const rows = []
+  const PAGE = 1000
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await db.from(table).select(select).range(from, from + PAGE - 1)
+    if (error) return { rows: null, error }
+    rows.push(...data)
+    if (data.length < PAGE) break
+  }
+  return { rows, error: null }
+}
+
+/** Every object currently in the bucket, recursively. */
+async function listObjects(prefix = '') {
+  const out = []
+  const PAGE = 1000
+  for (let offset = 0; ; offset += PAGE) {
+    const { data, error } = await db.storage
+      .from(BUCKET)
+      .list(prefix, { limit: PAGE, offset, sortBy: { column: 'name', order: 'asc' } })
+    if (error) throw new Error(`list(${prefix}): ${error.message}`)
+    for (const entry of data) {
+      const full = prefix ? `${prefix}/${entry.name}` : entry.name
+      // Supabase represents folders as rows with a null id.
+      if (entry.id === null) out.push(...(await listObjects(full)))
+      else out.push(full)
+    }
+    if (data.length < PAGE) break
+  }
+  return out
+}
+
+/** path -> { org, table, column, resolvable, reason } */
+async function buildOwnershipIndex() {
+  const index = new Map()
+  const skipped = []
+
+  for (const src of SOURCES) {
+    const select = src.orgVia
+      ? src.orgVia.select
+      : `${src.pathColumn}${src.orgColumn ? `, ${src.orgColumn}` : ''}`
+
+    const { rows, error } = await selectAll(src.table, select)
+    if (error) {
+      // A missing table or column is reported, never swallowed: an
+      // unqueried source shows up as orphaned objects, and orphans look
+      // like safe-to-ignore junk.
+      skipped.push({ table: src.table, error: error.message })
+      continue
+    }
+
+    for (const row of rows) {
+      const path = row[src.pathColumn]
+      if (!path) continue
+      const org = src.orgVia ? src.orgVia.pick(row) : row[src.orgColumn] ?? null
+      index.set(path, {
+        org: src.resolvable ? org : null,
+        table: src.table,
+        column: src.pathColumn,
+        resolvable: Boolean(src.resolvable && org),
+        reason: src.resolvable
+          ? org ? null : (src.note ?? 'row has no organization_id')
+          : src.reason,
+      })
+    }
+  }
+
+  return { index, skipped }
+}
+
+/** Walk a ProseMirror doc collecting fileAttachment filePath attributes. */
+function collectAttachmentPaths(node, acc = []) {
+  if (!node || typeof node !== 'object') return acc
+  if (Array.isArray(node)) {
+    for (const n of node) collectAttachmentPaths(n, acc)
+    return acc
+  }
+  if (node.attrs?.filePath) acc.push(node.attrs.filePath)
+  if (node.content) collectAttachmentPaths(node.content, acc)
+  return acc
+}
+
+async function indexNoteAttachments(index, skipped) {
+  for (const { table, orgColumn } of NOTE_CONTENT_TABLES) {
+    const { rows, error } = await selectAll(table, `id, content, ${orgColumn}`)
+    if (error) {
+      skipped.push({ table: `${table} (content scan)`, error: error.message })
+      continue
+    }
+    for (const row of rows) {
+      let doc = row.content
+      if (typeof doc === 'string') {
+        try { doc = JSON.parse(doc) } catch { continue }
+      }
+      for (const path of collectAttachmentPaths(doc)) {
+        if (index.has(path)) continue
+        const org = row[orgColumn] ?? null
+        index.set(path, {
+          org,
+          table,
+          column: 'content(json)',
+          noteId: row.id,
+          resolvable: Boolean(org),
+          reason: org ? null : 'note has no organization_id',
+        })
+      }
+    }
+  }
+}
+
+async function main() {
+  console.log(`${APPLY ? 'APPLY' : 'DRY RUN'} — bucket "${BUCKET}"\n`)
+
+  const objects = await listObjects()
+  console.log(`objects in bucket: ${objects.length}`)
+
+  const { index, skipped } = await buildOwnershipIndex()
+  await indexNoteAttachments(index, skipped)
+  console.log(`database rows referencing a path: ${index.size}`)
+
+  if (skipped.length) {
+    console.log('\n!! sources that could not be read — results are INCOMPLETE:')
+    for (const s of skipped) console.log(`   ${s.table}: ${s.error}`)
+  }
+
+  const buckets = { alreadyScoped: [], resolved: [], unattributable: [], orphan: [] }
+
+  for (const path of objects) {
+    if (isScoped(path) && index.get(path)?.resolvable !== false) {
+      // Ambiguous by shape for legacy checklist evidence (<assetId>/…), so
+      // trust the index when it disagrees.
+      const owner = index.get(path)
+      if (!owner || owner.org === path.split('/')[0]) {
+        buckets.alreadyScoped.push(path)
+        continue
+      }
+    }
+    const owner = index.get(path)
+    if (!owner) { buckets.orphan.push(path); continue }
+    if (!owner.resolvable) {
+      buckets.unattributable.push({ path, table: owner.table, reason: owner.reason })
+      continue
+    }
+    buckets.resolved.push({ path, to: `${owner.org}/${path}`, ...owner })
+  }
+
+  console.log(`
+  already scoped   ${buckets.alreadyScoped.length}
+  resolvable       ${buckets.resolved.length}
+  UNATTRIBUTABLE   ${buckets.unattributable.length}   <- needs a human decision
+  orphan           ${buckets.orphan.length}   <- object with no DB row
+`)
+
+  const byReason = {}
+  for (const u of buckets.unattributable) {
+    const k = `${u.table}: ${u.reason}`
+    byReason[k] = (byReason[k] || 0) + 1
+  }
+  if (Object.keys(byReason).length) {
+    console.log('unattributable breakdown:')
+    for (const [k, n] of Object.entries(byReason)) console.log(`  ${n.toString().padStart(5)}  ${k}`)
+  }
+
+  writeFileSync(REPORT_PATH, JSON.stringify({ generatedFor: url, skipped, ...buckets }, null, 2))
+  console.log(`\nfull report: ${REPORT_PATH}`)
+
+  if (!APPLY) {
+    console.log('\nDry run — nothing moved. Re-run with --apply once the report looks right.')
+    return
+  }
+
+  if (buckets.unattributable.length > 0) {
+    console.log(`
+Refusing to apply: ${buckets.unattributable.length} objects cannot be attributed
+to an org. Moving only the resolvable ones would leave the rest on legacy
+paths, and the Phase 3 policy denies those — so applying now silently
+strands them. Decide what happens to the unattributable set first.`)
+    process.exit(2)
+  }
+
+  let moved = 0, failed = 0
+  for (const item of buckets.resolved) {
+    const { error: moveErr } = await db.storage.from(BUCKET).move(item.path, item.to)
+    if (moveErr) { console.error(`move failed ${item.path}: ${moveErr.message}`); failed++; continue }
+
+    if (item.column === 'content(json)') {
+      console.error(`  ! ${item.path} lives in ${item.table}.content — rewrite the note JSON separately`)
+      failed++
+      continue
+    }
+    const { error: updErr } = await db
+      .from(item.table).update({ [item.column]: item.to }).eq(item.column, item.path)
+    if (updErr) {
+      console.error(`row update failed ${item.path}: ${updErr.message} — rolling the object back`)
+      await db.storage.from(BUCKET).move(item.to, item.path)
+      failed++
+      continue
+    }
+    moved++
+  }
+  console.log(`\nmoved ${moved}, failed ${failed}`)
+}
+
+main().catch(err => { console.error(err); process.exit(1) })

--- a/scripts/backfill-assets-bucket-org-scope.mjs
+++ b/scripts/backfill-assets-bucket-org-scope.mjs
@@ -9,26 +9,21 @@
  *
  * ─── Read this before running ────────────────────────────────────────────
  *
- * Not every object can be attributed to an org. Two sources cannot be
- * resolved from the schema as it stands:
+ * Every source now carries an organization_id: asset_models and
+ * model_versions gained one in 20260814100000, which also backfilled
+ * asset_notes rows that 20260603140000 had left NULL.
  *
- *   asset_models / model_versions
- *     asset_models has no organization_id — only created_by and asset_id
- *     (20251230000002_add_notes_models_section.sql). Its RLS is user
- *     ownership. `assets` is the global security master, so asset_id carries
- *     no tenant either. The creator's *current* org is not the same fact as
- *     the org they uploaded in, and for a multi-org user it can be a
- *     different org entirely.
+ * A residue can still be unattributable. Both backfills only fill in rows
+ * whose creator is an active member of exactly one organization. Where a
+ * creator belongs to several there is no way to recover which one they were
+ * in at upload time — users.current_organization_id is today's answer to a
+ * question about the past.
  *
- *   asset_notes rows predating 20260603140000_notes_organization_id.sql
- *     That migration added organization_id and states plainly that these
- *     rows have "no reconstructable origin org" and stay NULL.
- *
- * Guessing here is worse than not moving the file: filing Firm A's model
- * under Firm B's prefix hands it to Firm B under the new policy. So this
- * script never guesses. Unattributable objects are reported and left alone,
- * and deciding what happens to them is a separate, human call — see the
- * summary it prints.
+ * Guessing is worse than not moving the file: filing Firm A's model under
+ * Firm B's prefix hands it to Firm B under the new policy. So this script
+ * never guesses. Unattributable objects are reported and left alone; run the
+ * verification queries at the bottom of 20260814100000 to see which rows
+ * need an admin to assign an org, do that, then re-run.
  *
  * ─── Usage ───────────────────────────────────────────────────────────────
  *
@@ -103,14 +98,19 @@ const SOURCES = [
   {
     table: 'asset_models',
     pathColumn: 'file_path',
-    resolvable: false,
-    reason: 'asset_models has no organization_id; RLS is user ownership',
+    orgColumn: 'organization_id',
+    resolvable: true,
+    // Added by 20260814100000. Backfilled only where the creator belongs to
+    // exactly one org; rows whose creator is in several stay NULL and land
+    // in the unattributable bucket below for an admin to assign.
+    note: 'creator belongs to more than one org — assign manually',
   },
   {
     table: 'model_versions',
     pathColumn: 'file_path',
-    resolvable: false,
-    reason: 'inherits asset_models, which has no organization_id',
+    orgColumn: 'organization_id',
+    resolvable: true,
+    note: 'parent asset_models row has no organization_id',
   },
 ]
 

--- a/scripts/backfill-assets-bucket-org-scope.mjs
+++ b/scripts/backfill-assets-bucket-org-scope.mjs
@@ -41,6 +41,14 @@ import { createClient } from '@supabase/supabase-js'
 import { writeFileSync } from 'node:fs'
 
 const BUCKET = 'assets'
+/**
+ * Objects deliberately parked because no org could be established for them.
+ * They are kept rather than deleted, and no storage policy matches this
+ * prefix, so only the service role can reach them. Distinct from
+ * "unattributable": that means *not yet decided* and blocks --apply, whereas
+ * this means decided — leave it alone.
+ */
+const QUARANTINE_PREFIX = '_unattributed/'
 const APPLY = process.argv.includes('--apply')
 const REPORT_PATH = './assets-backfill-report.json'
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
@@ -249,9 +257,10 @@ async function main() {
     for (const s of skipped) console.log(`   ${s.table}: ${s.error}`)
   }
 
-  const buckets = { alreadyScoped: [], resolved: [], unattributable: [], orphan: [] }
+  const buckets = { alreadyScoped: [], resolved: [], unattributable: [], orphan: [], quarantined: [] }
 
   for (const path of objects) {
+    if (path.startsWith(QUARANTINE_PREFIX)) { buckets.quarantined.push(path); continue }
     if (isScoped(path) && index.get(path)?.resolvable !== false) {
       // Ambiguous by shape for legacy checklist evidence (<assetId>/…), so
       // trust the index when it disagrees.
@@ -275,6 +284,7 @@ async function main() {
   resolvable       ${buckets.resolved.length}
   UNATTRIBUTABLE   ${buckets.unattributable.length}   <- needs a human decision
   orphan           ${buckets.orphan.length}   <- object with no DB row
+  quarantined      ${buckets.quarantined.length}   <- parked under ${QUARANTINE_PREFIX}, no policy reaches them
 `)
 
   const byReason = {}
@@ -293,6 +303,14 @@ async function main() {
   if (!APPLY) {
     console.log('\nDry run — nothing moved. Re-run with --apply once the report looks right.')
     return
+  }
+
+  if (buckets.orphan.length > 0) {
+    console.log(`
+Refusing to apply: ${buckets.orphan.length} objects have no database row. They
+would stay on legacy paths that the Phase 3 policy denies. Move them under
+${QUARANTINE_PREFIX} (kept, unreachable) or delete them, then re-run.`)
+    process.exit(2)
   }
 
   if (buckets.unattributable.length > 0) {

--- a/scripts/sql/phase3-assets-bucket-org-rls.sql
+++ b/scripts/sql/phase3-assets-bucket-org-rls.sql
@@ -1,8 +1,18 @@
 -- ===========================================================================
 -- Phase 3: tenant-scope the `assets` storage bucket.
 --
--- DO NOT APPLY THIS YET, AND DO NOT MOVE IT INTO supabase/migrations/ UNTIL
--- THE PHASE 2 BACKFILL REPORTS ZERO UNATTRIBUTABLE AND ZERO LEGACY OBJECTS.
+-- STATUS: Phase 2 is DONE in production (2026-08-14). The bucket holds 6
+-- org-scoped objects and 3 quarantined ones; no database row points at a
+-- legacy path. This file is still not applied, for one reason only:
+--
+--   THE FRONTEND FIX IS NOT DEPLOYED YET. Production runs main, which still
+--   uploads to legacy paths like `documents/<assetId>/…`. The INSERT policy
+--   below would reject those, so applying this before main carries the
+--   org-scoped path helper breaks every upload in the product.
+--
+-- Apply only after the branch carrying src/lib/storage/asset-paths.ts is
+-- merged and deployed. Flip the `assets` bucket to private in the same
+-- window — it is still public, which is the remaining live exposure.
 --
 -- It lives here rather than in supabase/migrations/ specifically so that a
 -- `supabase db push` cannot pick it up by accident. Applying it before the
@@ -48,6 +58,11 @@ BEGIN
   SELECT count(*) INTO v_legacy
   FROM storage.objects
   WHERE bucket_id = 'assets'
+    -- `_unattributed/` is the quarantine prefix for objects no org could be
+    -- established for. They are kept deliberately and no policy below grants
+    -- access to them, so only the service role can reach them. Exempt from
+    -- the guard because they are a decided end state, not unfinished work.
+    AND (storage.foldername(name))[1] <> '_unattributed'
     AND (storage.foldername(name))[1] !~*
         '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$';
 

--- a/scripts/sql/phase3-assets-bucket-org-rls.sql
+++ b/scripts/sql/phase3-assets-bucket-org-rls.sql
@@ -1,0 +1,119 @@
+-- ===========================================================================
+-- Phase 3: tenant-scope the `assets` storage bucket.
+--
+-- DO NOT APPLY THIS YET, AND DO NOT MOVE IT INTO supabase/migrations/ UNTIL
+-- THE PHASE 2 BACKFILL REPORTS ZERO UNATTRIBUTABLE AND ZERO LEGACY OBJECTS.
+--
+-- It lives here rather than in supabase/migrations/ specifically so that a
+-- `supabase db push` cannot pick it up by accident. Applying it before the
+-- backfill completes makes every object still on a legacy path unreadable
+-- to everyone — models, note attachments, checklist evidence, all of it.
+--
+--   1. node scripts/backfill-assets-bucket-org-scope.mjs           (staging)
+--   2. read assets-backfill-report.json; resolve the unattributable set
+--   3. ... --apply                                                 (staging)
+--   4. re-run the dry run; confirm resolvable = 0 and orphan is understood
+--   5. apply this file to staging, exercise uploads/downloads/previews
+--   6. repeat 1-5 against production
+--   7. only then move this into supabase/migrations/ with a real timestamp
+--
+-- ===========================================================================
+--
+-- What it replaces. The bucket was created by
+-- 20251013115000_create_assets_storage_bucket.sql with:
+--
+--     CREATE POLICY "Authenticated users can read files"
+--     ON storage.objects FOR SELECT TO authenticated
+--     USING (bucket_id = 'assets');
+--
+-- The only condition is that the object is in the bucket. Any authenticated
+-- user of any organization could read every file any customer had ever
+-- uploaded. INSERT was equally open. This adds the tenant condition that was
+-- never there, matching the first path segment against the caller's current
+-- org — the same boundary the table policies already use.
+--
+-- The owner conditions on UPDATE and DELETE are preserved exactly as they
+-- were. This change is a pure tightening: nothing that was denied before is
+-- allowed now.
+-- ===========================================================================
+
+BEGIN;
+
+-- Fail loudly rather than half-applying if any object is still unscoped.
+-- storage.foldername() returns the folder segments, so [1] is the prefix.
+DO $$
+DECLARE
+  v_legacy bigint;
+BEGIN
+  SELECT count(*) INTO v_legacy
+  FROM storage.objects
+  WHERE bucket_id = 'assets'
+    AND (storage.foldername(name))[1] !~*
+        '^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$';
+
+  IF v_legacy > 0 THEN
+    RAISE EXCEPTION
+      'Refusing to apply: % objects in the assets bucket are still on legacy '
+      'paths and would become unreadable. Run the Phase 2 backfill first.',
+      v_legacy;
+  END IF;
+END $$;
+
+DROP POLICY IF EXISTS "Authenticated users can upload files" ON storage.objects;
+DROP POLICY IF EXISTS "Authenticated users can read files"   ON storage.objects;
+DROP POLICY IF EXISTS "Users can update their own files"     ON storage.objects;
+DROP POLICY IF EXISTS "Users can delete their own files"     ON storage.objects;
+
+CREATE POLICY "assets: read within current org"
+ON storage.objects FOR SELECT TO authenticated
+USING (
+  bucket_id = 'assets'
+  AND (storage.foldername(name))[1] = current_org_id()::text
+);
+
+CREATE POLICY "assets: upload within current org"
+ON storage.objects FOR INSERT TO authenticated
+WITH CHECK (
+  bucket_id = 'assets'
+  AND (storage.foldername(name))[1] = current_org_id()::text
+);
+
+CREATE POLICY "assets: update own files within current org"
+ON storage.objects FOR UPDATE TO authenticated
+USING (
+  bucket_id = 'assets'
+  AND (storage.foldername(name))[1] = current_org_id()::text
+  AND auth.uid()::text = owner
+);
+
+CREATE POLICY "assets: delete own files within current org"
+ON storage.objects FOR DELETE TO authenticated
+USING (
+  bucket_id = 'assets'
+  AND (storage.foldername(name))[1] = current_org_id()::text
+  AND auth.uid()::text = owner
+);
+
+COMMIT;
+
+-- ---------------------------------------------------------------------------
+-- Verification — run after applying. Both should return zero rows.
+-- ---------------------------------------------------------------------------
+--
+-- Objects whose prefix is not a real organization:
+--
+--   SELECT DISTINCT (storage.foldername(name))[1] AS prefix
+--   FROM storage.objects
+--   WHERE bucket_id = 'assets'
+--     AND (storage.foldername(name))[1] NOT IN (SELECT id::text FROM organizations);
+--
+-- Database rows still pointing at a legacy path:
+--
+--   SELECT 'asset_notes' AS src, file_path FROM asset_notes
+--     WHERE file_path IS NOT NULL AND file_path !~* '^[0-9a-f-]{36}/'
+--   UNION ALL SELECT 'asset_models', file_path FROM asset_models
+--     WHERE file_path IS NOT NULL AND file_path !~* '^[0-9a-f-]{36}/'
+--   UNION ALL SELECT 'model_versions', file_path FROM model_versions
+--     WHERE file_path IS NOT NULL AND file_path !~* '^[0-9a-f-]{36}/'
+--   UNION ALL SELECT 'model_templates', base_template_path FROM model_templates
+--     WHERE base_template_path IS NOT NULL AND base_template_path !~* '^[0-9a-f-]{36}/';

--- a/scripts/tenant-boundary-lint.mjs
+++ b/scripts/tenant-boundary-lint.mjs
@@ -220,9 +220,9 @@ const FK_CHAIN_TABLES = {
   asset_team_members:             'teams chain',
 
   // --- Asset models chain ---
-  asset_models:                   'RLS via user ownership',
+  // asset_models and model_versions moved off this list in 20260814100000 —
+  // they now carry organization_id directly and are categorized by it.
   model_files:                    'asset_models chain',
-  model_versions:                 'asset_models chain',
   model_template_collaborations:  'model_templates chain',
 
   // --- Asset lists chain ---
@@ -380,6 +380,12 @@ async function run() {
   const GRANDFATHERED_NULLABLE = new Set([
     'ai_column_library', 'coverage_settings', 'investment_case_templates',
     'model_templates', 'rating_scales', 'research_fields',
+    // 20260814100000 added organization_id to both. Nullable on purpose:
+    // legacy rows whose creator belongs to more than one org cannot be
+    // attributed, and NOT NULL would force a guess. They stay NULL and
+    // invisible until an admin assigns one — see that migration's
+    // verification queries. Drop from this list once those are resolved.
+    'asset_models', 'model_versions',
   ])
   const nullableOrgId = allTables.filter(
     t => t.has_org_id && t.org_id_nullable === 'YES' && !GRANDFATHERED_NULLABLE.has(t.table_name)

--- a/src/components/contributions/AddReferenceModal.tsx
+++ b/src/components/contributions/AddReferenceModal.tsx
@@ -18,6 +18,8 @@ import { useKeyReferences, type ReferenceCategory, type ReferenceImportance } fr
 import { useAssetModels, type AssetModel } from '../../hooks/useAssetModels'
 import { useAuth } from '../../hooks/useAuth'
 import { supabase } from '../../lib/supabase'
+import { useOrganizationOptional } from '../../contexts/OrganizationContext'
+import { assetsPath } from '../../lib/storage/asset-paths'
 import { useQuery } from '@tanstack/react-query'
 
 interface AddReferenceModalProps {
@@ -70,6 +72,10 @@ const EXTERNAL_PROVIDERS = [
 
 export function AddReferenceModal({ isOpen, onClose, assetId }: AddReferenceModalProps) {
   const { user } = useAuth()
+  // Optional on purpose: useOrganization() throws without a provider, and
+  // a throw in a leaf like this takes the whole surface down. A null org
+  // instead fails loudly at upload time, where assetsPath() rejects it.
+  const currentOrgId = useOrganizationOptional()?.currentOrgId ?? null
   const { createReference, isReferenced, isCreating } = useKeyReferences(assetId)
   const { models } = useAssetModels(assetId)
 
@@ -229,7 +235,7 @@ export function AddReferenceModal({ isOpen, onClose, assetId }: AddReferenceModa
       // Upload file
       const randomId = Math.random().toString(36).substring(2, 10)
       const extension = uploadedFile.name.split('.').pop() || 'bin'
-      const filePath = `references/${assetId}/${Date.now()}_${randomId}.${extension}`
+      const filePath = assetsPath(currentOrgId, 'references', assetId, `${Date.now()}_${randomId}.${extension}`)
 
       const { error: uploadError } = await supabase.storage
         .from('assets')

--- a/src/components/contributions/KeyReferencesSection.tsx
+++ b/src/components/contributions/KeyReferencesSection.tsx
@@ -53,6 +53,8 @@ import { useAssetModels, type AssetModel } from '../../hooks/useAssetModels'
 import { ExternalLinkModal } from '../notes/ExternalLinkModal'
 import { useAuth } from '../../hooks/useAuth'
 import { supabase } from '../../lib/supabase'
+import { useOrganizationOptional } from '../../contexts/OrganizationContext'
+import { assetsPath } from '../../lib/storage/asset-paths'
 import { useQueryClient } from '@tanstack/react-query'
 
 // ============================================================================
@@ -351,6 +353,10 @@ export function KeyReferencesSection({
   notes = []
 }: KeyReferencesSectionProps) {
   const { user } = useAuth()
+  // Optional on purpose: useOrganization() throws without a provider, and
+  // a throw in a leaf like this takes the whole surface down. A null org
+  // instead fails loudly at upload time, where assetsPath() rejects it.
+  const currentOrgId = useOrganizationOptional()?.currentOrgId ?? null
   const queryClient = useQueryClient()
   const fileInputRef = useRef<HTMLInputElement>(null)
   const dropZoneRef = useRef<HTMLDivElement>(null)
@@ -594,7 +600,7 @@ export function KeyReferencesSection({
       for (const file of Array.from(files)) {
         const randomId = Math.random().toString(36).substring(2, 10)
         const extension = file.name.split('.').pop() || 'bin'
-        const filePath = `documents/${assetId}/${Date.now()}_${randomId}.${extension}`
+        const filePath = assetsPath(currentOrgId, 'documents', assetId, `${Date.now()}_${randomId}.${extension}`)
 
         const { error: uploadError } = await supabase.storage
           .from('assets')

--- a/src/components/documents/DocumentLibrarySection.tsx
+++ b/src/components/documents/DocumentLibrarySection.tsx
@@ -28,6 +28,8 @@ import { BulkExcelImporter } from '../outcomes/BulkExcelImporter'
 import { useAssetModels, AssetModel } from '../../hooks/useAssetModels'
 import { useAuth } from '../../hooks/useAuth'
 import { supabase } from '../../lib/supabase'
+import { useOrganizationOptional } from '../../contexts/OrganizationContext'
+import { assetsPath } from '../../lib/storage/asset-paths'
 import { useQueryClient } from '@tanstack/react-query'
 import clsx from 'clsx'
 
@@ -197,6 +199,10 @@ export function DocumentLibrarySection({
   isEmbedded = false
 }: DocumentLibrarySectionProps) {
   const { user } = useAuth()
+  // Optional on purpose: useOrganization() throws without a provider, and
+  // a throw in a leaf like this takes the whole surface down. A null org
+  // instead fails loudly at upload time, where assetsPath() rejects it.
+  const currentOrgId = useOrganizationOptional()?.currentOrgId ?? null
   const queryClient = useQueryClient()
 
   // Models hook
@@ -340,7 +346,7 @@ export function DocumentLibrarySection({
     try {
       const randomId = Math.random().toString(36).substring(2, 10)
       const extension = file.name.split('.').pop() || 'bin'
-      const filePath = `documents/${assetId}/${Date.now()}_${randomId}.${extension}`
+      const filePath = assetsPath(currentOrgId, 'documents', assetId, `${Date.now()}_${randomId}.${extension}`)
 
       const { error: uploadError } = await supabase.storage
         .from('assets')

--- a/src/components/mobile/CaptureFilePicker.tsx
+++ b/src/components/mobile/CaptureFilePicker.tsx
@@ -4,6 +4,7 @@ import { clsx } from 'clsx'
 import { Check, Loader2, Search } from 'lucide-react'
 import { supabase } from '../../lib/supabase'
 import { useAuth } from '../../hooks/useAuth'
+import { useOrganizationOptional } from '../../contexts/OrganizationContext'
 
 interface CaptureFilePickerProps {
   target: 'list' | 'theme'
@@ -26,19 +27,23 @@ interface CaptureFilePickerProps {
  */
 export function CaptureFilePicker({ target, assetId, assetSymbol, onDone }: CaptureFilePickerProps) {
   const { user } = useAuth()
+  // created_by alone is not a tenant filter: a user in two orgs would be
+  // offered lists from both, in whichever one they happen to be capturing.
+  const currentOrgId = useOrganizationOptional()?.currentOrgId ?? null
   const queryClient = useQueryClient()
   const [query, setQuery] = useState('')
   const [justAdded, setJustAdded] = useState<string | null>(null)
 
   const { data: options = [], isLoading } = useQuery({
-    queryKey: ['capture-file-options', target, user?.id],
-    enabled: !!user?.id,
+    queryKey: ['capture-file-options', target, user?.id, currentOrgId],
+    enabled: !!user?.id && !!currentOrgId,
     staleTime: 60_000,
     queryFn: async () => {
       if (target === 'list') {
         const { data } = await supabase
           .from('asset_lists')
           .select('id, name, color')
+          .eq('organization_id', currentOrgId!)
           .eq('created_by', user!.id)
           .order('updated_at', { ascending: false })
           .limit(50)

--- a/src/components/notes/NotesModelsSection.tsx
+++ b/src/components/notes/NotesModelsSection.tsx
@@ -10,6 +10,8 @@ import { BulkExcelImporter } from '../outcomes/BulkExcelImporter'
 import { useAssetModels, AssetModel } from '../../hooks/useAssetModels'
 import { useAuth } from '../../hooks/useAuth'
 import { supabase } from '../../lib/supabase'
+import { useOrganizationOptional } from '../../contexts/OrganizationContext'
+import { assetsPath } from '../../lib/storage/asset-paths'
 import { useQueryClient } from '@tanstack/react-query'
 import clsx from 'clsx'
 
@@ -35,6 +37,10 @@ export function NotesModelsSection({
   onViewAllNotes
 }: NotesModelsSectionProps) {
   const { user } = useAuth()
+  // Optional on purpose: useOrganization() throws without a provider, and
+  // a throw in a leaf like this takes the whole surface down. A null org
+  // instead fails loudly at upload time, where assetsPath() rejects it.
+  const currentOrgId = useOrganizationOptional()?.currentOrgId ?? null
   const queryClient = useQueryClient()
 
   // Models hook
@@ -119,7 +125,7 @@ export function NotesModelsSection({
       // Generate unique file path
       const randomId = Math.random().toString(36).substring(2, 10)
       const extension = file.name.split('.').pop() || 'bin'
-      const filePath = `notes/${assetId}/${Date.now()}_${randomId}.${extension}`
+      const filePath = assetsPath(currentOrgId, 'notes', assetId, `${Date.now()}_${randomId}.${extension}`)
 
       // Upload file to Supabase Storage
       const { error: uploadError } = await supabase.storage

--- a/src/components/research/InvestmentCaseBuilder.tsx
+++ b/src/components/research/InvestmentCaseBuilder.tsx
@@ -31,6 +31,8 @@ import { useAuth } from '../../hooks/useAuth'
 import { useAnalystRatings } from '../../hooks/useAnalystRatings'
 import { useAnalystPriceTargets } from '../../hooks/useAnalystPriceTargets'
 import { supabase } from '../../lib/supabase'
+import { useOrganizationOptional } from '../../contexts/OrganizationContext'
+import { assetsPath } from '../../lib/storage/asset-paths'
 import { SLUG_TO_SECTION } from '../../lib/research/contribution-sections'
 import { useQueryClient } from '@tanstack/react-query'
 import { InvestmentCaseTemplateSelector, InvestmentCaseTemplateEditor } from '../investment-case-templates'
@@ -101,6 +103,10 @@ export function InvestmentCaseBuilder({
   onClose
 }: InvestmentCaseBuilderProps) {
   const { user } = useAuth()
+  // Optional on purpose: useOrganization() throws without a provider, and
+  // a throw in a leaf like this takes the whole surface down. A null org
+  // instead fails loudly at upload time, where assetsPath() rejects it.
+  const currentOrgId = useOrganizationOptional()?.currentOrgId ?? null
   const queryClient = useQueryClient()
   const { displayedFieldsBySection, isLoading } = useUserAssetPagePreferences(assetId)
   const { contributions } = useContributions({ assetId })
@@ -780,7 +786,7 @@ export function InvestmentCaseBuilder({
         try {
           const blob = pdf.output('blob')
           const randomId = Math.random().toString(36).substring(2, 10)
-          const storagePath = `documents/${assetId}/${Date.now()}_${randomId}.pdf`
+          const storagePath = assetsPath(currentOrgId, 'documents', assetId, `${Date.now()}_${randomId}.pdf`)
 
           const { error: uploadError } = await supabase.storage
             .from('assets')

--- a/src/components/rich-text-editor/extensions/FileAttachmentExtension.tsx
+++ b/src/components/rich-text-editor/extensions/FileAttachmentExtension.tsx
@@ -8,6 +8,8 @@ import {
 } from 'lucide-react'
 import { clsx } from 'clsx'
 import { supabase } from '../../../lib/supabase'
+import { useOrganizationOptional } from '../../../contexts/OrganizationContext'
+import { assetsPath } from '../../../lib/storage/asset-paths'
 // XLSX is lazy loaded to reduce bundle size
 
 // Debounce helper
@@ -518,6 +520,66 @@ function FileAttachmentView({ node, updateAttributes, deleteNode, selected }: No
   const [error, setError] = useState<string | null>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const uploadStartedRef = useRef(false)
+  // Optional on purpose: useOrganization() throws without a provider, and
+  // a throw in a leaf like this takes the whole surface down. A null org
+  // instead fails loudly at upload time, where assetsPath() rejects it.
+  const currentOrgId = useOrganizationOptional()?.currentOrgId ?? null
+
+  // The URL used to preview, open and download this attachment.
+  //
+  // This was previously a getPublicUrl() result persisted into the node's
+  // attributes and saved inside the note. Two things were wrong with that:
+  // the `assets` bucket is private, so the URL 400'd and every preview here
+  // was dead; and had the bucket ever been made public, a permanent
+  // unauthenticated link to the file would have been sitting in the note
+  // body forever. Signed URLs cannot be persisted — they expire — which is
+  // exactly why deriving one at render from `filePath` is the correct shape.
+  const [signedUrl, setSignedUrl] = useState<string | null>(null)
+  const filePath: string | null = node.attrs.filePath ?? null
+
+  useEffect(() => {
+    if (!filePath) {
+      setSignedUrl(null)
+      return
+    }
+
+    let cancelled = false
+    let refreshTimer: ReturnType<typeof setTimeout>
+
+    const sign = async () => {
+      const { data, error: signError } = await supabase.storage
+        .from('assets')
+        .createSignedUrl(filePath, 3600)
+
+      if (cancelled) return
+
+      if (signError || !data?.signedUrl) {
+        setSignedUrl(null)
+        return
+      }
+
+      setSignedUrl(data.signedUrl)
+      // Refresh before the hour is up so a long editing session doesn't
+      // leave a stale link behind a preview iframe.
+      refreshTimer = setTimeout(sign, 50 * 60 * 1000)
+    }
+
+    sign()
+
+    return () => {
+      cancelled = true
+      clearTimeout(refreshTimer)
+    }
+  }, [filePath])
+
+  // Legacy notes stored a (broken) public URL and no filePath. Fall back to it
+  // so those nodes keep whatever behaviour they had rather than losing the
+  // download button entirely.
+  const fileUrl: string | null = signedUrl ?? node.attrs.fileUrl ?? null
+  // Upload completion is keyed on filePath, not fileUrl: fileUrl is no longer
+  // written on upload, so using it as the sentinel would leave the node stuck
+  // in its uploading state forever.
+  const hasUploadedFile = Boolean(filePath || node.attrs.fileUrl)
 
   // Local state - initialized once from node attributes, never synced back
   // This prevents save operations from resetting the UI state
@@ -581,7 +643,13 @@ function FileAttachmentView({ node, updateAttributes, deleteNode, selected }: No
       const timestamp = Date.now()
       const randomId = Math.random().toString(36).substring(2, 9)
       const extension = file.name.split('.').pop() || 'bin'
-      const filePath = `attachments/${node.attrs.contextType || 'general'}/${node.attrs.contextId || 'shared'}/${timestamp}_${randomId}.${extension}`
+      const filePath = assetsPath(
+        currentOrgId,
+        'attachments',
+        node.attrs.contextType || 'general',
+        node.attrs.contextId || 'shared',
+        `${timestamp}_${randomId}.${extension}`
+      )
 
       setUploadProgress(30)
 
@@ -602,23 +670,16 @@ function FileAttachmentView({ node, updateAttributes, deleteNode, selected }: No
 
       if (uploadError) throw uploadError
 
-      setUploadProgress(90)
-
-      // Get public URL
-      const { data: urlData } = supabase.storage
-        .from('assets')
-        .getPublicUrl(filePath)
-
       setUploadProgress(100)
 
-      // Update attributes
+      // Update attributes. `fileUrl` is deliberately not written — the
+      // signing effect derives a fresh URL from filePath on every mount.
       updateAttributes({
         fileId: data.path,
         fileName: file.name,
         fileSize: file.size,
         fileType: file.type || 'application/octet-stream',
         filePath: filePath,
-        fileUrl: urlData.publicUrl,
         pendingUploadId: null
       })
     } catch (err: any) {
@@ -655,7 +716,7 @@ function FileAttachmentView({ node, updateAttributes, deleteNode, selected }: No
   useEffect(() => {
     const pendingUploadId = node.attrs.pendingUploadId
 
-    if (!pendingUploadId || node.attrs.fileUrl || uploadStartedRef.current) {
+    if (!pendingUploadId || hasUploadedFile || uploadStartedRef.current) {
       return
     }
 
@@ -681,7 +742,7 @@ function FileAttachmentView({ node, updateAttributes, deleteNode, selected }: No
 
     // Timeout to prevent infinite spinning - if no upload starts in 5 seconds, show error
     const failsafeTimeout = setTimeout(() => {
-      if (!uploadStartedRef.current && !node.attrs.fileUrl) {
+      if (!uploadStartedRef.current && !hasUploadedFile) {
         setError('Upload timed out. Please try again.')
       }
     }, 5000)
@@ -690,7 +751,7 @@ function FileAttachmentView({ node, updateAttributes, deleteNode, selected }: No
       clearTimeout(timeoutId)
       clearTimeout(failsafeTimeout)
     }
-  }, [node.attrs.pendingUploadId, node.attrs.fileUrl, uploadFile])
+  }, [node.attrs.pendingUploadId, hasUploadedFile, uploadFile])
 
   const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
@@ -701,14 +762,14 @@ function FileAttachmentView({ node, updateAttributes, deleteNode, selected }: No
 
   const handleOpenInNewTab = (e: React.MouseEvent) => {
     e.stopPropagation()
-    if (node.attrs.fileUrl) {
-      window.open(node.attrs.fileUrl, '_blank')
+    if (fileUrl) {
+      window.open(fileUrl, '_blank')
     }
   }
 
   const handleDownload = async (e: React.MouseEvent) => {
     e.stopPropagation()
-    if (!node.attrs.filePath && !node.attrs.fileUrl) return
+    if (!filePath && !fileUrl) return
 
     const fileName = node.attrs.fileName || 'download'
 
@@ -716,15 +777,15 @@ function FileAttachmentView({ node, updateAttributes, deleteNode, selected }: No
       let blob: Blob
 
       // Try using Supabase storage download first
-      if (node.attrs.filePath) {
+      if (filePath) {
         const { data, error } = await supabase.storage
           .from('assets')
-          .download(node.attrs.filePath)
+          .download(filePath)
 
         if (error) throw error
         blob = data
       } else {
-        const response = await fetch(node.attrs.fileUrl, { mode: 'cors' })
+        const response = await fetch(fileUrl!, { mode: 'cors' })
         if (!response.ok) throw new Error('Fetch failed')
         blob = await response.blob()
       }
@@ -733,7 +794,7 @@ function FileAttachmentView({ node, updateAttributes, deleteNode, selected }: No
       saveFile(blob, fileName, node.attrs.fileType)
     } catch (err) {
       console.error('Download failed:', err)
-      window.open(node.attrs.fileUrl, '_blank')
+      if (fileUrl) window.open(fileUrl, '_blank')
     }
   }
 
@@ -797,7 +858,7 @@ function FileAttachmentView({ node, updateAttributes, deleteNode, selected }: No
   }, [handleToggleExpand])
 
   // Show uploading state
-  if (isUploading || (node.attrs.pendingUploadId && !node.attrs.fileUrl && !error)) {
+  if (isUploading || (node.attrs.pendingUploadId && !hasUploadedFile && !error)) {
     return (
       <NodeViewWrapper className="file-attachment-wrapper my-1" data-drag-handle>
         <div className="inline-flex items-center gap-2 px-2 py-1 rounded bg-gray-50 border border-gray-200 max-w-md dark:border-gray-700 dark:bg-gray-900">
@@ -846,7 +907,7 @@ function FileAttachmentView({ node, updateAttributes, deleteNode, selected }: No
   }
 
   // Show upload UI if no file attached yet
-  if (!node.attrs.fileUrl) {
+  if (!hasUploadedFile) {
     return (
       <NodeViewWrapper className="file-attachment-wrapper my-1" data-drag-handle>
         <div
@@ -959,7 +1020,7 @@ function FileAttachmentView({ node, updateAttributes, deleteNode, selected }: No
           <>
             {category === 'spreadsheet' && (
               <ExcelPreview
-                fileUrl={node.attrs.fileUrl}
+                fileUrl={fileUrl ?? ''}
                 width={localWidth}
                 height={localHeight}
                 onSizeChange={handlePreviewSizeChange}
@@ -967,7 +1028,7 @@ function FileAttachmentView({ node, updateAttributes, deleteNode, selected }: No
             )}
             {category === 'image' && (
               <ImagePreview
-                fileUrl={node.attrs.fileUrl}
+                fileUrl={fileUrl ?? ''}
                 fileName={node.attrs.fileName}
                 width={localWidth}
                 height={localHeight}
@@ -976,7 +1037,7 @@ function FileAttachmentView({ node, updateAttributes, deleteNode, selected }: No
             )}
             {category === 'document' && (
               <DocumentPreview
-                fileUrl={node.attrs.fileUrl}
+                fileUrl={fileUrl ?? ''}
                 fileName={node.attrs.fileName}
                 fileType={node.attrs.fileType}
                 width={localWidth}

--- a/src/components/rich-text-editor/extensions/capture/CaptureView.tsx
+++ b/src/components/rich-text-editor/extensions/capture/CaptureView.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useCallback } from 'react'
+import React, { useState, useCallback, useEffect } from 'react'
 import { NodeViewWrapper, NodeViewProps } from '@tiptap/react'
+import { supabase } from '../../../../lib/supabase'
 import {
   Link2, Image, Camera, ExternalLink, ChevronDown, ChevronRight,
   X, MoreHorizontal, RefreshCw, Clock, TrendingUp, Building2,
@@ -72,6 +73,50 @@ export function CaptureView({ node, updateAttributes, deleteNode, selected }: Ca
     deleteNode()
   }, [deleteNode])
 
+  // Screenshot URL. The node stores the storage path, never a URL: a public
+  // URL would outlive the note it was embedded in and stay fetchable by
+  // anyone who had ever seen it. Signed URLs expire, so we mint one per
+  // mount and refresh it well before the hour is up.
+  const [screenshotUrl, setScreenshotUrl] = useState<string | null>(null)
+  const [screenshotError, setScreenshotError] = useState(false)
+
+  useEffect(() => {
+    if (!screenshotPath) {
+      setScreenshotUrl(null)
+      return
+    }
+
+    let cancelled = false
+    let refreshTimer: ReturnType<typeof setTimeout>
+
+    const sign = async () => {
+      const { data, error } = await supabase.storage
+        .from('captures')
+        .createSignedUrl(screenshotPath, 3600)
+
+      if (cancelled) return
+
+      if (error || !data?.signedUrl) {
+        setScreenshotError(true)
+        setScreenshotUrl(null)
+        return
+      }
+
+      setScreenshotError(false)
+      setScreenshotUrl(data.signedUrl)
+      // Re-sign at 50 minutes so a note left open all afternoon doesn't
+      // silently turn into a broken image.
+      refreshTimer = setTimeout(sign, 50 * 60 * 1000)
+    }
+
+    sign()
+
+    return () => {
+      cancelled = true
+      clearTimeout(refreshTimer)
+    }
+  }, [screenshotPath])
+
   // Get entity config if this is an entity capture
   const entityConfig = entityType ? ENTITY_CONFIG[entityType as CaptureEntityType] : null
   const captureConfig = CAPTURE_TYPE_CONFIG[captureType as CaptureType]
@@ -121,8 +166,7 @@ export function CaptureView({ node, updateAttributes, deleteNode, selected }: Ca
   }
 
   const renderScreenshotCapture = () => {
-    // TODO: Get public URL from Supabase storage
-    const imageUrl = screenshotPath ? `${process.env.VITE_SUPABASE_URL}/storage/v1/object/public/captures/${screenshotPath}` : null
+    const imageUrl = screenshotUrl
 
     return (
       <div className="flex flex-col">
@@ -169,14 +213,30 @@ export function CaptureView({ node, updateAttributes, deleteNode, selected }: Ca
         </div>
 
         {/* Expanded content */}
-        {localExpanded && imageUrl && (
+        {localExpanded && (
           <div className="p-4 bg-white rounded-b-lg dark:bg-gray-800">
-            <img
-              src={imageUrl}
-              alt={displayTitle || 'Screenshot'}
-              className="max-w-full rounded-lg border border-gray-200 dark:border-gray-700"
-              style={{ maxWidth: previewWidth, maxHeight: previewHeight }}
-            />
+            {imageUrl ? (
+              <img
+                src={imageUrl}
+                alt={displayTitle || 'Screenshot'}
+                className="max-w-full rounded-lg border border-gray-200 dark:border-gray-700"
+                style={{ maxWidth: previewWidth, maxHeight: previewHeight }}
+              />
+            ) : (
+              <div className="flex items-center gap-2 px-3 py-6 justify-center rounded-lg border border-dashed border-gray-200 text-xs text-gray-400 dark:border-gray-700">
+                {screenshotError ? (
+                  <>
+                    <X className="h-3.5 w-3.5" />
+                    Screenshot unavailable
+                  </>
+                ) : (
+                  <>
+                    <RefreshCw className="h-3.5 w-3.5 animate-spin" />
+                    Loading screenshot…
+                  </>
+                )}
+              </div>
+            )}
             {screenshotNotes && (
               <p className="mt-3 text-sm text-gray-600 dark:text-gray-400">{screenshotNotes}</p>
             )}

--- a/src/components/thoughts/QuickThoughtCapture.tsx
+++ b/src/components/thoughts/QuickThoughtCapture.tsx
@@ -17,7 +17,11 @@ import type { CapturedContext } from './ContextSelector'
 
 interface Attachment {
   name: string
-  url: string
+  /** Storage path inside the `thought-attachments` bucket — never a URL.
+   *  A public URL persisted here would outlive the thought and stay
+   *  fetchable by anyone who ever saw it, including after deletion.
+   *  Callers that need to display the file sign this path on demand. */
+  path: string
   type: string
   size: number
 }
@@ -376,7 +380,7 @@ export function QuickThoughtCapture({
         const fileName = `${user.id}/${Date.now()}-${Math.random().toString(36).substring(7)}.${fileExt}`
 
         // Upload to Supabase storage
-        const { data, error } = await supabase.storage
+        const { error } = await supabase.storage
           .from('thought-attachments')
           .upload(fileName, file)
 
@@ -385,14 +389,9 @@ export function QuickThoughtCapture({
           continue
         }
 
-        // Get public URL
-        const { data: urlData } = supabase.storage
-          .from('thought-attachments')
-          .getPublicUrl(fileName)
-
         newAttachments.push({
           name: file.name,
-          url: urlData.publicUrl,
+          path: fileName,
           type: file.type,
           size: file.size,
         })
@@ -410,8 +409,16 @@ export function QuickThoughtCapture({
     }
   }
 
-  const removeAttachment = (url: string) => {
-    setAttachments(prev => prev.filter(a => a.url !== url))
+  // Removing an attachment before the thought is posted also deletes the
+  // uploaded object. Without this the file stays in the bucket forever with
+  // nothing in the database pointing at it — invisible, undeletable, and
+  // still counted as data we hold on the user's behalf.
+  const removeAttachment = (path: string) => {
+    setAttachments(prev => prev.filter(a => a.path !== path))
+    void supabase.storage.from('thought-attachments').remove([path])
+      .then(({ error }) => {
+        if (error) console.error('Failed to remove orphaned attachment:', error)
+      })
   }
 
   const getFileIcon = (type: string) => {
@@ -763,14 +770,14 @@ export function QuickThoughtCapture({
                 const FileIcon = getFileIcon(attachment.type)
                 return (
                   <div
-                    key={attachment.url}
+                    key={attachment.path}
                     className="flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] bg-blue-50 text-blue-700 border border-blue-200"
                   >
                     <FileIcon className="h-2.5 w-2.5" />
                     <span className="max-w-[100px] truncate">{attachment.name}</span>
                     <span className="text-blue-400">({formatFileSize(attachment.size)})</span>
                     <button
-                      onClick={() => removeAttachment(attachment.url)}
+                      onClick={() => removeAttachment(attachment.path)}
                       className="ml-0.5 hover:text-red-600"
                     >
                       <X className="h-2.5 w-2.5" />

--- a/src/components/ui/checklist/DecisionItemCard.tsx
+++ b/src/components/ui/checklist/DecisionItemCard.tsx
@@ -15,6 +15,8 @@ import {
 } from 'lucide-react'
 import { supabase } from '../../../lib/supabase'
 import { useSidebarStore } from '../../../stores/sidebarStore'
+import { useOrganizationOptional } from '../../../contexts/OrganizationContext'
+import { assetsPath } from '../../../lib/storage/asset-paths'
 import { MentionInput } from '../MentionInput'
 import { WorkRequestModal } from './WorkRequestModal'
 import {
@@ -93,6 +95,10 @@ export function DecisionItemCard({
   const attachTable = scopeType === 'portfolio' ? 'portfolio_checklist_attachments' : 'asset_checklist_attachments'
   const scopeIdField = scopeType === 'portfolio' ? 'portfolio_id' : 'asset_id'
   const qc = useQueryClient()
+  // Optional on purpose: useOrganization() throws without a provider, and
+  // a throw in a leaf like this takes the whole surface down. A null org
+  // instead fails loudly at upload time, where assetsPath() rejects it.
+  const currentOrgId = useOrganizationOptional()?.currentOrgId ?? null
   const openInspector = useSidebarStore(s => s.openInspector)
   const status = item.status || (item.completed ? 'completed' : 'unchecked')
 
@@ -302,7 +308,7 @@ export function DecisionItemCard({
   const uploadEvidenceM = useMutation({
     mutationFn: async ({ file, evidenceType: et, description }: { file: File; evidenceType: EvidenceType; description: string }) => {
       if (!currentUser) throw new Error('No user')
-      const filePath = `${assetId}/${workflowId}/${stageId}/${item.id}/${Date.now()}_${file.name}`
+      const filePath = assetsPath(currentOrgId, assetId, workflowId, stageId, item.id, `${Date.now()}_${file.name}`)
       const { error: upErr } = await supabase.storage.from('assets').upload(filePath, file)
       if (upErr) throw upErr
       const insertRow: any = {

--- a/src/components/ui/checklist/OperationalItemCard.tsx
+++ b/src/components/ui/checklist/OperationalItemCard.tsx
@@ -14,6 +14,8 @@ import {
 } from 'lucide-react'
 import { supabase } from '../../../lib/supabase'
 import { useOrgMembers } from '../../../hooks/useOrgMembers'
+import { useOrganizationOptional } from '../../../contexts/OrganizationContext'
+import { assetsPath } from '../../../lib/storage/asset-paths'
 import {
   ChecklistItemData,
   userName, userInitials, avatarColor, relativeTime,
@@ -46,6 +48,10 @@ export function OperationalItemCard({
   const attachTable = scopeType === 'portfolio' ? 'portfolio_checklist_attachments' : 'asset_checklist_attachments'
   const scopeIdField = scopeType === 'portfolio' ? 'portfolio_id' : 'asset_id'
   const qc = useQueryClient()
+  // Optional on purpose: useOrganization() throws without a provider, and
+  // a throw in a leaf like this takes the whole surface down. A null org
+  // instead fails loudly at upload time, where assetsPath() rejects it.
+  const currentOrgId = useOrganizationOptional()?.currentOrgId ?? null
   const status = item.status || (item.completed ? 'completed' : 'unchecked')
   const fileInputRef = useRef<HTMLInputElement>(null)
 
@@ -158,7 +164,7 @@ export function OperationalItemCard({
   const uploadFileM = useMutation({
     mutationFn: async (file: File) => {
       if (!currentUser) throw new Error('No user')
-      const filePath = `${assetId}/${workflowId}/${stageId}/${item.id}/${Date.now()}_${file.name}`
+      const filePath = assetsPath(currentOrgId, assetId, workflowId, stageId, item.id, `${Date.now()}_${file.name}`)
       const { error: upErr } = await supabase.storage.from('assets').upload(filePath, file)
       if (upErr) throw upErr
       const insertRow: any = {

--- a/src/hooks/useAssetModels.ts
+++ b/src/hooks/useAssetModels.ts
@@ -1,6 +1,8 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../lib/supabase'
 import { useAuth } from './useAuth'
+import { useOrganizationOptional } from '../contexts/OrganizationContext'
+import { assetsPath } from '../lib/storage/asset-paths'
 
 export type ModelSourceType = 'uploaded' | 'external_link'
 export type ExternalProvider = 'google_sheets' | 'airtable' | 'excel_online' | 'smartsheet' | 'other'
@@ -76,6 +78,10 @@ interface UpdateModelData {
 
 export function useAssetModels(assetId: string | undefined) {
   const { user } = useAuth()
+  // Optional on purpose: useOrganization() throws without a provider, and
+  // a throw in a leaf like this takes the whole surface down. A null org
+  // instead fails loudly at upload time, where assetsPath() rejects it.
+  const currentOrgId = useOrganizationOptional()?.currentOrgId ?? null
   const queryClient = useQueryClient()
 
   // Fetch all models for an asset
@@ -153,7 +159,7 @@ export function useAssetModels(assetId: string | undefined) {
       // Generate unique file path
       const randomId = Math.random().toString(36).substring(2, 10)
       const extension = file.name.split('.').pop() || 'bin'
-      const filePath = `models/${assetId}/${Date.now()}_${randomId}.${extension}`
+      const filePath = assetsPath(currentOrgId, 'models', assetId, `${Date.now()}_${randomId}.${extension}`)
 
       // Upload file to Supabase Storage
       const { error: uploadError } = await supabase.storage
@@ -314,7 +320,7 @@ export function useAssetModels(assetId: string | undefined) {
       // Upload new file
       const randomId = Math.random().toString(36).substring(2, 10)
       const extension = file.name.split('.').pop() || 'bin'
-      const filePath = `models/${assetId}/${Date.now()}_${randomId}.${extension}`
+      const filePath = assetsPath(currentOrgId, 'models', assetId, `${Date.now()}_${randomId}.${extension}`)
 
       const { error: uploadError } = await supabase.storage
         .from('assets')
@@ -403,7 +409,7 @@ export function useAssetModels(assetId: string | undefined) {
       // Copy the old version file to a new path
       const randomId = Math.random().toString(36).substring(2, 10)
       const extension = version.file_name.split('.').pop() || 'bin'
-      const newFilePath = `models/${currentModel.asset_id}/${Date.now()}_${randomId}_restored.${extension}`
+      const newFilePath = assetsPath(currentOrgId, 'models', currentModel.asset_id, `${Date.now()}_${randomId}_restored.${extension}`)
 
       // Download old file and re-upload
       const { data: fileData, error: downloadError } = await supabase.storage

--- a/src/hooks/useAssetModels.ts
+++ b/src/hooks/useAssetModels.ts
@@ -115,6 +115,7 @@ export function useAssetModels(assetId: string | undefined) {
         .from('asset_models')
         .insert({
           asset_id: data.asset_id,
+          organization_id: currentOrgId,
           name: data.name,
           description: data.description || null,
           source_type: data.source_type,
@@ -173,6 +174,7 @@ export function useAssetModels(assetId: string | undefined) {
         .from('asset_models')
         .insert({
           asset_id: assetId,
+          organization_id: currentOrgId,
           name,
           description: description || null,
           source_type: 'uploaded',
@@ -305,6 +307,7 @@ export function useAssetModels(assetId: string | undefined) {
           .from('model_versions')
           .insert({
             model_id: modelId,
+            organization_id: currentOrgId,
             version_number: currentModel.version,
             file_path: currentModel.file_path,
             file_name: currentModel.file_name,
@@ -396,6 +399,7 @@ export function useAssetModels(assetId: string | undefined) {
           .from('model_versions')
           .insert({
             model_id: modelId,
+            organization_id: currentOrgId,
             version_number: currentModel.version,
             file_path: currentModel.file_path,
             file_name: currentModel.file_name,

--- a/src/hooks/useCapture.ts
+++ b/src/hooks/useCapture.ts
@@ -227,12 +227,15 @@ export function useCapture() {
     return path
   }
 
-  // Get public URL for screenshot
-  const getScreenshotUrl = (path: string): string => {
-    const { data } = supabase.storage
+  // Get a time-limited URL for a screenshot. Deliberately not getPublicUrl:
+  // captures contain whatever the user had on screen, so a link that works
+  // forever for anyone who has it is not an acceptable default.
+  const getScreenshotUrl = async (path: string): Promise<string | null> => {
+    const { data, error } = await supabase.storage
       .from('captures')
-      .getPublicUrl(path)
-    return data.publicUrl
+      .createSignedUrl(path, 3600)
+    if (error) return null
+    return data?.signedUrl ?? null
   }
 
   return {

--- a/src/hooks/useExploreSearch.ts
+++ b/src/hooks/useExploreSearch.ts
@@ -1,5 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../lib/supabase'
+import { useOrganizationOptional } from '../contexts/OrganizationContext'
 
 /**
  * Keyword search across *content*, not just object names.
@@ -70,10 +71,15 @@ function recencyBonus(iso: string | null | undefined): number {
 
 export function useExploreSearch(query: string, options?: { enabled?: boolean }) {
   const term = safe(query)
+  const currentOrgId = useOrganizationOptional()?.currentOrgId ?? null
 
   return useQuery<ExploreResult[]>({
-    queryKey: ['explore-search', term],
-    enabled: (options?.enabled ?? true) && term.length >= 2,
+    queryKey: ['explore-search', term, currentOrgId],
+    // Gated on the org as well as the term: asset_lists and trade_queue_items
+    // have no org-aware RLS, so the filters below are the only thing keeping
+    // one workspace's lists and ideas out of another's search results. Running
+    // this before the org resolves would return everything.
+    enabled: (options?.enabled ?? true) && term.length >= 2 && !!currentOrgId,
     staleTime: 60_000,
     queryFn: async () => {
       const like = `%${term}%`
@@ -90,6 +96,7 @@ export function useExploreSearch(query: string, options?: { enabled?: boolean })
           .limit(15),
         supabase.from('asset_lists')
           .select('id, name, description, brief, updated_at')
+          .eq('organization_id', currentOrgId!)
           .or(`name.ilike.${like},description.ilike.${like},brief.ilike.${like}`)
           .limit(15),
         supabase.from('portfolio_notes')
@@ -99,6 +106,7 @@ export function useExploreSearch(query: string, options?: { enabled?: boolean })
           .limit(15),
         supabase.from('trade_queue_items')
           .select('id, rationale, thesis_text, updated_at, asset_id, assets(id, symbol, company_name)')
+          .eq('organization_id', currentOrgId!)
           .or(`rationale.ilike.${like},thesis_text.ilike.${like}`)
           .limit(15),
       ])

--- a/src/hooks/useModelTemplates.ts
+++ b/src/hooks/useModelTemplates.ts
@@ -1,6 +1,8 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { supabase } from '../lib/supabase'
 import { useAuth } from './useAuth'
+import { useOrganizationOptional } from '../contexts/OrganizationContext'
+import { assetsPath } from '../lib/storage/asset-paths'
 
 export interface FieldMapping {
   field: string // tesseract field name: price_target, rating, eps_fy25, etc.
@@ -130,6 +132,10 @@ const getFullName = (user: { first_name?: string | null; last_name?: string | nu
 
 export function useModelTemplates() {
   const { user } = useAuth()
+  // Optional on purpose: useOrganization() throws without a provider, and
+  // a throw in a leaf like this takes the whole surface down. A null org
+  // instead fails loudly at upload time, where assetsPath() rejects it.
+  const currentOrgId = useOrganizationOptional()?.currentOrgId ?? null
   const queryClient = useQueryClient()
 
   const {
@@ -379,7 +385,7 @@ export function useModelTemplates() {
           // Generate new path for the copy
           const randomId = Math.random().toString(36).substring(2, 10)
           const extension = template.base_template_filename.split('.').pop() || 'xlsx'
-          const newStoragePath = `model-templates/${newTemplate.id}/${Date.now()}_${randomId}.${extension}`
+          const newStoragePath = assetsPath(currentOrgId, 'model-templates', newTemplate.id, `${Date.now()}_${randomId}.${extension}`)
 
           // Use Supabase's copy method to copy the file server-side
           // Note: Files are stored in the 'assets' bucket
@@ -436,7 +442,7 @@ export function useModelTemplates() {
       const extension = file.name.split('.').pop() || 'xlsx'
 
       // Use same pattern as other working uploads (models, documents, notes)
-      const storagePath = `model-templates/${templateId}/${Date.now()}_${randomId}.${extension}`
+      const storagePath = assetsPath(currentOrgId, 'model-templates', templateId, `${Date.now()}_${randomId}.${extension}`)
 
       // Get auth session for manual upload
       const { data: { session } } = await supabase.auth.getSession()

--- a/src/hooks/useObjectSearch.ts
+++ b/src/hooks/useObjectSearch.ts
@@ -147,8 +147,13 @@ export function useObjectSearch(debouncedQuery: string) {
         const rpcPortfolios: any[] = data?.portfolios || []
         const rpcIds = new Set(rpcPortfolios.map((p: any) => p.id))
 
-        // Also search by portfolio_id mnemonic (RPC only searches name)
+        // Also search by portfolio_id mnemonic (RPC only searches name).
+        // An explicit .eq('organization_id') would be *narrower* than the
+        // policy and would hide legacy rows carrying team_id with a null
+        // organization_id.
         const { data: mnemonicHits } = await supabase
+          // org-scope-exempt: portfolios RLS is genuinely org-aware
+          // ("Org members can view portfolios in current org"), unlike asset_lists.
           .from('portfolios')
           .select('id, name, description, benchmark, portfolio_id')
           .ilike('portfolio_id', `%${debouncedQuery.trim()}%`)

--- a/src/lib/org-scope/known-unscoped-queries.json
+++ b/src/lib/org-scope/known-unscoped-queries.json
@@ -34,7 +34,6 @@
   "src/components/projects/RecentProjectActivity.tsx",
   "src/components/projects/UpcomingDeadlines.tsx",
   "src/components/research/InvestmentCaseBuilder.tsx",
-  "src/components/search/GlobalSearch.tsx",
   "src/components/table/AssetTableView.tsx",
   "src/components/tabs/AssetTab.tsx",
   "src/components/tabs/ListTab.tsx",

--- a/src/lib/storage/asset-paths.test.ts
+++ b/src/lib/storage/asset-paths.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest'
+import {
+  assetsPath,
+  orgOfAssetsPath,
+  isOrgScopedAssetsPath,
+  MissingOrgScopeError,
+} from './asset-paths'
+
+const ORG = '3f2504e0-4f89-11d3-9a0c-0305e82c3301'
+const ASSET = '7c9e6679-7425-40de-944b-e07fc1f90ae7'
+
+describe('assetsPath', () => {
+  it('puts the org first — that segment is the tenant boundary', () => {
+    expect(assetsPath(ORG, 'models', ASSET, 'f.xlsx')).toBe(`${ORG}/models/${ASSET}/f.xlsx`)
+  })
+
+  it('refuses to build a path without an org', () => {
+    // Uploading to an unscoped path would succeed and then be unreadable
+    // under the org-prefix policy, so this has to fail loudly at the source.
+    expect(() => assetsPath(null, 'models', ASSET)).toThrow(MissingOrgScopeError)
+    expect(() => assetsPath(undefined, 'models')).toThrow(MissingOrgScopeError)
+    expect(() => assetsPath('', 'models')).toThrow(MissingOrgScopeError)
+  })
+
+  it('keeps a user-supplied filename from escaping into extra nesting', () => {
+    // DecisionItemCard interpolates file.name straight into the path.
+    expect(assetsPath(ORG, 'attachments', 'a/b.pdf')).toBe(`${ORG}/attachments/a_b.pdf`)
+    expect(assetsPath(ORG, 'attachments', 'a\\b.pdf')).toBe(`${ORG}/attachments/a_b.pdf`)
+  })
+
+  it('drops empty segments rather than emitting a double slash', () => {
+    expect(assetsPath(ORG, 'models', '', 'f.xlsx')).toBe(`${ORG}/models/f.xlsx`)
+  })
+
+  it('accepts the numeric segments call sites pass (Date.now())', () => {
+    expect(assetsPath(ORG, 'models', 1755123456)).toBe(`${ORG}/models/1755123456`)
+  })
+})
+
+describe('orgOfAssetsPath / isOrgScopedAssetsPath', () => {
+  it('reads the org back off a scoped path', () => {
+    expect(orgOfAssetsPath(assetsPath(ORG, 'models', 'f.xlsx'))).toBe(ORG)
+    expect(isOrgScopedAssetsPath(`${ORG}/models/f.xlsx`)).toBe(true)
+  })
+
+  it('rejects every legacy literal prefix', () => {
+    for (const legacy of [
+      'models/x/f.xlsx',
+      'documents/x/f.pdf',
+      'references/x/f.pdf',
+      'notes/x/f.xlsx',
+      'attachments/note/x/f.png',
+      'model-templates/x/f.xlsx',
+    ]) {
+      expect(isOrgScopedAssetsPath(legacy)).toBe(false)
+      expect(orgOfAssetsPath(legacy)).toBeNull()
+    }
+  })
+
+  it('cannot distinguish legacy checklist evidence by shape alone', () => {
+    // `<assetId>/<workflowId>/<stageId>/<itemId>/<file>` also starts with a
+    // uuid, so this predicate reports true for it. That is why the backfill
+    // resolves ownership through the referencing table rather than trusting
+    // the path — asserted here so the limitation is not rediscovered later.
+    expect(isOrgScopedAssetsPath(`${ASSET}/wf/stage/item/f.pdf`)).toBe(true)
+    expect(orgOfAssetsPath(`${ASSET}/wf/stage/item/f.pdf`)).toBe(ASSET)
+  })
+})

--- a/src/lib/storage/asset-paths.ts
+++ b/src/lib/storage/asset-paths.ts
@@ -1,0 +1,92 @@
+/**
+ * Org-scoped paths for the shared `assets` storage bucket.
+ *
+ * Every object in this bucket lives under `<organization_id>/…`. That first
+ * segment is the tenant boundary: the storage RLS policy matches it against
+ * `current_org_id()`, exactly the way the database policies work. Nothing
+ * else in the path is trusted for access control.
+ *
+ * This exists because the historical paths could not be scoped. They started
+ * with either a literal (`models/`, `documents/`, `attachments/`) or an
+ * `assets.id` — and `assets` is the shared security master, deliberately
+ * global with no organization_id (see scripts/tenant-boundary-lint.mjs).
+ * Two firms researching the same ticker share that row, so an asset id says
+ * nothing about who may read the file. The org has to be in the path itself.
+ *
+ * Call sites must go through {@link assetsPath} rather than interpolating
+ * their own strings, so the invariant is enforced in one place and the
+ * backfill has a single definition of "correct" to check against.
+ */
+
+export const ASSETS_BUCKET = 'assets'
+
+/**
+ * Thrown when a path is built without an org. Deliberately loud: silently
+ * writing to an unscoped path would produce an object that no policy grants
+ * access to, so the upload would appear to succeed and the file would be
+ * unreadable forever after.
+ */
+export class MissingOrgScopeError extends Error {
+  constructor(context: string) {
+    super(
+      `Cannot build an assets-bucket path without an organization id (${context}). ` +
+      `The caller must wait for OrganizationContext to resolve currentOrgId before uploading.`
+    )
+    this.name = 'MissingOrgScopeError'
+  }
+}
+
+/**
+ * Strip path separators from a single segment.
+ *
+ * Several call sites interpolate a user-supplied `file.name` directly. A name
+ * containing a slash would silently create extra nesting; it stays inside the
+ * org prefix so it is not a security problem, but it makes paths unpredictable
+ * for the backfill and for anything that later parses them.
+ */
+function sanitizeSegment(segment: string): string {
+  return segment.replace(/[/\\]+/g, '_')
+}
+
+/**
+ * Build an org-scoped path into the `assets` bucket.
+ *
+ * @example
+ *   assetsPath(currentOrgId, 'models', assetId, `${Date.now()}_${id}.xlsx`)
+ *   // => '9f3c…/models/1b2a…/1755123456_x7k.xlsx'
+ */
+export function assetsPath(
+  orgId: string | null | undefined,
+  ...segments: Array<string | number>
+): string {
+  if (!orgId) throw new MissingOrgScopeError(segments.join('/') || '<no segments>')
+
+  const tail = segments
+    .map(s => sanitizeSegment(String(s)))
+    .filter(s => s.length > 0)
+
+  return [orgId, ...tail].join('/')
+}
+
+/** The org a path belongs to, or null if it predates org scoping. */
+export function orgOfAssetsPath(path: string): string | null {
+  const first = path.split('/')[0]
+  return UUID_RE.test(first) ? first : null
+}
+
+/**
+ * Whether a path carries an org prefix.
+ *
+ * Used by the backfill to tell migrated objects from legacy ones. The check is
+ * "first segment is a UUID" rather than a lookup: every legacy prefix in use
+ * was either a literal word (`models`, `documents`, `references`, `notes`,
+ * `attachments`, `model-templates`) or an `assets.id`. Asset ids ARE uuids,
+ * so this predicate alone cannot separate a legacy checklist-evidence path
+ * (`<assetId>/<workflowId>/…`) from a migrated one — the backfill resolves
+ * those by looking the path up in the table that references it, not by shape.
+ */
+export function isOrgScopedAssetsPath(path: string): boolean {
+  return orgOfAssetsPath(path) !== null
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -16,8 +16,19 @@ if (SENTRY_DSN) {
       import.meta.env.VITE_SENTRY_ENVIRONMENT || import.meta.env.MODE,
     integrations: [
       Sentry.browserTracingIntegration(),
-      Sentry.replayIntegration(),
+      // Masking is passed explicitly rather than left to the SDK default.
+      // These are Sentry's defaults today, but a replay of this app records
+      // client holdings, theses and portfolio names — that must not become
+      // readable in a third-party tool because a library changed a default
+      // in a minor release. Pinned here so the guarantee is ours, not theirs.
+      Sentry.replayIntegration({
+        maskAllText: true,
+        maskAllInputs: true,
+        blockAllMedia: true,
+      }),
     ],
+    // Never attach request headers, cookies or user IP to events.
+    sendDefaultPii: false,
     // Performance tracing — 10% in prod, 100% elsewhere (cheap on pilots).
     tracesSampleRate: import.meta.env.MODE === 'production' ? 0.1 : 1.0,
     // Session Replay — never record happy sessions (would burn quota fast);

--- a/supabase/migrations/20260814100000_asset_models_organization_id.sql
+++ b/supabase/migrations/20260814100000_asset_models_organization_id.sql
@@ -13,17 +13,25 @@
  *    column identifies a tenant. Without this column those files cannot be
  *    attributed and cannot be migrated.
  *
- * 2. The SELECT policy never scoped anything. From 20251230000002:
+ * 2. No policy on this table has ever mentioned an organization.
  *
- *      CREATE POLICY "Users can view models for accessible assets"
- *        ON asset_models FOR SELECT TO authenticated
- *        USING (EXISTS (SELECT 1 FROM assets a WHERE a.id = asset_models.asset_id));
+ *    20251230000002 shipped:
  *
- *    asset_id is NOT NULL and references assets, so that EXISTS is true for
- *    every row. The comment says "same pattern as asset_notes" but the
- *    predicate reduces to "the row exists" — every authenticated user of
- *    every org could read every model row in the instance: names,
- *    descriptions, file paths, the lot. Replaced below.
+ *      USING (EXISTS (SELECT 1 FROM assets a WHERE a.id = asset_models.asset_id))
+ *
+ *    asset_id is NOT NULL and references assets, so that predicate reduces to
+ *    "the row exists" — it granted every row to everyone.
+ *
+ *    Production no longer runs that. The live policy is
+ *
+ *      USING ((created_by = auth.uid()) OR (is_shared = true))
+ *
+ *    renamed to "Users can view own and shared models" and applied outside
+ *    the migrations directory, so the repo never recorded it. Better, but
+ *    still not tenant-scoped: is_shared = true means any authenticated user
+ *    of any of the 27 organizations can read that row. Both spellings are
+ *    dropped below and replaced with an org-scoped equivalent that keeps the
+ *    own/shared distinction the live policy was reaching for.
  *
  * ── On the backfill ───────────────────────────────────────────────────────
  *
@@ -77,7 +85,7 @@ END $$;
 UPDATE public.asset_models m
 SET organization_id = sole.organization_id
 FROM (
-  SELECT user_id, MIN(organization_id) AS organization_id
+  SELECT user_id, (array_agg(DISTINCT organization_id))[1] AS organization_id
   FROM public.organization_memberships
   WHERE status = 'active'
   GROUP BY user_id
@@ -111,7 +119,7 @@ END $$;
 UPDATE public.asset_notes n
 SET organization_id = sole.organization_id
 FROM (
-  SELECT user_id, MIN(organization_id) AS organization_id
+  SELECT user_id, (array_agg(DISTINCT organization_id))[1] AS organization_id
   FROM public.organization_memberships
   WHERE status = 'active'
   GROUP BY user_id
@@ -169,6 +177,8 @@ END $$;
 -- previous predicate simply never implemented it.
 
 DROP POLICY IF EXISTS "Users can view models for accessible assets" ON public.asset_models;
+-- Live name in production, applied outside migrations:
+DROP POLICY IF EXISTS "Users can view own and shared models" ON public.asset_models;
 
 CREATE POLICY "Org members can view models in current org"
   ON public.asset_models
@@ -182,6 +192,7 @@ CREATE POLICY "Org members can view models in current org"
 -- INSERT additionally has to prove the row lands in the caller's own org, or
 -- a user could write rows into another tenant.
 DROP POLICY IF EXISTS "Users can create models" ON public.asset_models;
+DROP POLICY IF EXISTS "Users can create own models" ON public.asset_models;
 
 CREATE POLICY "Users can create models in current org"
   ON public.asset_models

--- a/supabase/migrations/20260814100000_asset_models_organization_id.sql
+++ b/supabase/migrations/20260814100000_asset_models_organization_id.sql
@@ -1,0 +1,232 @@
+/**
+ * asset_models / model_versions get a canonical organization_id.
+ *
+ * Same pattern as 20260603140000 (notes) and 20260605120000 (quick thoughts):
+ * a model belongs to the org it was built in, not to the user globally.
+ *
+ * Two things are being fixed here, and the second is the more serious.
+ *
+ * 1. Storage attribution. Phase 2 of org-scoping the `assets` bucket has to
+ *    decide which org owns each uploaded object. asset_models carried only
+ *    created_by and asset_id, and `assets` is the global security master —
+ *    two firms researching the same ticker share that row — so neither
+ *    column identifies a tenant. Without this column those files cannot be
+ *    attributed and cannot be migrated.
+ *
+ * 2. The SELECT policy never scoped anything. From 20251230000002:
+ *
+ *      CREATE POLICY "Users can view models for accessible assets"
+ *        ON asset_models FOR SELECT TO authenticated
+ *        USING (EXISTS (SELECT 1 FROM assets a WHERE a.id = asset_models.asset_id));
+ *
+ *    asset_id is NOT NULL and references assets, so that EXISTS is true for
+ *    every row. The comment says "same pattern as asset_notes" but the
+ *    predicate reduces to "the row exists" — every authenticated user of
+ *    every org could read every model row in the instance: names,
+ *    descriptions, file paths, the lot. Replaced below.
+ *
+ * ── On the backfill ───────────────────────────────────────────────────────
+ *
+ * Existing rows are only filled in where the answer is unambiguous: the
+ * creator is an active member of exactly one organization. Where a creator
+ * belongs to several, there is no way to recover which one they were in when
+ * they uploaded, and users.current_organization_id is today's answer to a
+ * question about the past. A wrong guess files one firm's model under
+ * another firm's org, which is worse than leaving it unset — under the new
+ * policy the wrong firm would be able to read it.
+ *
+ * Rows left NULL are invisible under the new policies until an admin sets
+ * them. The verification queries at the bottom list them.
+ */
+
+-- ---------------------------------------------------------------------------
+-- 1. Column, FK, index
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE public.asset_models
+  ADD COLUMN IF NOT EXISTS organization_id UUID
+  REFERENCES public.organizations(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS asset_models_org_id_idx
+  ON public.asset_models (organization_id) WHERE is_deleted IS NOT TRUE;
+
+-- model_versions was created outside the migrations directory (it appears in
+-- application code and in the tenant lint's FK-chain list, but no migration
+-- defines it). Guard so this file is safe to run against an environment
+-- where it does not exist.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'model_versions'
+  ) THEN
+    ALTER TABLE public.model_versions
+      ADD COLUMN IF NOT EXISTS organization_id UUID
+      REFERENCES public.organizations(id) ON DELETE SET NULL;
+
+    CREATE INDEX IF NOT EXISTS model_versions_org_id_idx
+      ON public.model_versions (organization_id);
+  END IF;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Unambiguous backfill only
+-- ---------------------------------------------------------------------------
+
+-- asset_models: creator is an active member of exactly one org.
+UPDATE public.asset_models m
+SET organization_id = sole.organization_id
+FROM (
+  SELECT user_id, MIN(organization_id) AS organization_id
+  FROM public.organization_memberships
+  WHERE status = 'active'
+  GROUP BY user_id
+  HAVING COUNT(DISTINCT organization_id) = 1
+) sole
+WHERE sole.user_id = m.created_by
+  AND m.organization_id IS NULL;
+
+-- model_versions: inherit from the parent model, which is exact.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'model_versions'
+  ) THEN
+    EXECUTE $sql$
+      UPDATE public.model_versions v
+      SET organization_id = m.organization_id
+      FROM public.asset_models m
+      WHERE m.id = v.model_id
+        AND v.organization_id IS NULL
+        AND m.organization_id IS NOT NULL
+    $sql$;
+  END IF;
+END $$;
+
+-- asset_notes: 20260603140000 left pre-migration rows NULL because the
+-- relation table carries no org. The same single-org-creator rule recovers
+-- the unambiguous ones, which is also what makes their attachments
+-- migratable in Phase 2.
+UPDATE public.asset_notes n
+SET organization_id = sole.organization_id
+FROM (
+  SELECT user_id, MIN(organization_id) AS organization_id
+  FROM public.organization_memberships
+  WHERE status = 'active'
+  GROUP BY user_id
+  HAVING COUNT(DISTINCT organization_id) = 1
+) sole
+WHERE sole.user_id = n.created_by
+  AND n.organization_id IS NULL;
+
+-- ---------------------------------------------------------------------------
+-- 3. Stamp organization_id on insert
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.set_model_org_id_from_caller()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_caller UUID := auth.uid();
+BEGIN
+  IF NEW.organization_id IS NOT NULL THEN RETURN NEW; END IF;
+  IF v_caller IS NOT NULL THEN
+    SELECT current_organization_id INTO NEW.organization_id
+    FROM public.users WHERE id = v_caller;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS set_asset_models_org_id_trigger ON public.asset_models;
+CREATE TRIGGER set_asset_models_org_id_trigger
+  BEFORE INSERT ON public.asset_models
+  FOR EACH ROW EXECUTE FUNCTION public.set_model_org_id_from_caller();
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.tables
+    WHERE table_schema = 'public' AND table_name = 'model_versions'
+  ) THEN
+    DROP TRIGGER IF EXISTS set_model_versions_org_id_trigger ON public.model_versions;
+    CREATE TRIGGER set_model_versions_org_id_trigger
+      BEFORE INSERT ON public.model_versions
+      FOR EACH ROW EXECUTE FUNCTION public.set_model_org_id_from_caller();
+  END IF;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- 4. Replace the always-true SELECT policy
+-- ---------------------------------------------------------------------------
+--
+-- The is_shared flag is preserved: a model is visible to the org when shared,
+-- and to its creator either way. That is what the original intended — the
+-- previous predicate simply never implemented it.
+
+DROP POLICY IF EXISTS "Users can view models for accessible assets" ON public.asset_models;
+
+CREATE POLICY "Org members can view models in current org"
+  ON public.asset_models
+  FOR SELECT
+  TO authenticated
+  USING (
+    organization_id = current_org_id()
+    AND (is_shared OR created_by = auth.uid())
+  );
+
+-- INSERT additionally has to prove the row lands in the caller's own org, or
+-- a user could write rows into another tenant.
+DROP POLICY IF EXISTS "Users can create models" ON public.asset_models;
+
+CREATE POLICY "Users can create models in current org"
+  ON public.asset_models
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    auth.uid() = created_by
+    AND organization_id = current_org_id()
+  );
+
+DROP POLICY IF EXISTS "Users can update own models" ON public.asset_models;
+
+CREATE POLICY "Users can update own models in current org"
+  ON public.asset_models
+  FOR UPDATE
+  TO authenticated
+  USING (
+    auth.uid() = created_by
+    AND organization_id = current_org_id()
+  );
+
+DROP POLICY IF EXISTS "Users can delete own models" ON public.asset_models;
+
+CREATE POLICY "Users can delete own models in current org"
+  ON public.asset_models
+  FOR DELETE
+  TO authenticated
+  USING (
+    auth.uid() = created_by
+    AND organization_id = current_org_id()
+  );
+
+COMMENT ON COLUMN public.asset_models.organization_id IS
+  'Owning organization. Required for tenant isolation and for attributing the '
+  'model file in the assets storage bucket. NULL only on legacy rows whose '
+  'creator belongs to more than one org; those must be assigned by an admin.';
+
+-- ---------------------------------------------------------------------------
+-- Verification — rows needing a human decision
+-- ---------------------------------------------------------------------------
+--
+--   SELECT m.id, m.name, m.file_path, u.email AS created_by
+--   FROM asset_models m JOIN users u ON u.id = m.created_by
+--   WHERE m.organization_id IS NULL AND m.is_deleted IS NOT TRUE;
+--
+--   SELECT n.id, n.title, n.file_path, u.email AS created_by
+--   FROM asset_notes n JOIN users u ON u.id = n.created_by
+--   WHERE n.organization_id IS NULL AND n.is_deleted IS NOT TRUE;


### PR DESCRIPTION
Closes the cross-tenant hole in the `assets` storage bucket, and stops permanent public URLs being written into the database.

## Why this needs to merge before anything else can finish

Phases 1 and 2 are **already applied to production**. This deploy unblocks the final two steps, because production currently runs upload code that writes legacy paths the new policy rejects.

Immediately after this deploys:
1. flip the `assets` bucket to private — it is still public, and that is the remaining live exposure
2. apply `scripts/sql/phase3-assets-bucket-org-rls.sql`

## What was wrong

The bucket's read policy was `USING (bucket_id = 'assets')` — being logged in as anyone was sufficient to read any file any customer had uploaded. The bucket was also `public = true` in production (the migration created it `false`; it was flipped in the dashboard), so in practice those files were reachable **unauthenticated** by anyone with the URL, across 27 organizations.

Path-prefix scoping could not be bolted on, because none of the seven legacy path shapes carried a tenant — half start with a literal, half with an `assets.id`, and `assets` is the global security master shared across firms. Every write site had to change.

## What changed

- `src/lib/storage/asset-paths.ts` is the only sanctioned way to build a path into the bucket; 13 call sites route through it. It throws rather than falling back to an unscoped path, since a silent fallback uploads successfully and produces a file no policy grants access to.
- Two call sites would have been missed by grepping for `storage.from('assets').upload`: `useModelTemplates` builds the REST URL by hand and POSTs with `fetch`, and `InvestmentCaseBuilder` uploads a generated PDF. Found by enumerating path *constructions* instead of upload *calls*.
- `asset_models` gained `organization_id` (it had none — only `created_by` and a global `asset_id`), plus org-scoped policies. Its live policy allowed any authenticated user to read any row flagged `is_shared`.
- Screenshot and note-attachment URLs are now signed on demand rather than persisted. `CaptureView` built its image src from `process.env.VITE_SUPABASE_URL`, which is undefined under Vite — every screenshot embedded in a note has been a broken image behind an unfinished TODO.
- Sentry replay masking is pinned explicitly instead of inherited from SDK defaults.

## Verification

- Production build succeeds locally.
- Typecheck: no new errors in any touched file, verified by diffing against a stash rather than by eye (the repo carries a large pre-existing backlog).
- Tests: 1035 pass, +8 new for the path helper. The 2 `org-scope-guard` failures are pre-existing and fail identically on `main`.
- **Not verified in a browser.** The note previews especially — they have been broken long enough that nobody knows what working looks like.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
