### PR TITLE
Repair model_files, cascade storage deletion, orphan sweeper, and legal drafts

### DIFF
--- a/docs/legal/DATA-INVENTORY.md
+++ b/docs/legal/DATA-INVENTORY.md
@@ -1,0 +1,233 @@
+# Data Inventory — Tesseract
+
+**Status: factual working document. Not a legal document.**
+Compiled from the codebase and from the production database on 2026-08-14.
+Every claim below is traceable to a file path or a query; where something was
+not verified, it says so.
+
+This exists so counsel drafting the privacy policy, DPA and breach-response
+plan does not have to reverse-engineer the application. It is also the source
+the sibling drafts in this directory were written from — if this document
+changes, they need re-checking.
+
+---
+
+## 1. Who the parties are
+
+Tesseract is B2B software sold to investment firms. In data-protection terms
+the customer firm is the **controller** of the research, holdings and client
+data it puts into the platform; Tesseract is the **processor**. For account
+data about the firm's own employees (name, email, login), Tesseract acts as
+controller.
+
+That split matters for two reasons: the customer's DPA governs the research
+data, and the customer's own regulator reaches Tesseract through that contract
+(see §7).
+
+**Not verified:** the legal entity name, place of incorporation, and whether
+any customer contracts are already signed with terms that conflict with the
+drafts here.
+
+---
+
+## 2. Personal data held
+
+### About users of the platform
+
+| Data | Where | Source |
+|---|---|---|
+| Email, first/last name | `users` | account creation |
+| Organization membership, admin flags | `organization_memberships` | admin action |
+| Current organization | `users.current_organization_id` | set on org switch |
+| Per-user preferences, saved views, layouts | `user_preferences`, `user_saved_views`, `user_asset_*` | in-product |
+| Activity and audit trail | `activity_events`, `audit_events`, `organization_audit_log` | automatic |
+| Notifications | `notifications` | automatic |
+| AI prompt history | `user_quick_prompt_history` | in-product |
+| AI usage and cost | `ai_usage_log` | automatic |
+
+### Customer business data (controller data)
+
+Investment research and decision records: theses, notes, price targets,
+ratings, trade ideas, simulations, committed trades, portfolio holdings and
+their history, coverage assignments, workflow and checklist state.
+
+**This is commercially sensitive and, for the customer, likely regulated
+recordkeeping.** Portfolio holdings and trade intentions are the material
+non-public information of a registered adviser.
+
+### Uploaded files
+
+Stored in Supabase Storage. As of 2026-08-14 the `assets` bucket holds **9
+objects, 703 kB** — 6 customer documents, 2 model templates, 1 note
+attachment. All other buckets are empty except `template-branding` (1 org
+logo).
+
+Buckets: `assets`, `captures`, `thought-attachments`, `model-templates`,
+`workflow-templates`, `org-exports`, `template-branding`. **All are private
+as of 2026-08-14.** `assets`, `captures`, `thought-attachments` and
+`model-templates` were public before that date — see §8.
+
+---
+
+## 3. Third parties that receive data
+
+Everything here is disclosable in a privacy policy and belongs on a
+subprocessor list.
+
+### Infrastructure
+
+| Party | What they hold | Notes |
+|---|---|---|
+| **Supabase** | The entire database and all uploaded files | us-east-1 |
+| **Netlify** | Static hosting, build logs | serves the app |
+
+### AI providers — `supabase/functions/ai-chat/index.ts`
+
+The AI chat feature sends customer research content to a third-party model
+provider. `buildContextPrompt` assembles and transmits: asset data,
+**investment theses, `where_different`, `risks_to_thesis`, note bodies,
+outcomes, portfolio names and holdings**.
+
+Configurable per platform or per organization (BYOK):
+
+| Provider | Default model |
+|---|---|
+| Anthropic (default) | `claude-haiku-4-5-20251001` |
+| OpenAI | `gpt-4o-mini` |
+| Google | — |
+| **Perplexity** | `llama-3.1-sonar-*` — search-augmented; call out separately |
+
+**Not verified:** whether zero-retention / no-training terms are in place with
+any of these. This needs confirming in writing before the privacy policy
+claims anything about it.
+
+When an organization supplies its own key (BYOK), that organization — not
+Tesseract — holds the provider relationship. The policy and DPA should say so.
+
+### Market data providers
+
+Alpha Vantage, Yahoo, Polygon, Finnhub. These receive **ticker symbols**, not
+customer content. Lower sensitivity, but they are still recipients and belong
+on the list.
+
+### Error monitoring — `src/main.tsx`
+
+**Sentry.** Errors, performance traces (10% sampled in production), and
+**session replay recorded on every errored session** (`replaysOnErrorSampleRate: 1.0`;
+happy sessions are never recorded).
+
+Replay records the DOM of a user working inside the product. Masking
+(`maskAllText`, `maskAllInputs`, `blockAllMedia`) is now passed explicitly
+rather than inherited from SDK defaults, and `sendDefaultPii` is off. Session
+replay is the single most commonly challenged item in a security review —
+disclose it plainly.
+
+---
+
+## 4. Deletion — what is true today
+
+Be careful here: promising more than this is a policy that is not implemented.
+
+| Ask | Reality |
+|---|---|
+| Delete an uploaded model | Row soft-deleted **and file removed from storage** (as of this change) |
+| Delete a note | Row deleted; **an attachment inside the note body is not removed** |
+| Delete an attachment in the composer | File removed (as of this change) |
+| Delete a user account | **No path exists.** Users can only be *suspended* via `deactivate_org_member` |
+| Delete an organization and its data | **No path exists** |
+| Export my data | `org-exports` job infrastructure exists; not a user-facing DSAR flow |
+
+`scripts/sweep-orphaned-assets.mjs` reports (and optionally deletes) files no
+row points at. Report-only by default.
+
+**The account-erasure gap is the one that most directly contradicts a standard
+privacy policy.** Either build it or write the policy around what exists.
+
+---
+
+## 5. Retention
+
+Only one retention control exists: `organization_governance.retention_days_audit_log`
+(`20260224000000_phase16_governance_jobs.sql`).
+
+Everything else is kept indefinitely. There is no scheduled purge of notes,
+research, holdings history, activity events or uploaded files.
+
+---
+
+## 6. Tenant isolation
+
+Relevant because a policy that promises "your data is separated from other
+customers" should be true.
+
+Isolation is enforced by Postgres row-level security keyed on
+`current_org_id()`, plus a client-side filter on tables whose RLS is not
+org-aware. Two lint scripts and a test guard it:
+`scripts/tenant-boundary-lint.mjs`, `scripts/frontend-tenant-lint.mjs`,
+`src/lib/org-scope/__tests__/org-scope-guard.test.ts`.
+
+**Known accepted gaps:** `src/lib/org-scope/known-unscoped-queries.json`
+currently lists **109 files** that query org-scoped tables without an explicit
+org filter and rely on RLS. That baseline is a known-issues register, and a
+diligence questionnaire may ask about it.
+
+---
+
+## 7. Regulatory obligations that reach Tesseract
+
+Tesseract is not itself SEC-registered, but its customers are, and their
+obligations arrive by contract.
+
+- **SEC Regulation S-P (amended).** Compliance dates have passed (Dec 2025
+  larger entities / June 2026 smaller). Covered advisers must have written
+  contracts requiring **service providers** to notify them of unauthorized
+  access to customer information **within 72 hours**. Expect this in every
+  customer contract. See `INCIDENT-RESPONSE.md`.
+- **GLBA Safeguards Rule.** Reaches Tesseract through the same contracts.
+- **Advisers Act Rule 204-2 (books and records).** If advisers keep required
+  records in Tesseract, retention and production obligations may attach.
+  **Needs a securities lawyer's view** — it interacts directly with §4 and §5.
+- **CalOPPA.** Requires a posted privacy policy for any commercial online
+  service collecting personal information from California residents. Applies
+  regardless of size. This is the baseline obligation.
+- **CCPA/CPRA.** Threshold-dependent (~$25M revenue / 100k consumers). Note
+  it has covered B2B contacts since 2023.
+- **GDPR / UK GDPR.** Applies if there are any EU/UK users. **Not verified.**
+
+---
+
+## 8. Incidents and material changes to record
+
+Facts a regulator or customer might ask about, documented rather than lost:
+
+- **Until 2026-08-14 the `assets` storage bucket was publicly readable.** Its
+  creating migration set `public = false`; it was `true` in production, changed
+  outside version control at an unknown date. Any object path that had ever
+  been disclosed was fetchable **without authentication**. The bucket held 9
+  objects belonging to one organization. `captures`, `thought-attachments` and
+  `model-templates` were also public and were **empty**.
+- **Until 2026-08-14 the `assets` bucket's read policy was `bucket_id = 'assets'`**
+  — any authenticated user of any organization could read any file.
+- **Until 2026-08-14 mobile explore search queried `asset_lists` and
+  `trade_queue_items` with no organization filter**, and RLS on those tables is
+  not org-aware, so results could include other organizations' lists and trade
+  ideas.
+
+All three are closed. Whether any of them requires customer notification is a
+legal judgement, not an engineering one — but the facts are here to make it.
+Access logs would be needed to establish whether anything was actually
+retrieved; **that has not been investigated.**
+
+---
+
+## 9. Open questions for counsel
+
+1. Does the Aug 2026 bucket exposure trigger notification to the affected
+   customer, or to any regulator?
+2. Does Rule 204-2 make Tesseract a recordkeeping system, and what retention
+   and production guarantees follow?
+3. Is account/organization erasure required before the privacy policy can
+   promise deletion — or can the policy be written around suspension?
+4. Are EU/UK users in scope?
+5. Do the AI providers' standard terms suffice, or is a zero-retention
+   agreement needed per provider?

