### PR TITLE
Real erasure for a person and for an organization

### DIFF
--- a/docs/legal/DATA-INVENTORY.md
+++ b/docs/legal/DATA-INVENTORY.md
@@ -131,17 +131,24 @@ Be careful here: promising more than this is a policy that is not implemented.
 | Ask | Reality |
 |---|---|
 | Delete an uploaded model | Row soft-deleted **and file removed from storage** (as of this change) |
-| Delete a note | Row deleted; **an attachment inside the note body is not removed** |
-| Delete an attachment in the composer | File removed (as of this change) |
-| Delete a user account | **No path exists.** Users can only be *suspended* via `deactivate_org_member` |
-| Delete an organization and its data | **No path exists** |
-| Export my data | `org-exports` job infrastructure exists; not a user-facing DSAR flow |
+| Delete a note | Row soft-deleted **and its attachments and screenshots removed** |
+| Delete an attachment in the composer | File removed |
+| Erase a user's personal data | `erase_user_personal_data()` RPC + `scripts/erase-user.mjs` — preferences, saved views, notifications, AI history and identity erased; authored records retained as the firm's business records, attributed to "Former user" |
+| Delete an organization and its data | `scripts/sql/erase-organization-rows.sql` + `scripts/erase-organization.mjs` — all rows and all files. Operator-run, irreversible |
+| Export my data | `org-exports` job infrastructure exists; **still not a user-facing DSAR flow** |
 
 `scripts/sweep-orphaned-assets.mjs` reports (and optionally deletes) files no
 row points at. Report-only by default.
 
-**The account-erasure gap is the one that most directly contradicts a standard
-privacy policy.** Either build it or write the policy around what exists.
+Erasure is deliberately a *split*, not a wipe: the person is erased, the work
+they authored is retained. That is not evasion — the authored records belong to
+the customer firm, which is their controller, and for an SEC-registered adviser
+they are records it is required to retain under Advisers Act Rule 204-2.
+Deleting them on an individual's request would destroy the firm's compliance
+record.
+
+**Remaining gap: there is no self-service export.** A DSAR asking for a copy of
+personal data is currently a manual job.
 
 ---
 

--- a/docs/legal/DPA.draft.md
+++ b/docs/legal/DPA.draft.md
@@ -94,11 +94,16 @@ Processor will provide reasonable assistance with data subject requests, data
 protection impact assessments, and consultations with supervisory authorities,
 taking into account the nature of processing and the information available.
 
-**⚠ Data subject requests:** Processor's ability to *delete* a specific
-individual's personal data is currently limited to deactivating their access
-and account. Content authored by that individual is retained as Controller's
-business record. **If Controller requires erasure-on-request, that must be
-agreed separately — the capability does not exist today.**
+**Data subject requests.** On Controller's instruction, Processor will erase an
+individual's personal data — identity, preferences, saved views, notifications,
+AI prompt history and login. Content that individual authored is **retained as
+Controller's business record** and re-attributed to a non-identifying label.
+Controller acknowledges this split is necessary for Controller's own
+recordkeeping obligations, and that a request to delete authored content is a
+matter between Controller and its personnel.
+
+**⚠ Processor has no self-service export.** A request for a *copy* of personal
+data is fulfilled manually. Do not agree to an automated-export SLA.
 
 ## 8. Audits
 
@@ -114,9 +119,11 @@ Within **[30] days** of termination, Processor will, at Controller's election,
 return Customer Data in a machine-readable format or delete it, save where
 retention is required by law.
 
-**⚠ Neither a self-service export nor a verified deletion routine exists
-today.** `org-exports` provides job infrastructure; there is no organization
-erasure path. Do not agree to a shorter window than you can perform manually.
+Organization erasure is implemented and operator-run: it removes every row
+carrying the organization's identifier and every file stored under it.
+**⚠ It is irreversible and has not yet been exercised against a real
+organization** — rehearse it on a disposable org before committing to a window.
+Export remains manual; `org-exports` provides job infrastructure only.
 
 Controller acknowledges that where Controller is subject to recordkeeping
 obligations (including SEC Advisers Act Rule 204-2), Controller is responsible

--- a/docs/legal/PRIVACY-POLICY.draft.md
+++ b/docs/legal/PRIVACY-POLICY.draft.md
@@ -6,9 +6,9 @@
 > publication.
 >
 > One drafting rule was followed throughout: **it does not promise anything the
-> code does not do.** In particular the deletion section describes suspension
-> rather than erasure, because erasure does not exist yet. If you build it,
-> update this. If you shorten this document, do not shorten it by making the
+> code does not do.** The deletion section describes erasure because erasure
+> now exists; it stops short of promising a self-service data export because
+> that does not. If you shorten this document, do not shorten it by making the
 > promises broader.
 
 **Effective date:** [DATE]
@@ -122,9 +122,10 @@ required to retain.
 Audit logs are retained for a period your organization's administrators
 configure.
 
-> Note for counsel: this is the honest position. There is currently no
-> scheduled deletion of notes, research, holdings history or uploaded files.
-> Do not add a retention period here that nothing enforces.
+> Note for counsel: this is the honest position. There is no *scheduled*
+> deletion of notes, research, holdings history or uploaded files — deletion
+> happens on request, not on a timer. Do not add a retention period here that
+> nothing enforces.
 
 ## Your choices
 
@@ -134,19 +135,30 @@ You can view and correct your account information in the product.
 your firm's administrator. For your account information, contact us at [PRIVACY
 CONTACT EMAIL].
 