--- a/docs/legal/DPA.draft.md
+++ b/docs/legal/DPA.draft.md
@@ -1,0 +1,139 @@
+# Data Processing Addendum — DRAFT, NOT LEGAL REVIEWED
+
+> This is the document enterprise customers will send you their own version of.
+> Having a credible one ready shortens diligence considerably; signing theirs
+> unread is how you end up with obligations the software cannot meet.
+>
+> Drafted from `DATA-INVENTORY.md`. Clauses marked **⚠** commit you to something
+> the product does not currently do — build it or negotiate it, do not sign it.
+
+Between **[LEGAL ENTITY]** ("Processor") and the customer ("Controller"),
+supplementing the Agreement.
+
+---
+
+## 1. Roles
+
+Controller determines the purposes and means of processing Customer Data.
+Processor processes it only on Controller's documented instructions, which
+include the Agreement and Controller's configuration and use of the Service.
+
+Processor is an independent controller for account data about Controller's
+personnel (name, business email, role, authentication and usage records)
+strictly for operating and securing the Service.
+
+## 2. Subject matter and duration
+
+Processing continues for the term of the Agreement plus the return/deletion
+period in §9.
+
+**Categories of data subjects:** Controller's personnel and authorized users.
+
+**Categories of personal data:** name, business email, organizational role,
+authentication records, product usage and audit records, and any personal data
+Controller includes in content it uploads.
+
+**Nature and purpose:** hosting, storage, retrieval, search, analysis and
+display of investment research and decision records; provision of AI features
+where enabled by Controller.
+
+**Special categories:** none intended. Controller should not upload special
+category data.
+
+## 3. Confidentiality
+
+Processor ensures personnel authorized to process Customer Data are bound by
+confidentiality obligations and receive appropriate training.
+
+## 4. Security
+
+Processor maintains technical and organizational measures appropriate to the
+risk, including:
+
+- Logical separation of each Controller's data, enforced at the database layer
+- Access control limiting production access to personnel who require it
+- Encryption in transit; encryption at rest as provided by the hosting platform
+- Time-limited, signed access URLs for stored files rather than public links
+- Audit logging of access to and modification of Customer Data
+
+**⚠ Do not add SOC 2, penetration testing, or a formal vulnerability-management
+programme here until they exist.** Customers will ask; "not yet, planned for
+[DATE]" is a survivable answer and a false attestation is not.
+
+## 5. Subprocessors
+
+Controller authorizes the subprocessors listed at [SUBPROCESSOR LIST URL].
+
+Processor will give Controller **[30] days'** notice before adding a
+subprocessor, during which Controller may object on reasonable data-protection
+grounds; if the objection cannot be resolved, Controller may terminate the
+affected Service without penalty.
+
+Processor imposes data protection obligations on each subprocessor no less
+protective than those in this DPA, and remains liable for their performance.
+
+**AI providers:** Controller acknowledges that enabling AI features transmits
+the Customer Data described in the documentation to the applicable AI provider.
+Where Controller supplies its own provider credentials, that provider is
+Controller's subprocessor and Processor is not responsible for its processing.
+
+## 6. Security incidents
+
+Processor will notify Controller **without undue delay and in any event within
+72 hours** of becoming aware of a Security Incident affecting Customer Data,
+and will provide the information reasonably available to Controller to meet its
+own notification obligations.
+
+> This mirrors amended SEC Reg S-P, which requires covered advisers to hold
+> service providers to exactly this. It is not negotiable in practice — see
+> `INCIDENT-RESPONSE.draft.md`, which is what makes it deliverable.
+
+## 7. Assistance
+
+Processor will provide reasonable assistance with data subject requests, data
+protection impact assessments, and consultations with supervisory authorities,
+taking into account the nature of processing and the information available.
+
+**⚠ Data subject requests:** Processor's ability to *delete* a specific
+individual's personal data is currently limited to deactivating their access
+and account. Content authored by that individual is retained as Controller's
+business record. **If Controller requires erasure-on-request, that must be
+agreed separately — the capability does not exist today.**
+
+## 8. Audits
+
+Processor will make available information reasonably necessary to demonstrate
+compliance, and will allow audits by Controller or its auditor **no more than
+once per twelve months**, on reasonable notice, during business hours, subject
+to confidentiality, at Controller's cost. Processor may satisfy this with a
+current third-party report where one exists.
+
+## 9. Return and deletion
+
+Within **[30] days** of termination, Processor will, at Controller's election,
+return Customer Data in a machine-readable format or delete it, save where
+retention is required by law.
+
+**⚠ Neither a self-service export nor a verified deletion routine exists
+today.** `org-exports` provides job infrastructure; there is no organization
+erasure path. Do not agree to a shorter window than you can perform manually.
+
+Controller acknowledges that where Controller is subject to recordkeeping
+obligations (including SEC Advisers Act Rule 204-2), Controller is responsible
+for retaining its own records independently of the Service.
+
+## 10. International transfers
+
+Processing occurs in the United States. **[IF EU/UK DATA IS IN SCOPE, ATTACH
+STANDARD CONTRACTUAL CLAUSES AND THE UK ADDENDUM, AND COMPLETE A TRANSFER
+IMPACT ASSESSMENT.]**
+
+## 11. Precedence
+
+In conflict with the Agreement, this DPA governs as to processing of personal
+data.
+
+---
+
+**Annex 1 — Subprocessors:** see `SUBPROCESSORS.md`
+**Annex 2 — Technical and organizational measures:** §4 above

--- a/docs/legal/INCIDENT-RESPONSE.draft.md
+++ b/docs/legal/INCIDENT-RESPONSE.draft.md
@@ -1,0 +1,142 @@
+# Incident Response Plan — DRAFT, NOT LEGAL REVIEWED
+
+> Drafted from `DATA-INVENTORY.md`. The 72-hour commitment below is not
+> aspirational — under amended **SEC Regulation S-P** your customers are
+> required to hold their service providers to it, so it will appear in their
+> contracts whether or not this document exists. Compliance dates have already
+> passed (Dec 2025 larger entities, June 2026 smaller).
+>
+> A plan nobody has rehearsed does not work. The single most valuable thing
+> after adopting this is a one-hour tabletop against §7.
+
+**Owner:** [NAME, ROLE] — **Deputy:** [NAME]
+**Effective:** [DATE] · **Review:** annually and after any incident
+
+---
+
+## 1. What counts as an incident
+
+Any of these starts this plan:
+
+- Unauthorized access to, or disclosure of, customer content or personal data
+- A tenant-isolation failure — one organization able to reach another's data
+- Storage or database exposed without the intended access control
+- Credential or API key compromise (Supabase service role, provider keys,
+  GitHub, Netlify)
+- Ransomware, destructive action, or unexplained data loss
+- A vendor in §3 of the inventory reporting a breach affecting us
+
+**When unsure, declare.** Standing an incident down is cheap; a late clock is
+not.
+
+## 2. Severity
+
+| | Definition | Examples |
+|---|---|---|
+| **SEV-1** | Confirmed unauthorized access to customer content, or cross-tenant exposure | Another firm's holdings readable; database exfiltration |
+| **SEV-2** | Exposure possible but unconfirmed; control failed with no evidence of access | A private resource found publicly readable with no access-log evidence of retrieval |
+| **SEV-3** | Control weakness, no exposure | Over-broad policy found by review before reaching production |
+
+The **Aug 2026 storage exposure** (inventory §8) is the worked example of a
+SEV-2: a bucket was publicly readable, so retrieval was possible, and access
+logs were never examined to establish whether it happened.
+
+## 3. The clock
+
+**Start it when a plausible report arrives, not when it is confirmed.**
+Confirmation is part of the response, not a precondition for it.
+
+| Time | What must have happened |
+|---|---|
+| **0h** | Incident declared, owner assigned, timeline log opened |
+| **+4h** | Scope assessed: what data, which organizations, what window |
+| **+24h** | Containment complete or a written reason it is not |
+| **+72h** | **Notification to every affected customer organization** |
+
+The 72-hour deadline is a **Reg S-P service-provider obligation** flowing to
+Tesseract through customer contracts. It does not pause for weekends, and it
+does not wait for a complete forensic picture — an incomplete notification on
+time beats a complete one late.
+
+## 4. Roles
+
+- **Incident owner** — declares, runs the response, writes the notification.
+  The only role that cannot be shared.
+- **Technical lead** — containment and evidence preservation.
+- **Communications** — customer contact; ensures every affected org is told.
+- **Legal** — [EXTERNAL COUNSEL NAME AND OUT-OF-HOURS NUMBER]. Engage at
+  declaration for anything SEV-2 or above, not after triage.
+
+At current headcount one person may hold several. Write down who, per incident,
+in the timeline log — an unassigned role is an unperformed one.
+
+## 5. Containment
+
+**Preserve evidence before you fix.** Capture access logs first: closing a hole
+often destroys the record of whether it was used, and "we could not determine
+whether data was accessed" is a much worse sentence to write to a customer than
+it needs to be.
+
+Order:
+1. Snapshot relevant logs — Supabase storage/API logs, Netlify, GitHub audit
+2. Revoke or rotate implicated credentials
+3. Close the hole
+4. Verify closure with an explicit negative test (attempt the access; record
+   that it now fails)
+5. Only then restore normal service
+
+Useful commands live in `scripts/` — `backfill-assets-bucket-org-scope.mjs`
+and `sweep-orphaned-assets.mjs` both enumerate storage and its owners.
+
+## 6. Notification
+
+To each affected customer organization, in writing, within 72 hours:
+
+- What happened, in plain terms
+- What data was involved, and for which of *their* users
+- The window of exposure
+- Whether access is confirmed, possible-but-unconfirmed, or ruled out — state
+  which, and how you know
+- What has been done
+- What they should do
+- A named contact
+
+Say "we could not determine whether the data was accessed" when that is true.
+Do not say "no data was accessed" unless logs support it.
+
+Regulatory notification (SEC, state AGs, GDPR supervisory authorities) is
+**counsel's call**, not engineering's. Escalate; do not decide.
+
+## 7. Contacts
+
+| | |
+|---|---|
+| Incident owner | [NAME, PHONE] |
+| External counsel | [FIRM, NAME, 24h NUMBER] |
+| Supabase support | [SUPPORT PLAN / ESCALATION PATH] |
+| Cyber insurance | [CARRIER, POLICY NUMBER, CLAIMS LINE] |
+| Customer security contacts | [MAINTAIN A LIST — you need it at 3am, not then] |
+
+## 8. Afterwards
+
+Within 10 business days: a written post-incident review — timeline, root cause,
+what detection would have caught it sooner, and dated remediation owners.
+
+Blameless as to people, specific as to systems. The Aug 2026 exposure is a fair
+example: the control was correct in the migration and wrong in production
+because it was changed outside version control and nothing compared the two.
+The remediation is a drift check, not a reprimand.
+
+## 9. Known gaps
+
+Recorded deliberately — a plan claiming capabilities it lacks is worse than one
+that admits them.
+
+- **No alerting.** Every incident so far was found by a human looking. There is
+  no monitor that would page anyone for a bucket turning public or a policy
+  being dropped.
+- **No schema-drift detection.** Production has diverged from
+  `supabase/migrations/` in at least four documented ways.
+- **Access logs not routinely reviewed**, and retention of them is unconfirmed
+  — this directly limits what can be said in a notification.
+- **Untested.** No tabletop has been run.