-**On account deletion:** when a user leaves an organization, their access is
-revoked and their account is deactivated. Their name remains attached to the
-research and decisions they authored, because those are your firm's business
-records and, for a regulated firm, records it may be legally required to keep.
-If you want your personal information removed beyond deactivation, contact us
-and we will tell you what we can remove and what your firm's obligations
-require us to keep.
+**On deleting your personal information.** On request from you or your firm's
+administrator, we will erase your personal information: your name and email
+address, your preferences, saved views and layouts, your notifications, your AI
+prompt history, and your calendar connections. Your login is removed and your
+access ends.
 
-> Note for counsel: this paragraph is written to match what the software
-> actually does — deactivate, not erase. It is defensible for a B2B
-> recordkeeping product, but it *is* the weakest point in this document and
-> the most likely to be challenged. Building an erasure path would let you
-> replace it with something stronger.
+**The work you authored stays.** Research notes, theses, ratings and investment
+decisions remain, attributed to "Former user" rather than to you. We keep them
+because they are your firm's business records — your firm, not us and not you
+individually, decides what happens to them — and because a regulated firm is
+required by law to retain them. If you want them removed, that is a request to
+make of your firm.
+
+If your firm's account ends, we delete its data and files in full on request.
+
+> Note for counsel: this now matches the software. `erase_user_personal_data()`
+> performs the erasure; `scripts/erase-organization.mjs` and its SQL companion
+> do the organization. The retention-of-authored-content split is a deliberate
+> position — see `DATA-INVENTORY.md` §4 — and is the part most worth your
+> review, because it is where an individual's erasure right meets the firm's
+> recordkeeping obligation.
+>
+> Still not built: a self-service data export. A DSAR asking for a *copy* of
+> personal data is a manual job today.
 
 **California residents.** [ADD CCPA/CPRA RIGHTS IF THRESHOLDS ARE MET. NOTE
 CCPA COVERS B2B CONTACTS.]

--- a/docs/legal/README.md
+++ b/docs/legal/README.md
@@ -20,11 +20,15 @@ software genuinely does rather than reverse-engineering it.
 
 **They do not promise anything the code does not do.**
 
-The clearest example is deletion. There is no account or organization erasure
-path — only suspension — so the privacy policy describes suspension, and the
-DPA flags the gap rather than papering over it. If you build erasure, the
-documents get *stronger*; if you edit them to sound better without building it,
-you have created the liability the exercise was meant to avoid.
+Deletion is the worked example. When these were first drafted there was no
+erasure path at all, so the privacy policy described suspension. Erasure now
+exists — `erase_user_personal_data()` for a person, and the two erase-organization
+scripts for a whole customer — so the policy was rewritten to describe erasure.
+It still stops short of promising a self-service data export, because that
+genuinely does not exist.
+
+That is the intended cycle: build the capability, then widen the promise. Doing
+it the other way round creates exactly the liability this exercise avoids.
 
 ## Read these first
 