--- a/docs/legal/PRIVACY-POLICY.draft.md
+++ b/docs/legal/PRIVACY-POLICY.draft.md
@@ -1,0 +1,179 @@
+# Privacy Policy — DRAFT, NOT LEGAL REVIEWED
+
+> **Do not publish this as-is.** It was drafted from `DATA-INVENTORY.md` by an
+> engineer, not a lawyer. Every bracketed `[…]` is a fact only you can supply.
+> The notes in blockquotes are for your counsel and should be deleted before
+> publication.
+>
+> One drafting rule was followed throughout: **it does not promise anything the
+> code does not do.** In particular the deletion section describes suspension
+> rather than erasure, because erasure does not exist yet. If you build it,
+> update this. If you shorten this document, do not shorten it by making the
+> promises broader.
+
+**Effective date:** [DATE]
+**Last updated:** [DATE]
+
+---
+
+## Who we are
+
+Tesseract is research and decision software for investment teams, operated by
+[LEGAL ENTITY NAME], [JURISDICTION]. You can reach us at [PRIVACY CONTACT
+EMAIL].
+
+## Two different roles
+
+Most of what Tesseract stores is information your firm puts into it — research
+notes, investment theses, portfolio holdings, trade decisions. For that
+information **your firm decides what is collected and why, and we act on your
+firm's instructions.** In data-protection terms, your firm is the controller
+and we are the processor. If you are an employee of a customer firm and want
+that information changed or removed, ask your firm first; we act on their
+instruction.
+
+For the information we hold about you as a user of the service — your name,
+email, how you use the product — **we decide, and this policy governs.**
+
+## What we collect
+
+**Account information.** Your name, email address, which organization you
+belong to, and your role within it.
+
+**Usage information.** Records of what you do in the product: what you viewed
+and edited, when, and from which organization. This drives audit history,
+notifications and activity feeds. Some of it exists specifically so your firm
+can reconstruct who made which investment decision and when.
+
+**Content you create.** Research notes, theses, price targets, ratings, trade
+ideas, simulations, portfolio and holdings data, workflow state, and any files
+you upload.
+
+**Technical information.** Browser and device information, and error diagnostics
+when something goes wrong — see *Error monitoring* below.
+
+We do not use cookies for advertising, and we do not sell personal information.
+
+## Error monitoring and session recording
+
+When the application encounters an error, we send diagnostic information to
+**Sentry**, our error-monitoring provider. For sessions that hit an error, this
+includes a **replay of the session** — a reconstruction of what was on screen —
+so we can see what went wrong. Sessions that do not error are never recorded.
+
+Replays are captured with text, form inputs and media masked, so the content of
+your research should not be legible in them. [CONFIRM WITH COUNSEL WHETHER YOU
+WANT TO STATE THIS AS A GUARANTEE.] We do not attach IP addresses or cookies to
+these reports.
+
+> Note for counsel: this is disclosed prominently because session replay is the
+> item most often challenged in customer security reviews. Under-disclosing it
+> is the bigger risk.
+
+## Artificial intelligence
+
+Tesseract includes AI features. **When you use them, the relevant content is
+sent to a third-party AI provider to generate a response.** Depending on what
+your organization has configured, that content can include asset information,
+investment theses, note content, outcomes, and portfolio and holdings data.
+
+Our current providers are **Anthropic** (default), **OpenAI**, **Google**, and
+**Perplexity**. Perplexity's models are search-augmented, meaning your query may
+be used to retrieve information from the public web.
+
+We do not use your content to train our own models. [WE HAVE AGREEMENTS WITH
+THESE PROVIDERS THAT THEY DO NOT TRAIN ON YOUR CONTENT — **confirm in writing
+per provider before stating this**.]
+
+If your organization supplies its own AI provider key, the content goes to that
+provider under **your organization's** agreement with them, not ours.
+
+AI output can be wrong. It supports your judgement; it does not replace it, and
+it is not investment advice.
+
+## Who else we share information with
+
+We share information only with providers that help us run the service:
+
+| Provider | Purpose |
+|---|---|
+| Supabase | Database and file storage (United States) |
+| Netlify | Application hosting |
+| Anthropic, OpenAI, Google, Perplexity | AI features, when used |
+| Sentry | Error monitoring and session replay |
+| Alpha Vantage, Yahoo, Polygon, Finnhub | Market data. They receive ticker symbols, not your research |
+
+A current list is maintained at [SUBPROCESSOR LIST URL].
+
+We also disclose information where the law requires it, and to a successor
+entity in the event of a merger or acquisition.
+
+## Where information is held
+
+In the United States. [IF YOU HAVE EU/UK USERS, ADD A TRANSFER MECHANISM —
+STANDARD CONTRACTUAL CLAUSES — AND SAY SO.]
+
+## How long we keep it
+
+We keep your firm's content for as long as your firm's account is active,
+because it is their business record and in many cases something they are
+required to retain.
+
+Audit logs are retained for a period your organization's administrators
+configure.
+
+> Note for counsel: this is the honest position. There is currently no
+> scheduled deletion of notes, research, holdings history or uploaded files.
+> Do not add a retention period here that nothing enforces.
+
+## Your choices
+
+You can view and correct your account information in the product.
+
+**Access, correction and deletion.** For content your firm controls, contact
+your firm's administrator. For your account information, contact us at [PRIVACY
+CONTACT EMAIL].
+
+**On account deletion:** when a user leaves an organization, their access is
+revoked and their account is deactivated. Their name remains attached to the
+research and decisions they authored, because those are your firm's business
+records and, for a regulated firm, records it may be legally required to keep.
+If you want your personal information removed beyond deactivation, contact us
+and we will tell you what we can remove and what your firm's obligations
+require us to keep.
+
+> Note for counsel: this paragraph is written to match what the software
+> actually does — deactivate, not erase. It is defensible for a B2B
+> recordkeeping product, but it *is* the weakest point in this document and
+> the most likely to be challenged. Building an erasure path would let you
+> replace it with something stronger.
+
+**California residents.** [ADD CCPA/CPRA RIGHTS IF THRESHOLDS ARE MET. NOTE
+CCPA COVERS B2B CONTACTS.]
+
+**EU/UK residents.** [ADD GDPR RIGHTS AND LEGAL BASES IF IN SCOPE.]
+
+## Security
+
+Customer data is separated by organization and access is enforced at the
+database level. Access to production systems is limited to personnel who need
+it. [DESCRIBE ENCRYPTION AT REST AND IN TRANSIT ONCE CONFIRMED.]
+
+If we become aware of unauthorized access to your information, we will notify
+the affected organization without undue delay and in any event within the
+timeframes required by our customer agreements and applicable law. See our
+incident response commitments in your customer agreement.
+
+## Children
+
+Tesseract is business software and is not directed to anyone under 18.
+
+## Changes
+
+We will post any change here and update the date above. For material changes we
+will notify organization administrators.
+
+## Contact
+
+[PRIVACY CONTACT EMAIL]
+[POSTAL ADDRESS]