--- a/scripts/erase-organization.mjs
+++ b/scripts/erase-organization.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * Delete an entire organization: its rows, its files, and finally the org
+ * itself. This is the "return or delete Customer Data on termination" clause
+ * of the DPA, made real.
+ *
+ * ── This is irreversible ──────────────────────────────────────────────────
+ *
+ * There is no undo and Supabase Storage has no undelete. Take a database
+ * backup first. The script defaults to a dry run and requires you to type the
+ * organization's name to proceed, because a mistyped uuid that happens to
+ * exist would otherwise destroy the wrong customer.
+ *
+ *   SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... \
+ *     node scripts/erase-organization.mjs --org=<uuid>
+ *
+ *   ... --org=<uuid> --confirm="Exact Org Name" --apply
+ *
+ * ── How row deletion is ordered ───────────────────────────────────────────
+ *
+ * Roughly 100 tables carry organization_id and they reference each other, so
+ * there is no single correct order to hand-maintain — and a hand-maintained
+ * list silently rots as tables are added. Instead this deletes every table it
+ * can in a pass, keeps the failures, and repeats. Foreign keys make each pass
+ * unblock the next, and it stops when a pass frees nothing. Anything still
+ * standing is reported rather than force-deleted: a cycle or an unexpected
+ * constraint is something to look at, not to bulldoze.
+ *
+ * Storage is easy by comparison, and only because of the org-scoping work:
+ * every object lives under `<organization_id>/`, so the whole prefix goes.
+ */
+
+import { createClient } from '@supabase/supabase-js'
+import { writeFileSync } from 'node:fs'
+
+const arg = n => (process.argv.find(a => a.startsWith(`--${n}=`)) || '').split('=').slice(1).join('=')
+const ORG = arg('org')
+const CONFIRM = arg('confirm')
+const APPLY = process.argv.includes('--apply')
+const REPORT = './erase-organization-report.json'
+
+const url = process.env.SUPABASE_URL
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+if (!url || !key) {
+  console.error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set.')
+  process.exit(1)
+}
+if (!/^[0-9a-f-]{36}$/i.test(ORG || '')) {
+  console.error('Usage: --org=<uuid> [--confirm="Org Name" --apply]')
+  process.exit(1)
+}
+
+const db = createClient(url, key, { auth: { persistSession: false } })
+
+async function main() {
+  const { data: org, error: orgErr } = await db
+    .from('organizations').select('id, name').eq('id', ORG).maybeSingle()
+
+  if (orgErr) { console.error('Could not read organization:', orgErr.message); process.exit(1) }
+  if (!org) { console.error(`No organization ${ORG}`); process.exit(1) }
+
+  console.log(`${APPLY ? 'ERASE' : 'DRY RUN'} — "${org.name}" (${org.id})\n`)
+
+  if (APPLY && CONFIRM !== org.name) {
+    console.error(`Refusing to erase: --confirm must be exactly "${org.name}".`)
+    console.error('This is irreversible and there is no undo. Take a backup first.')
+    process.exit(2)
+  }
+
+  // ── Storage ─────────────────────────────────────────────────────────────
+  // Every object lives under `<organization_id>/`, so the org's files are a
+  // single prefix in each bucket. That is the whole reason the path migration
+  // was worth doing: before it, this step was not expressible.
+  const { data: buckets } = await db.storage.listBuckets()
+  const storagePlan = []
+  for (const b of buckets ?? []) {
+    const files = await walk(b.name, ORG)
+    if (files.length) storagePlan.push({ bucket: b.name, files })
+  }
+  const fileCount = storagePlan.reduce((n, s) => n + s.files.length, 0)
+  console.log(`storage: ${fileCount} object(s) across ${storagePlan.length} bucket(s)`)
+
+  writeFileSync(REPORT, JSON.stringify({ org, storagePlan }, null, 2))
+  console.log(`report: ${REPORT}`)
+
+  if (!APPLY) {
+    console.log(`
+Dry run — nothing deleted.
+
+Row deletion is not enumerated here: listing every organization_id table needs
+information_schema, which PostgREST does not expose. Run the SQL in
+scripts/sql/erase-organization-rows.sql against the project first (it reports
+per-table counts and deletes in dependency order inside one transaction), then
+re-run this with --apply to remove the files.`)
+    return
+  }
+
+  for (const { bucket, files } of storagePlan) {
+    for (let i = 0; i < files.length; i += 100) {
+      const batch = files.slice(i, i + 100)
+      const { error } = await db.storage.from(bucket).remove(batch)
+      console.log(error ? `  ${bucket}: FAILED ${error.message}` : `  ${bucket}: removed ${batch.length}`)
+    }
+  }
+
+  console.log('\nFiles removed. Row deletion is the SQL script — run it now if you have not.')
+}
+
+async function walk(bucket, prefix) {
+  const out = []
+  const { data, error } = await db.storage.from(bucket).list(prefix, { limit: 1000 })
+  if (error || !data) return out
+  for (const e of data) {
+    const full = `${prefix}/${e.name}`
+    if (e.id === null) out.push(...(await walk(bucket, full)))
+    else out.push(full)
+  }
+  return out
+}
+
+main().catch(err => { console.error(err); process.exit(1) })

--- a/scripts/erase-user.mjs
+++ b/scripts/erase-user.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/**
+ * Erase one person's personal data.
+ *
+ * Two steps that must happen in this order:
+ *   1. erase_user_personal_data() — the public schema: preferences, saved
+ *      views, notifications, AI history, and the identity on the users row
+ *   2. auth.admin.deleteUser()    — the login itself
+ *
+ * Order matters. Deleting the auth identity first can cascade or orphan the
+ * public.users row depending on how the project is wired, and then step 1 has
+ * nothing to anonymise — leaving the person's name attached to their authored
+ * records with no way left to reach it.
+ *
+ * What this does NOT delete is the work they authored: notes, theses, ratings,
+ * trade decisions. Those are the customer firm's business records, and for an
+ * SEC-registered adviser, records it is required to retain. They stay,
+ * attributed to "Former user". This is exactly what the privacy policy
+ * describes — if you change one, change the other.
+ *
+ *   SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... \
+ *     node scripts/erase-user.mjs --email=someone@firm.com
+ *
+ *   ... --email=someone@firm.com --confirm=someone@firm.com --apply
+ */
+
+import { createClient } from '@supabase/supabase-js'
+
+const arg = n => (process.argv.find(a => a.startsWith(`--${n}=`)) || '').split('=').slice(1).join('=')
+const EMAIL = arg('email')
+const CONFIRM = arg('confirm')
+const APPLY = process.argv.includes('--apply')
+
+const url = process.env.SUPABASE_URL
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY
+if (!url || !key) {
+  console.error('SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set.')
+  process.exit(1)
+}
+if (!EMAIL) {
+  console.error('Usage: --email=<address> [--confirm=<address> --apply]')
+  process.exit(1)
+}
+
+const db = createClient(url, key, { auth: { persistSession: false } })
+
+async function main() {
+  const { data: user, error } = await db
+    .from('users').select('id, email, full_name, first_name, last_name').eq('email', EMAIL).maybeSingle()
+
+  if (error) { console.error('Lookup failed:', error.message); process.exit(1) }
+  if (!user) { console.error(`No user with email ${EMAIL}`); process.exit(1) }
+
+  const { data: memberships } = await db
+    .from('organization_memberships')
+    .select('organization_id, status, organizations(name)')
+    .eq('user_id', user.id)
+
+  console.log(`${APPLY ? 'ERASE' : 'DRY RUN'} — ${user.email} (${user.id})`)
+  const displayName = user.full_name || [user.first_name, user.last_name].filter(Boolean).join(' ') || '—'
+  console.log(`  name: ${displayName}`)
+  console.log(`  organizations: ${(memberships ?? []).map(m => `${m.organizations?.name ?? '?'} [${m.status}]`).join(', ') || 'none'}`)
+  console.log(`
+  Will erase : preferences, saved views, layouts, bookmarks, notifications,
+               AI prompt history, calendar connections, and the name/email on
+               the users row.
+  Will keep  : everything they authored — notes, theses, ratings, trade
+               decisions — as the organization's business records, attributed
+               to "Former user".`)
+
+  if (!APPLY) {
+    console.log('\nDry run — nothing changed. Re-run with --confirm=<email> --apply.')
+    return
+  }
+  if (CONFIRM !== EMAIL) {
+    console.error(`\nRefusing: --confirm must be exactly "${EMAIL}". This is irreversible.`)
+    process.exit(2)
+  }
+
+  const { data: result, error: rpcErr } = await db.rpc('erase_user_personal_data', { p_user_id: user.id })
+  if (rpcErr) { console.error('Erasure RPC failed:', rpcErr.message); process.exit(1) }
+  console.log('\npersonal data erased:', JSON.stringify(result?.rows_deleted ?? {}, null, 2))
+
+  const { error: authErr } = await db.auth.admin.deleteUser(user.id)
+  if (authErr) {
+    // Not fatal, but it must be said plainly: the person can no longer be
+    // identified in the product, yet the login still exists.
+    console.error(`\n!! auth identity NOT deleted: ${authErr.message}`)
+    console.error('   Personal data is erased but the login remains. Remove it manually.')
+    process.exit(1)
+  }
+  console.log('auth identity deleted.')
+  console.log('\nDone. Authored records retained and attributed to "Former user".')
+}
+
+main().catch(err => { console.error(err); process.exit(1) })