--- a/docs/legal/README.md
+++ b/docs/legal/README.md
@@ -1,0 +1,45 @@
+# Legal and compliance documents
+
+**Nothing here has been reviewed by a lawyer. Do not publish or sign any of it
+as-is.**
+
+These were written by an engineer from the actual codebase and a live read of
+the production database on 2026-08-14, so that counsel can start from what the
+software genuinely does rather than reverse-engineering it.
+
+| File | Status | What it is |
+|---|---|---|
+| `DATA-INVENTORY.md` | **Factual** | What is collected, where it goes, who receives it, what deletion really does. Everything else derives from this. |
+| `SUBPROCESSORS.md` | **Factual — publishable** | The third parties that receive data. Customers ask for this in diligence. |
+| `PRIVACY-POLICY.draft.md` | Draft | Required in practice: CalOPPA obliges a posted policy for any commercial site collecting personal info from Californians. |
+| `TERMS-OF-SERVICE.draft.md` | Draft | Boilerplate except the ★ clauses — not-advice, AI, recordkeeping, liability cap. |
+| `DPA.draft.md` | Draft | What enterprise customers will require. ⚠ clauses commit to things not yet built. |
+| `INCIDENT-RESPONSE.draft.md` | Draft | The 72-hour Reg S-P commitment and how to actually meet it. |
+
+## The one rule these follow
+
+**They do not promise anything the code does not do.**
+
+The clearest example is deletion. There is no account or organization erasure
+path — only suspension — so the privacy policy describes suspension, and the
+DPA flags the gap rather than papering over it. If you build erasure, the
+documents get *stronger*; if you edit them to sound better without building it,
+you have created the liability the exercise was meant to avoid.
+
+## Read these first
+
+- `DATA-INVENTORY.md` §4 — deletion reality
+- `DATA-INVENTORY.md` §8 — three closed exposures a regulator or customer may
+  ask about, including a publicly-readable storage bucket up to 2026-08-14
+- `DATA-INVENTORY.md` §9 — the five questions for counsel
+
+## Keeping them true
+
+They are only useful while accurate. Re-check when you:
+
+- add a third-party service that receives data → `SUBPROCESSORS.md`
+- add or change a data-deleting path → inventory §4 and the privacy policy
+- change what the AI features transmit → inventory §3 and the privacy policy
+- change retention → inventory §5
+
+An out-of-date privacy policy is a misrepresentation, not just stale docs.

--- a/docs/legal/SUBPROCESSORS.md
+++ b/docs/legal/SUBPROCESSORS.md
@@ -1,0 +1,52 @@
+# Subprocessors
+
+**Status: factual. Publish this one.**
+Last verified against the codebase 2026-08-14.
+
+Customers ask for this list during diligence and their own privacy policies
+have to name it. Keep it current: adding a provider in code without adding it
+here breaks the DPA commitment to notify before new subprocessors.
+
+## Infrastructure
+
+| Subprocessor | Purpose | Data | Location |
+|---|---|---|---|
+| Supabase | Database, authentication, file storage | All customer content and account data | United States (us-east-1) |
+| Netlify | Application hosting and build | Static assets; request logs | United States |
+
+## AI providers
+
+Engaged only when a customer uses AI features. Content sent can include asset
+data, investment theses, note bodies, outcomes, and portfolio holdings —
+see `DATA-INVENTORY.md` §3.
+
+| Subprocessor | Purpose | Notes |
+|---|---|---|
+| Anthropic | AI chat and generation | Platform default |
+| OpenAI | AI chat and generation | Selectable |
+| Google | AI chat and generation | Selectable |
+| Perplexity | AI chat and generation | **Search-augmented** — queries may be used to retrieve from the public web |
+
+Where a customer configures its own provider key (BYOK), that provider is the
+**customer's** subprocessor, not ours.
+
+> **Open item:** zero-retention / no-training terms have not been confirmed in
+> writing with any of these. Until they are, neither the privacy policy nor
+> the DPA should assert them.
+
+## Operations
+
+| Subprocessor | Purpose | Data |
+|---|---|---|
+| Sentry | Error monitoring, performance tracing, session replay on errored sessions | Diagnostics; masked DOM replay |
+
+## Market data
+
+These receive **ticker symbols only** — no customer content or personal data.
+
+| Subprocessor | Purpose |
+|---|---|
+| Alpha Vantage | Prices, fundamentals |
+| Yahoo Finance | Prices, charts |
+| Polygon | Market data |
+| Finnhub | Market data, news |

--- a/docs/legal/TERMS-OF-SERVICE.draft.md
+++ b/docs/legal/TERMS-OF-SERVICE.draft.md
@@ -1,0 +1,134 @@
+# Terms of Service — DRAFT, NOT LEGAL REVIEWED
+
+> Drafted from `DATA-INVENTORY.md`. Terms are more boilerplate-able than the
+> privacy policy, so this is deliberately shorter — but the clauses that are
+> *specific to Tesseract* are marked **★** and are the ones worth your
+> counsel's actual attention. Everything else is standard SaaS scaffolding
+> your lawyer likely has a better version of.
+
+**Effective:** [DATE] · Between **[LEGAL ENTITY]** ("we") and the customer
+organization ("you").
+
+---
+
+## 1. The service
+
+We provide research, decision and outcome-tracking software for investment
+teams, as described in your order form or subscription.
+
+## 2. Accounts
+
+You are responsible for your users' accounts and credentials, for the accuracy
+of the information in them, and for promptly removing access for people who
+should no longer have it. Administrators you designate can add, suspend and
+configure users.
+
+## 3. Your content
+
+**You own your content.** Research, notes, theses, holdings, trade records and
+uploaded files remain yours. You grant us the rights necessary to host,
+process, transmit and display it in order to provide the service — including
+transmitting it to the subprocessors listed at [URL].
+
+You are responsible for having the right to upload what you upload, and for not
+uploading anything unlawful or infringing.
+
+## 4. ★ Not investment advice
+
+The service is a tool. It does not provide investment, legal, tax or accounting
+advice, and nothing it outputs — including AI-generated content, price targets,
+simulations, or any ranking, score or suggestion — is a recommendation to buy
+or sell any security.
+
+**You are solely responsible for every investment decision you make.** You are
+responsible for your own regulatory compliance, including suitability, best
+execution, recordkeeping and supervision.
+
+## 5. ★ AI features
+
+AI features are provided on an as-is basis and rely on third-party model
+providers. **Output can be inaccurate, incomplete or fabricated, and must be
+independently verified before being relied on.**
+
+Using AI features transmits your content to the applicable provider — see the
+privacy policy. Where you supply your own provider key, your agreement with
+that provider governs that processing.
+
+We do not warrant that AI output is accurate, complete, current or suitable for
+any purpose.
+
+## 6. ★ Records and retention
+
+The service is not a system of record for regulatory purposes unless expressly
+agreed in writing. **You remain responsible for your own recordkeeping
+obligations, including under SEC Advisers Act Rule 204-2 and any equivalent
+rule, and for retaining your records independently of the service.**
+
+> Note for counsel: this disclaimer matters. Advisers *will* keep required
+> records here in practice. Whether this clause holds if they do is worth a
+> securities lawyer's view — see `DATA-INVENTORY.md` §9 question 2.
+
+## 7. Acceptable use
+
+Do not attempt to access another organization's data; probe, scan or test the
+security of the service except under a written authorization; reverse engineer
+it; resell it; or use it to build a competing product.
+
+Do not upload malware or use the service to violate law.
+
+## 8. Availability and support
+
+We aim to keep the service available and will provide support as described in
+your order form. **[ADD AN SLA ONLY IF YOU CAN MEET IT AND MEASURE IT.]** We may
+perform maintenance, and will give reasonable notice where practical.
+
+## 9. Fees
+
+As set out in your order form. Fees are non-refundable except as stated there.
+Late payment may result in suspension after notice.
+
+## 10. Confidentiality
+
+Each party will protect the other's confidential information with at least
+reasonable care and use it only to perform under these terms.
+
+## 11. Term and termination
+
+Either party may terminate for material breach not cured within [30] days'
+notice. On termination your access ends and data is handled per the DPA.
+
+## 12. Warranties and disclaimers
+
+We warrant we will provide the service with reasonable skill and care. **Except
+as expressly stated, the service is provided "as is" and we disclaim all other
+warranties to the extent permitted by law.**
+
+## 13. Limitation of liability
+
+Neither party is liable for indirect, incidental, special or consequential
+damages, or lost profits.
+
+**Each party's aggregate liability is limited to [FEES PAID IN THE PRECEDING 12
+MONTHS].**
+
+> ★ Note for counsel: think hard about the cap and its carve-outs. This
+> product holds portfolio holdings and trade intentions — the material
+> non-public information of regulated firms. Customers will push for a
+> super-cap or an uncapped carve-out for data breach and confidentiality.
+> Decide your position deliberately rather than discovering it mid-negotiation.
+
+## 14. Indemnities
+
+**[ADD: your IP indemnity to them; their indemnity for their content and
+unlawful use. Standard, but get the drafting from counsel.]**
+
+## 15. General
+
+Governing law: **[JURISDICTION]**. Disputes: **[FORUM / ARBITRATION]**. These
+terms plus the order form, DPA and privacy policy are the entire agreement.
+Neither party may assign without consent except in a merger or sale of
+substantially all assets. We may update these terms on reasonable notice.
+
+## Contact
+
+[LEGAL CONTACT EMAIL]

--- a/scripts/sql/phase3-assets-bucket-org-rls.sql
+++ b/scripts/sql/phase3-assets-bucket-org-rls.sql
@@ -98,7 +98,10 @@ ON storage.objects FOR UPDATE TO authenticated
 USING (
   bucket_id = 'assets'
   AND (storage.foldername(name))[1] = current_org_id()::text
-  AND auth.uid()::text = owner
+  -- `owner` is uuid here, so compare uuid to uuid. 20251013115000 wrote
+  -- `auth.uid()::text = owner`, which no longer type-checks; the live policy
+  -- reads `owner = auth.uid()`, and that is what is preserved.
+  AND owner = auth.uid()
 );
 
 CREATE POLICY "assets: delete own files within current org"
@@ -106,7 +109,10 @@ ON storage.objects FOR DELETE TO authenticated
 USING (
   bucket_id = 'assets'
   AND (storage.foldername(name))[1] = current_org_id()::text
-  AND auth.uid()::text = owner
+  -- `owner` is uuid here, so compare uuid to uuid. 20251013115000 wrote
+  -- `auth.uid()::text = owner`, which no longer type-checks; the live policy
+  -- reads `owner = auth.uid()`, and that is what is preserved.
+  AND owner = auth.uid()
 );
 
 COMMIT;