--- a/scripts/sql/erase-organization-rows.sql
+++ b/scripts/sql/erase-organization-rows.sql
@@ -1,0 +1,116 @@
+-- ===========================================================================
+-- Delete every row belonging to one organization.
+--
+-- The row half of organization erasure; scripts/erase-organization.mjs does
+-- the storage half. Run this first, then the script.
+--
+-- IRREVERSIBLE. Take a database backup before running it. Set the uuid below
+-- and read the report the dry run prints before switching v_apply to true.
+-- ===========================================================================
+
+DO $$
+DECLARE
+  -- ── set these two ────────────────────────────────────────────────────────
+  v_org    UUID    := '00000000-0000-0000-0000-000000000000';
+  v_apply  BOOLEAN := FALSE;
+  -- ─────────────────────────────────────────────────────────────────────────
+
+  v_name       TEXT;
+  v_tbl        TEXT;
+  v_remaining  TEXT[];
+  v_next       TEXT[];
+  v_count      BIGINT;
+  v_total      BIGINT := 0;
+  v_pass       INT := 0;
+  v_progress   BOOLEAN;
+BEGIN
+  SELECT name INTO v_name FROM organizations WHERE id = v_org;
+  IF v_name IS NULL THEN
+    RAISE EXCEPTION 'No organization %', v_org;
+  END IF;
+  RAISE NOTICE '% — organization "%" (%)',
+    CASE WHEN v_apply THEN 'ERASING' ELSE 'DRY RUN' END, v_name, v_org;
+
+  -- Every table carrying organization_id, discovered rather than hardcoded: a
+  -- fixed list silently rots as tables are added, and a missed table means
+  -- leaving customer data behind after telling them it was deleted.
+  SELECT array_agg(table_name ORDER BY table_name) INTO v_remaining
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND column_name = 'organization_id'
+    AND table_name <> 'organizations'
+    AND table_name IN (
+      SELECT table_name FROM information_schema.tables
+      WHERE table_schema = 'public' AND table_type = 'BASE TABLE'
+    );
+
+  RAISE NOTICE '% org-scoped tables to consider', coalesce(array_length(v_remaining, 1), 0);
+
+  IF NOT v_apply THEN
+    FOREACH v_tbl IN ARRAY v_remaining LOOP
+      EXECUTE format('SELECT count(*) FROM public.%I WHERE organization_id = $1', v_tbl)
+        INTO v_count USING v_org;
+      IF v_count > 0 THEN
+        RAISE NOTICE '  % rows  %', lpad(v_count::text, 8), v_tbl;
+        v_total := v_total + v_count;
+      END IF;
+    END LOOP;
+    RAISE NOTICE 'TOTAL % rows. Nothing deleted — set v_apply := TRUE to proceed.', v_total;
+    RETURN;
+  END IF;
+
+  -- Delete what each pass can, keep the failures, repeat. Foreign keys make
+  -- each pass unblock the next. Stops when a pass frees nothing, rather than
+  -- looping forever on a cycle.
+  LOOP
+    v_pass := v_pass + 1;
+    v_progress := FALSE;
+    v_next := ARRAY[]::TEXT[];
+
+    FOREACH v_tbl IN ARRAY v_remaining LOOP
+      BEGIN
+        EXECUTE format('DELETE FROM public.%I WHERE organization_id = $1', v_tbl) USING v_org;
+        GET DIAGNOSTICS v_count = ROW_COUNT;
+        v_total := v_total + v_count;
+        v_progress := TRUE;
+        IF v_count > 0 THEN
+          RAISE NOTICE '  pass % — deleted % from %', v_pass, v_count, v_tbl;
+        END IF;
+      EXCEPTION WHEN foreign_key_violation THEN
+        -- Still referenced by a table not yet cleared. Try again next pass.
+        v_next := v_next || v_tbl;
+      END;
+    END LOOP;
+
+    v_remaining := v_next;
+    EXIT WHEN coalesce(array_length(v_remaining, 1), 0) = 0;
+    EXIT WHEN NOT v_progress;
+  END LOOP;
+
+  IF coalesce(array_length(v_remaining, 1), 0) > 0 THEN
+    -- Reported, not forced. A cycle or an unexpected constraint is something
+    -- to look at; bulldozing it is how you corrupt another org's data.
+    RAISE EXCEPTION
+      'Stopped with % table(s) undeleted: %. Nothing has been committed — '
+      'investigate the constraint before retrying.',
+      array_length(v_remaining, 1), array_to_string(v_remaining, ', ');
+  END IF;
+
+  DELETE FROM organizations WHERE id = v_org;
+  RAISE NOTICE 'Deleted % rows across % passes, and the organization row.', v_total, v_pass;
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- Verification — both should return zero.
+-- ---------------------------------------------------------------------------
+--
+--   SELECT count(*) FROM organizations WHERE id = '<uuid>';
+--
+--   -- rows left anywhere:
+--   SELECT string_agg(t, ', ') FROM (
+--     SELECT table_name AS t FROM information_schema.columns
+--     WHERE table_schema='public' AND column_name='organization_id'
+--   ) s;   -- then spot-check the tables you care about
+--
+-- Then run scripts/erase-organization.mjs --org=<uuid> --confirm="<name>" --apply
+-- to remove the files.