--- a/scripts/sweep-orphaned-assets.mjs
+++ b/scripts/sweep-orphaned-assets.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+/**
+ * Find (and optionally delete) objects in the `assets` bucket that no database
+ * row points at.
+ *
+ * Orphans accumulate for ordinary reasons — an upload that succeeded while the
+ * row insert failed, a row deleted by a path that predates cascade cleanup, a
+ * note whose attachment was removed from the document. They are invisible in
+ * the product and unreachable by any user, which is exactly what makes them a
+ * problem: they are personal data we hold, cannot show anyone, and would not
+ * think to include in a deletion request or a breach notification.
+ *
+ * Ownership sources are the same ones the org-scope backfill uses. Anything
+ * not claimed by one of them is an orphan.
+ *
+ *   SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... \
+ *     node scripts/sweep-orphaned-assets.mjs                 # report only
+ *
+ *   ... node scripts/sweep-orphaned-assets.mjs --delete      # actually delete
+ *
+ * Report-only is the default. --delete is irreversible: Supabase Storage has
+ * no undelete, so run the report, read it, and keep the JSON before deleting.
+ * A --min-age-days guard (default 7) keeps it from racing an upload that is
+ * mid-flight in another tab.
+ */
+
+import { createClient } from '@supabase/supabase-js'
+import { writeFileSync } from 'node:fs'
+
+const BUCKET = 'assets'
+const DELETE = process.argv.includes('--delete')
+const MIN_AGE_DAYS = Number(
+  (process.argv.find(a => a.startsWith('--min-age-days=')) || '').split('=')[1] ?? 7
+)
+const REPORT = './orphaned-assets-report.json'
+
+const url = process.env.SUPABASE_URL
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+if (!url || !key) {
+  console.error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set.')
+  process.exit(1)
+}
+const db = createClient(url, key, { auth: { persistSession: false } })
+
+/** Tables that own an object, and the column holding its path. */
+const PATH_SOURCES = [
+  ['asset_notes', 'file_path'],
+  ['asset_models', 'file_path'],
+  ['model_versions', 'file_path'],
+  ['model_files', 'storage_path'],
+  ['model_templates', 'base_template_path'],
+  ['asset_checklist_attachments', 'file_path'],
+  ['portfolio_checklist_attachments', 'file_path'],
+]
+
+/** Note tables whose ProseMirror content embeds fileAttachment filePath attrs. */
+const NOTE_TABLES = ['asset_notes', 'portfolio_notes', 'theme_notes', 'custom_notebook_notes']
+
+async function selectAll(table, select) {
+  const rows = []
+  const PAGE = 1000
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await db.from(table).select(select).range(from, from + PAGE - 1)
+    if (error) return { rows: null, error }
+    rows.push(...data)
+    if (data.length < PAGE) break
+  }
+  return { rows, error: null }
+}
+
+async function listObjects(prefix = '') {
+  const out = []
+  const PAGE = 1000
+  for (let offset = 0; ; offset += PAGE) {
+    const { data, error } = await db.storage
+      .from(BUCKET)
+      .list(prefix, { limit: PAGE, offset, sortBy: { column: 'name', order: 'asc' } })
+    if (error) throw new Error(`list(${prefix}): ${error.message}`)
+    for (const e of data) {
+      const full = prefix ? `${prefix}/${e.name}` : e.name
+      if (e.id === null) out.push(...(await listObjects(full)))
+      else out.push({ name: full, created_at: e.created_at, size: e.metadata?.size ?? 0 })
+    }
+    if (data.length < PAGE) break
+  }
+  return out
+}
+
+function collectPaths(node, acc = []) {
+  if (!node || typeof node !== 'object') return acc
+  if (Array.isArray(node)) { for (const n of node) collectPaths(n, acc); return acc }
+  if (node.attrs?.filePath) acc.push(node.attrs.filePath)
+  if (node.content) collectPaths(node.content, acc)
+  return acc
+}
+
+async function main() {
+  console.log(`${DELETE ? 'DELETE' : 'REPORT'} mode — bucket "${BUCKET}", min age ${MIN_AGE_DAYS}d\n`)
+
+  const objects = await listObjects()
+  const referenced = new Set()
+  const unreadable = []
+
+  for (const [table, col] of PATH_SOURCES) {
+    const { rows, error } = await selectAll(table, col)
+    if (error) { unreadable.push(`${table}.${col}: ${error.message}`); continue }
+    for (const r of rows) if (r[col]) referenced.add(r[col])
+  }
+
+  for (const table of NOTE_TABLES) {
+    const { rows, error } = await selectAll(table, 'id, content')
+    if (error) { unreadable.push(`${table}.content: ${error.message}`); continue }
+    for (const r of rows) {
+      let doc = r.content
+      if (typeof doc === 'string') { try { doc = JSON.parse(doc) } catch { continue } }
+      for (const p of collectPaths(doc)) referenced.add(p)
+    }
+  }
+
+  // A source we could not read makes every object it owns look orphaned.
+  // Deleting on that basis would destroy live files, so refuse outright.
+  if (unreadable.length) {
+    console.log('!! could not read these ownership sources:')
+    for (const u of unreadable) console.log(`   ${u}`)
+    if (DELETE) {
+      console.log('\nRefusing to delete: objects owned by an unreadable source are')
+      console.log('indistinguishable from orphans. Fix the query first.')
+      process.exit(2)
+    }
+  }
+
+  const cutoff = Date.now() - MIN_AGE_DAYS * 86_400_000
+  const orphans = objects.filter(o => !referenced.has(o.name))
+  const deletable = orphans.filter(o => new Date(o.created_at).getTime() < cutoff)
+  const tooNew = orphans.length - deletable.length
+
+  console.log(`objects            ${objects.length}`)
+  console.log(`referenced by a row${String(referenced.size).padStart(4)}`)
+  console.log(`orphans            ${orphans.length}${tooNew ? `  (${tooNew} newer than ${MIN_AGE_DAYS}d, held back)` : ''}`)
+  const bytes = deletable.reduce((n, o) => n + Number(o.size || 0), 0)
+  if (deletable.length) console.log(`reclaimable        ${(bytes / 1024).toFixed(1)} kB`)
+
+  writeFileSync(REPORT, JSON.stringify({ generatedFor: url, unreadable, orphans, deletable }, null, 2))
+  console.log(`\nreport: ${REPORT}`)
+
+  if (!DELETE) {
+    if (deletable.length) console.log('\nReport only — re-run with --delete to remove them.')
+    return
+  }
+  if (!deletable.length) { console.log('\nNothing to delete.'); return }
+
+  for (let i = 0; i < deletable.length; i += 100) {
+    const batch = deletable.slice(i, i + 100).map(o => o.name)
+    const { error } = await db.storage.from(BUCKET).remove(batch)
+    console.log(error ? `batch failed: ${error.message}` : `deleted ${batch.length}`)
+  }
+}
+
+main().catch(err => { console.error(err); process.exit(1) })

--- a/src/hooks/useAssetModels.ts
+++ b/src/hooks/useAssetModels.ts
@@ -225,9 +225,25 @@ export function useAssetModels(assetId: string | undefined) {
     }
   })
 
-  // Soft delete model
+  // Soft delete model.
+  //
+  // The row is kept for history, but the uploaded file is removed. Nothing in
+  // the product restores a soft-deleted model — there is no is_deleted:false
+  // path anywhere — so leaving the object behind meant a file the user
+  // believes they deleted stayed in storage indefinitely, with a row pointing
+  // at it that no screen renders. That is data we hold and cannot account for.
+  //
+  // Storage removal is best-effort and runs first: if it fails we still mark
+  // the row deleted (the user asked for it to go), and the orphan sweeper in
+  // scripts/sweep-orphaned-assets.mjs catches whatever is left behind.
   const deleteModel = useMutation({
     mutationFn: async (id: string) => {
+      const model = models.find(m => m.id === id)
+      if (model?.file_path) {
+        const { error: rmErr } = await supabase.storage.from('assets').remove([model.file_path])
+        if (rmErr) console.error('Failed to remove model file from storage:', rmErr)
+      }
+
       const { error } = await supabase
         .from('asset_models')
         .update({ is_deleted: true })

--- a/src/hooks/useModelTemplates.ts
+++ b/src/hooks/useModelTemplates.ts
@@ -567,6 +567,7 @@ interface UseModelFilesOptions {
 
 export function useModelFiles({ assetId, userId, latestOnly = true }: UseModelFilesOptions) {
   const { user } = useAuth()
+  const currentOrgId = useOrganizationOptional()?.currentOrgId ?? null
   const queryClient = useQueryClient()
 
   const {
@@ -647,10 +648,17 @@ export function useModelFiles({ assetId, userId, latestOnly = true }: UseModelFi
       const nextVersion = (prevFiles?.[0]?.version || 0) + 1
       const previousVersionId = prevFiles?.[0]?.id
 
-      // Upload file to storage
-      const storagePath = `models/${assetId}/${user.id}/${Date.now()}_${file.name}`
+      // Upload file to storage.
+      //
+      // This wrote to a `model-files` bucket that does not exist in the
+      // project — so did the delete and download paths — which is why
+      // model_files has zero rows: the feature has never once worked. The
+      // sibling base-template code in this same hook already reads and
+      // writes `assets`, so that is where these belong; the distinct
+      // `model-files/` prefix keeps them out of asset_models' `models/`.
+      const storagePath = assetsPath(currentOrgId, 'model-files', assetId, user.id, `${Date.now()}_${file.name}`)
       const { error: uploadError } = await supabase.storage
-        .from('model-files')
+        .from('assets')
         .upload(storagePath, file)
 
       if (uploadError) throw uploadError
@@ -738,7 +746,7 @@ export function useModelFiles({ assetId, userId, latestOnly = true }: UseModelFi
 
       if (file?.storage_path) {
         await supabase.storage
-          .from('model-files')
+          .from('assets')
           .remove([file.storage_path])
       }
 
@@ -758,7 +766,7 @@ export function useModelFiles({ assetId, userId, latestOnly = true }: UseModelFi
   // Get download URL for a file
   const getDownloadUrl = async (storagePath: string) => {
     const { data, error } = await supabase.storage
-      .from('model-files')
+      .from('assets')
       .createSignedUrl(storagePath, 60 * 60) // 1 hour
 
     if (error) throw error


### PR DESCRIPTION
Follow-on to #122, closing the remaining open items.

## model_files has never worked

Upload, delete and download all addressed a `model-files` bucket that does not exist in the project — the table has zero rows in production, which is the feature telling us so. All three now use the `assets` bucket under an org-scoped `model-files/` prefix, matching the sibling base-template code in the same hook.

## Deleting a model now deletes the file

`deleteModel` set `is_deleted` and left the object in storage forever. Nothing in the product restores a soft-deleted model — there is no `is_deleted: false` path anywhere — so that was a file the user believes they deleted, that no screen renders, and that we would not think to include in a deletion request.

Removal runs first and is best-effort: if storage fails we still mark the row deleted, because the user asked for it to go, and the sweeper catches the remainder.

## scripts/sweep-orphaned-assets.mjs

Finds objects no row points at — across all seven path columns plus `filePath` attributes embedded in note ProseMirror content. Report-only by default; `--delete` holds back anything under 7 days old so it cannot race an upload in another tab, and refuses outright if an ownership source fails to read, since objects owned by an unreadable source are indistinguishable from orphans and deleting on that basis destroys live files.

Run against production: 9 objects, 7 referenced, 2 genuine orphans (left in place).

## docs/legal/

Six documents written from the codebase and a live read of the production database rather than from assumption. Two factual (one publishable), four drafts marked NOT LEGAL REVIEWED.

They follow one rule: **they do not promise anything the code does not do.** There is no account or organization erasure path — only suspension — so the privacy policy describes suspension and the DPA flags the gap with a warning rather than papering over it. Clauses committing to things that do not exist (SOC 2, export routines, erasure-on-request) are marked as such.

`DATA-INVENTORY.md` is the source the others derive from. It also records three now-closed exposures a customer or regulator may ask about — including the `assets` bucket having been publicly readable until 2026-08-14 — and five open questions for counsel.

## Already applied to production

Quarantine cleared: all three `_unattributed/` objects moved into the Tesseract org per the owner's instruction, and the `Test` model template row now carries that `organization_id`. No object sits outside an org prefix, and `model_templates` has no rows without an org.

## Verification

Typecheck: 67 pre-existing errors across both touched hooks, 67 after — diffed against a stash, not eyeballed. Tests 1037 pass. Production build verified. **Not verified in a browser.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