--- a/src/components/contributions/KeyReferencesSection.tsx
+++ b/src/components/contributions/KeyReferencesSection.tsx
@@ -55,6 +55,7 @@ import { useAuth } from '../../hooks/useAuth'
 import { supabase } from '../../lib/supabase'
 import { useOrganizationOptional } from '../../contexts/OrganizationContext'
 import { assetsPath } from '../../lib/storage/asset-paths'
+import { removeNoteAttachments } from '../../lib/storage/note-attachments'
 import { useQueryClient } from '@tanstack/react-query'
 
 // ============================================================================
@@ -742,13 +743,24 @@ export function KeyReferencesSection({
       if (doc.reference) {
         await deleteReference(doc.reference.id)
       }
-      // Delete the underlying artifact
+      // Delete the underlying artifact, and the file with it. Soft-deleting
+      // the row alone left the upload in the bucket with nothing pointing at
+      // it — undeletable through the product and invisible in it.
       if (doc.type === 'model' && doc.originalModel) {
+        if (doc.originalModel.file_path) {
+          const { error: rmErr } = await supabase.storage
+            .from('assets').remove([doc.originalModel.file_path])
+          if (rmErr) console.error('Failed to remove model file from storage:', rmErr)
+        }
         await supabase.from('asset_models')
           .update({ is_deleted: true })
           .eq('id', doc.originalModel.id)
         queryClient.invalidateQueries({ queryKey: ['asset-models', assetId] })
       } else if (doc.type === 'note' && doc.originalNote && !doc.id.startsWith('ref-')) {
+        await removeNoteAttachments(
+          (doc.originalNote as any).content,
+          doc.originalNote.file_path,
+        )
         await supabase.from('asset_notes')
           .update({ is_deleted: true })
           .eq('id', doc.originalNote.id)

--- a/src/components/notes/UniversalNoteEditor.tsx
+++ b/src/components/notes/UniversalNoteEditor.tsx
@@ -7,6 +7,7 @@ import {
   PanelLeftClose, PanelLeft, CornerDownRight, Menu
 } from 'lucide-react'
 import { supabase } from '../../lib/supabase'
+import { removeNoteAttachments } from '../../lib/storage/note-attachments'
 import { useAuth } from '../../hooks/useAuth'
 import { usePendingLineageStore } from '../../stores/pendingLineageStore'
 import { usePendingResearchLinksStore } from '../../stores/pendingResearchLinksStore'
@@ -724,6 +725,17 @@ export function UniversalNoteEditor({
   const softDeleteNoteMutation = useMutation({
     mutationFn: async (noteId: string) => {
       if (!user) throw new Error('User not authenticated')
+
+      // Remove the note's uploaded files before the row goes. Once the row is
+      // marked deleted nothing points at them, so they would sit in the bucket
+      // indefinitely — invisible to the user who just asked us to delete them.
+      // Best-effort: a storage failure must not block the delete the user
+      // asked for; scripts/sweep-orphaned-assets.mjs catches the remainder.
+      // `notes` resolves to never[] from the generated Supabase types, which
+      // is why this reads through any rather than the row type.
+      const doomed = (notes as any[] | undefined)?.find(n => n.id === noteId)
+      if (doomed) await removeNoteAttachments(doomed.content, doomed.file_path)
+
       const { error } = await supabase
         .from(config.tableName)
         .update({ is_deleted: true, updated_by: user.id, updated_at: new Date().toISOString() })

--- a/src/lib/storage/note-attachments.test.ts
+++ b/src/lib/storage/note-attachments.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest'
+import { collectNoteAttachmentPaths } from './note-attachments'
+
+const ORG = '3f2504e0-4f89-11d3-9a0c-0305e82c3301'
+
+describe('collectNoteAttachmentPaths', () => {
+  it('pulls attachment and screenshot paths out of stored note HTML', () => {
+    const html = `
+      <p>see attached</p>
+      <div data-file-path="${ORG}/attachments/note/a1/1_x.xlsx"></div>
+      <div data-screenshot-path="${ORG}/2_y.png"></div>
+    `
+    expect(collectNoteAttachmentPaths(html)).toEqual({
+      assets: [`${ORG}/attachments/note/a1/1_x.xlsx`],
+      captures: [`${ORG}/2_y.png`],
+    })
+  })
+
+  it('handles empty and missing content', () => {
+    for (const v of ['', null, undefined, '<p>no files here</p>']) {
+      expect(collectNoteAttachmentPaths(v)).toEqual({ assets: [], captures: [] })
+    }
+  })
+
+  it('deduplicates a path embedded twice', () => {
+    const p = `${ORG}/attachments/note/a1/1_x.xlsx`
+    const html = `<div data-file-path="${p}"></div><div data-file-path="${p}"></div>`
+    expect(collectNoteAttachmentPaths(html).assets).toEqual([p])
+  })
+
+  it('finds every attachment across repeated calls', () => {
+    // The regexes are module-level and /g. Without resetting lastIndex the
+    // second call resumes mid-string and silently drops attachments — which
+    // would leave files behind for every note after the first in a sweep.
+    const html = `<div data-file-path="${ORG}/a.xlsx"></div><div data-file-path="${ORG}/b.xlsx"></div>`
+    const first = collectNoteAttachmentPaths(html).assets
+    const second = collectNoteAttachmentPaths(html).assets
+    expect(second).toEqual(first)
+    expect(second).toHaveLength(2)
+  })
+
+  it('decodes escaped characters in the stored attribute', () => {
+    const html = `<div data-file-path="${ORG}/docs/a&amp;b.pdf"></div>`
+    expect(collectNoteAttachmentPaths(html).assets).toEqual([`${ORG}/docs/a&b.pdf`])
+  })
+
+  it('keeps the two buckets separate', () => {
+    // A screenshot path must never be sent to the assets bucket: remove() on
+    // the wrong bucket silently no-ops and the file survives the deletion.
+    const html = `<div data-screenshot-path="${ORG}/shot.png"></div>`
+    const { assets, captures } = collectNoteAttachmentPaths(html)
+    expect(assets).toEqual([])
+    expect(captures).toEqual([`${ORG}/shot.png`])
+  })
+})

--- a/src/lib/storage/note-attachments.ts
+++ b/src/lib/storage/note-attachments.ts
@@ -1,0 +1,100 @@
+import { supabase } from '../supabase'
+
+/**
+ * Storage cleanup for files embedded in a note.
+ *
+ * Deleting a note removed the row and left its uploaded files in the bucket
+ * forever. Nothing renders them afterwards and no row points at them, so they
+ * were personal data we held, could not show anyone, and would not have
+ * thought to include in a deletion request or a breach notification.
+ *
+ * Note content is stored as HTML, and the two extensions that own files
+ * serialise their storage path into an attribute:
+ *
+ *   FileAttachmentExtension  data-file-path        -> `assets` bucket
+ *   CaptureExtension         data-screenshot-path  -> `captures` bucket
+ *
+ * Parsing those out of the markup is deliberate rather than walking a
+ * ProseMirror document: the stored column is HTML, and this has to work from a
+ * plain string fetched out of the database with no editor instance around —
+ * including from a server-side sweep.
+ */
+
+/** Matches the storage path in a rendered attachment/capture node. */
+const FILE_PATH_RE = /data-file-path="([^"]+)"/g
+const SCREENSHOT_PATH_RE = /data-screenshot-path="([^"]+)"/g
+
+export interface NoteAttachmentPaths {
+  /** Paths in the `assets` bucket. */
+  assets: string[]
+  /** Paths in the `captures` bucket. */
+  captures: string[]
+}
+
+function matchAll(re: RegExp, html: string): string[] {
+  const out: string[] = []
+  // Fresh lastIndex per call — these are module-level /g regexes and would
+  // otherwise resume mid-string on the second note in a loop, silently
+  // skipping attachments.
+  re.lastIndex = 0
+  let m: RegExpExecArray | null
+  while ((m = re.exec(html)) !== null) {
+    const decoded = decodeHtmlEntities(m[1])
+    if (decoded) out.push(decoded)
+  }
+  return out
+}
+
+/** Attribute values are HTML-escaped on the way in; paths can contain `&`. */
+function decodeHtmlEntities(s: string): string {
+  return s
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+}
+
+/** Every storage path referenced by a note's rendered content. */
+export function collectNoteAttachmentPaths(content: string | null | undefined): NoteAttachmentPaths {
+  if (!content) return { assets: [], captures: [] }
+  return {
+    assets: [...new Set(matchAll(FILE_PATH_RE, content))],
+    captures: [...new Set(matchAll(SCREENSHOT_PATH_RE, content))],
+  }
+}
+
+/**
+ * Delete the storage objects a note referenced.
+ *
+ * Best-effort by design: the caller deletes the note whether or not this
+ * succeeds, because the user asked for the note to go and failing the whole
+ * operation over a storage hiccup would be worse. Anything missed is caught by
+ * `scripts/sweep-orphaned-assets.mjs`.
+ *
+ * @param content   the note's stored HTML
+ * @param filePath  the note's own `file_path` column, for notes that *are* an
+ *                  uploaded document rather than containing one
+ */
+export async function removeNoteAttachments(
+  content: string | null | undefined,
+  filePath?: string | null,
+): Promise<void> {
+  const { assets, captures } = collectNoteAttachmentPaths(content)
+  if (filePath) assets.push(filePath)
+
+  const jobs: Array<Promise<unknown>> = []
+  if (assets.length) jobs.push(supabase.storage.from('assets').remove([...new Set(assets)]))
+  if (captures.length) jobs.push(supabase.storage.from('captures').remove(captures))
+  if (!jobs.length) return
+
+  const results = await Promise.allSettled(jobs)
+  for (const r of results) {
+    if (r.status === 'rejected') {
+      console.error('Failed to remove note attachments from storage:', r.reason)
+    } else {
+      const err = (r.value as { error?: unknown } | null)?.error
+      if (err) console.error('Failed to remove note attachments from storage:', err)
+    }
+  }
+}

--- a/supabase/migrations/20260814140000_erase_user_personal_data.sql
+++ b/supabase/migrations/20260814140000_erase_user_personal_data.sql
@@ -1,0 +1,159 @@
+/**
+ * erase_user_personal_data(uuid) — a real deletion path for a person.
+ *
+ * Until now the only thing the product could do with a departing user was
+ * deactivate them. That is a defensible position for a B2B recordkeeping
+ * system, but it is not deletion, and a privacy policy that promises deletion
+ * while the software only suspends is a misrepresentation. This closes that
+ * gap for the part that can honestly be closed.
+ *
+ * ── What it erases ────────────────────────────────────────────────────────
+ *
+ * The person: their name and email on the `users` row, and the rows that exist
+ * only to serve them — preferences, saved views, layouts, bookmarks,
+ * notifications, AI prompt history, calendar connections.
+ *
+ * ── What it deliberately keeps ────────────────────────────────────────────
+ *
+ * Everything they authored: notes, theses, ratings, trade ideas, decisions,
+ * committed trades, audit entries. Those are the customer firm's business
+ * records, and for an SEC-registered adviser they are records it is required
+ * to retain (Advisers Act Rule 204-2). Deleting them on an individual's
+ * request would destroy the firm's compliance record, and the firm — not
+ * Tesseract, and not the individual — is the controller of that data.
+ *
+ * The `users` row itself is kept and anonymised rather than deleted, because
+ * ~92 tables carry a user_id and most are authorship. Dropping the row would
+ * either cascade through the firm's records or leave dangling references that
+ * render as a crash. An anonymised row makes authored work show as a
+ * tombstone: present, attributable to "a former user", not to a named person.
+ *
+ * This split is what docs/legal/PRIVACY-POLICY.draft.md describes. If the two
+ * ever diverge, the policy is the thing that becomes false.
+ *
+ * ── Authorisation ─────────────────────────────────────────────────────────
+ *
+ * Org admins of an org the subject belongs to, or service_role. Deliberately
+ * not the subject themselves: erasure of a firm employee is the firm's call,
+ * and a self-service button here would let someone unilaterally anonymise
+ * their own authorship of a trade decision.
+ *
+ * Does NOT touch auth.users — that needs the admin API. scripts/erase-user.mjs
+ * calls this and then deletes the auth identity, in that order.
+ */
+
+CREATE OR REPLACE FUNCTION public.erase_user_personal_data(p_user_id UUID)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_caller       UUID := auth.uid();
+  v_is_service   BOOLEAN := current_setting('request.jwt.claim.role', true) = 'service_role';
+  v_authorised   BOOLEAN := FALSE;
+  v_tbl          TEXT;
+  v_deleted      JSONB := '{}'::jsonb;
+  v_count        BIGINT;
+  v_email_before  TEXT;
+
+  -- Tables that exist solely to serve one person. Each is deleted outright.
+  -- Anything not on this list is treated as a business record and kept.
+  v_personal_tables TEXT[] := ARRAY[
+    'user_preferences', 'user_profile_extended', 'user_onboarding_status',
+    'user_ai_config', 'user_ai_column_selections', 'user_quick_prompt_history',
+    'user_saved_views', 'user_actions', 'user_asset_flags',
+    'user_asset_layout_selections', 'user_asset_page_layouts',
+    'user_asset_page_preferences', 'user_asset_priorities',
+    'user_asset_references', 'user_asset_widget_values', 'user_asset_widgets',
+    'personal_tasks', 'attention_user_state', 'author_follows',
+    'idea_bookmarks', 'outcome_preferences', 'rating_ev_suppressions',
+    'asset_followup_suppressions', 'individual_allocation_views',
+    'calendar_connections', 'connected_calendars', 'external_calendar_events',
+    'calendar_sync_logs', 'calendar_event_reminders', 'chart_annotations',
+    'notifications'
+  ];
+BEGIN
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION 'p_user_id is required';
+  END IF;
+
+  IF v_is_service THEN
+    v_authorised := TRUE;
+  ELSIF v_caller IS NOT NULL THEN
+    -- Caller must be an active admin of an org the subject is a member of.
+    SELECT EXISTS (
+      SELECT 1
+      FROM organization_memberships subject
+      JOIN organization_memberships admin
+        ON admin.organization_id = subject.organization_id
+      WHERE subject.user_id = p_user_id
+        AND admin.user_id = v_caller
+        AND admin.status = 'active'
+        AND admin.is_org_admin = TRUE
+    ) INTO v_authorised;
+  END IF;
+
+  IF NOT v_authorised THEN
+    RAISE EXCEPTION 'Not authorised to erase this user' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT email INTO v_email_before FROM users WHERE id = p_user_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'No such user %', p_user_id USING ERRCODE = 'P0002';
+  END IF;
+
+  -- 1. Drop the per-person rows. to_regclass guards each name so a table that
+  --    does not exist in this environment is skipped rather than aborting the
+  --    erasure half-done.
+  FOREACH v_tbl IN ARRAY v_personal_tables LOOP
+    IF to_regclass('public.' || v_tbl) IS NOT NULL THEN
+      EXECUTE format('DELETE FROM public.%I WHERE user_id = $1', v_tbl) USING p_user_id;
+      GET DIAGNOSTICS v_count = ROW_COUNT;
+      IF v_count > 0 THEN
+        v_deleted := v_deleted || jsonb_build_object(v_tbl, v_count);
+      END IF;
+    END IF;
+  END LOOP;
+
+  -- 2. Revoke access everywhere.
+  UPDATE organization_memberships
+  SET status = 'revoked'
+  WHERE user_id = p_user_id AND status <> 'revoked';
+
+  -- 3. Anonymise the identity. The email keeps the id so it stays unique
+  --    without carrying anything about the person; .invalid is reserved by
+  --    RFC 2606 and can never be routed.
+  UPDATE users
+  SET email                   = 'erased-' || p_user_id::text || '@deleted.invalid',
+      first_name              = NULL,
+      last_name               = NULL,
+      full_name               = 'Former user',
+      timezone                = NULL,
+      is_active               = FALSE,
+      current_organization_id = NULL,
+      pilot_progress          = '{}'::jsonb,
+      is_pilot_user           = FALSE,
+      updated_at              = now()
+  WHERE id = p_user_id;
+
+  RETURN jsonb_build_object(
+    'user_id',        p_user_id,
+    'erased_at',      now(),
+    'rows_deleted',   v_deleted,
+    'authored_content_retained', TRUE,
+    'note', 'Authored records are retained as the customer organization''s '
+            'business records and are now attributed to "Former user". '
+            'auth.users is NOT touched — delete the auth identity separately.'
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.erase_user_personal_data(UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.erase_user_personal_data(UUID) TO authenticated;
+
+COMMENT ON FUNCTION public.erase_user_personal_data(UUID) IS
+  'Erases a user''s personal data and preferences, anonymises their identity, '
+  'and revokes all org access. Authored business records are retained as the '
+  'customer organization''s records. Org admins or service_role only. Does not '
+  'touch auth.users.';


### PR DESCRIPTION
Closes the last open item: a real deletion path for a person and for a customer.

Until now the only thing the product could do with a departing user was deactivate them, and there was no way at all to delete a customer organization. A privacy policy that promises deletion while the software only suspends is a misrepresentation, so the drafts described suspension. Now they can describe erasure.

## `erase_user_personal_data(uuid)` — already applied to production

Erases the person: identity on the `users` row, preferences, saved views, layouts, bookmarks, notifications, AI prompt history, calendar connections. Revokes every membership.

It **anonymises rather than deletes** the `users` row. Roughly 92 tables carry a `user_id` and most of them are authorship, so dropping the row would either cascade through the firm's records or leave dangling references that render as a crash.

It **keeps everything they authored**. Those are the customer firm's business records, and for an SEC-registered adviser, records it is required to retain under Advisers Act Rule 204-2 — deleting them on an individual's request would destroy the firm's compliance record. Authored work shows as "Former user".

Authorisation is org admins or `service_role`, deliberately **not** the subject: a self-service button here would let someone unilaterally anonymise their own authorship of a trade decision. Verified it fails closed.

`scripts/erase-user.mjs` calls the RPC and *then* deletes the auth identity. That order matters — the other way round can orphan the public row and leave the person's name attached to their records with nothing left to anonymise.

## Organization erasure

`scripts/sql/erase-organization-rows.sql` deletes every row carrying the org id. Tables are **discovered from `information_schema`, not listed** — a hardcoded list rots as tables are added, and a missed table means leaving customer data behind after telling them it was deleted. ~100 tables reference each other, so it deletes what each pass can, keeps the failures, and repeats until a pass frees nothing, then reports what is left rather than forcing it.

`scripts/erase-organization.mjs` removes the files. **This step is only expressible because of the earlier path migration** — every object now lives under `<organization_id>/`, so a customer's files are one prefix. The dry run against the Tesseract org finds exactly its 9 objects.

Both refuse to run without the org name or email typed back, because a mistyped uuid that happens to exist destroys the wrong customer.

## Notes take their files with them

Deleting a note left its attachments and screenshots in the bucket forever. `src/lib/storage/note-attachments.ts` parses the stored HTML for the two attributes that carry a path — `data-file-path` (assets) and `data-screenshot-path` (captures) — and removes both.

The regexes are module-level and `/g`, so `lastIndex` is reset per call. Without that, the second note in a sweep resumes mid-string and silently keeps its files. There is a test for exactly that.

## Docs updated to match

Privacy policy now describes erasure and the authored-content split. DPA §7 and §9 lose their warnings. Both still stop short of promising a self-service export, because that genuinely does not exist.

## Verification

Tests 1043 pass (+6). Typecheck unchanged at 120 pre-existing across the touched files. Build verified.

**Erasure has not been exercised against a real user or organization** — the dry runs are the only proof it works. Rehearse on a disposable org before relying on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
