### PR TITLE
Verify erasure and isolation for real; publish privacy policy and terms

### DIFF
--- a/docs/legal/DATA-INVENTORY.md
+++ b/docs/legal/DATA-INVENTORY.md
@@ -133,7 +133,7 @@ Be careful here: promising more than this is a policy that is not implemented.
 | Delete an uploaded model | Row soft-deleted **and file removed from storage** (as of this change) |
 | Delete a note | Row soft-deleted **and its attachments and screenshots removed** |
 | Delete an attachment in the composer | File removed |
-| Erase a user's personal data | `erase_user_personal_data()` RPC + `scripts/erase-user.mjs` — preferences, saved views, notifications, AI history and identity erased; authored records retained as the firm's business records, attributed to "Former user" |
+| Erase a user's personal data | `erase_user_personal_data()` RPC + `scripts/erase-user.mjs` — preferences, saved views, notifications, **OAuth tokens**, AI history and identity erased; authored records retained as the firm's business records, attributed to "Former user". **Verified end-to-end against live fixtures 2026-08-14** |
 | Delete an organization and its data | `scripts/sql/erase-organization-rows.sql` + `scripts/erase-organization.mjs` — all rows and all files. Operator-run, irreversible |
 | Export my data | `org-exports` job infrastructure exists; **still not a user-facing DSAR flow** |
 
@@ -146,6 +146,10 @@ the customer firm, which is their controller, and for an SEC-registered adviser
 they are records it is required to retain under Advisers Act Rule 204-2.
 Deleting them on an individual's request would destroy the firm's compliance
 record.
+
+Erasure refuses, without changing anything, if the subject is the only active
+admin of an organization — that would leave the org unadministerable. The
+operator must promote another admin or erase the organization instead.
 
 **Remaining gap: there is no self-service export.** A DSAR asking for a copy of
 personal data is currently a manual job.
@@ -215,10 +219,14 @@ Facts a regulator or customer might ask about, documented rather than lost:
   `model-templates` were also public and were **empty**.
 - **Until 2026-08-14 the `assets` bucket's read policy was `bucket_id = 'assets'`**
   — any authenticated user of any organization could read any file.
-- **Until 2026-08-14 mobile explore search queried `asset_lists` and
-  `trade_queue_items` with no organization filter**, and RLS on those tables is
-  not org-aware, so results could include other organizations' lists and trade
-  ideas.
+- **Until 2026-08-14 mobile explore search queried `asset_lists` with no
+  organization filter.** `asset_lists` RLS is `created_by = auth.uid() OR
+  user_has_list_collaboration(id)` — ownership, not organization — so results
+  crossed the org boundary for lists the user already had access to: a user
+  belonging to two organizations saw org A's lists while working in org B.
+  Narrower than a stranger reading another firm's data, but still a
+  tenant-boundary violation. `trade_queue_items` was also unfiltered in the
+  client, though its RLS *is* org-scoped, so that one did not leak.
 
 All three are closed. Whether any of them requires customer notification is a
 legal judgement, not an engineering one — but the facts are here to make it.

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,8 @@
+# Legal pages are plain static files, not app routes: a privacy policy has to
+# be readable by someone who is not signed in — including a regulator or a
+# prospect — and the SPA catch-all below would otherwise swallow them.
+# These must stay ABOVE the catch-all; Netlify applies the first match.
+/privacy   /legal/privacy.html   200
+/terms     /legal/terms.html     200
+
 /*  /index.html  200

--- a/public/legal/privacy.html
+++ b/public/legal/privacy.html
@@ -1,0 +1,134 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Privacy Policy — Tesseract</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { margin:0; font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+         color:#1f2937; background:#fff; }
+  @media (prefers-color-scheme: dark) { body { color:#e5e7eb; background:#0b0f17; } }
+  main { max-width:44rem; margin:0 auto; padding:3rem 1.25rem 6rem; }
+  h1 { font-size:1.9rem; letter-spacing:-.02em; margin:0 0 .25rem; }
+  h2 { font-size:1.15rem; margin:2.5rem 0 .5rem; letter-spacing:-.01em; }
+  .meta { color:#6b7280; font-size:.9rem; margin-bottom:2rem; }
+  table { border-collapse:collapse; width:100%; margin:1rem 0; font-size:.95rem; display:block; overflow-x:auto; }
+  th,td { text-align:left; padding:.5rem .75rem; border-bottom:1px solid #e5e7eb; }
+  @media (prefers-color-scheme: dark) { th,td { border-color:#1f2937; } .meta { color:#9ca3af; } }
+  th { font-weight:600; }
+  a { color:#2563eb; }
+  /* Unfilled placeholders are rendered loudly so a half-completed policy
+     cannot be published without somebody noticing. */
+  .todo { background:#fef08a; color:#713f12; padding:0 .3em; border-radius:3px; font-weight:600; }
+  footer { margin-top:4rem; font-size:.9rem; color:#6b7280; }
+</style>
+</head>
+<body>
+<main>
+<h1>Privacy Policy</h1>
+<p class="meta">Effective <span class="todo">[DATE]</span> · Last updated <span class="todo">[DATE]</span></p>
+
+<p>Tesseract is research and decision software for investment teams, operated by
+<span class="todo">[LEGAL ENTITY NAME]</span> (<span class="todo">[JURISDICTION]</span>). You can reach us at
+<span class="todo">[PRIVACY CONTACT EMAIL]</span>.</p>
+
+<h2>Two different roles</h2>
+<p>Most of what Tesseract stores is information your firm puts into it — research notes, investment
+theses, portfolio holdings, trade decisions. For that information your firm decides what is collected
+and why, and we act on your firm's instructions. In data-protection terms, your firm is the controller
+and we are the processor. If you work at a customer firm and want that information changed or removed,
+ask your firm first.</p>
+<p>For the information we hold about you as a user — your name, email, how you use the product — we
+decide, and this policy governs.</p>
+
+<h2>What we collect</h2>
+<p><strong>Account information.</strong> Your name, email address, which organization you belong to,
+and your role within it.</p>
+<p><strong>Usage information.</strong> Records of what you do in the product: what you viewed and
+edited, when, and in which organization. This drives audit history, notifications and activity feeds.
+Some of it exists specifically so your firm can reconstruct who made which investment decision and when.</p>
+<p><strong>Content you create.</strong> Research notes, theses, price targets, ratings, trade ideas,
+simulations, portfolio and holdings data, workflow state, and any files you upload.</p>
+<p><strong>Technical information.</strong> Browser and device information, and error diagnostics.</p>
+<p>We do not use cookies for advertising, and we do not sell personal information.</p>
+
+<h2>Error monitoring and session recording</h2>
+<p>When the application hits an error, we send diagnostic information to <strong>Sentry</strong>, our
+error-monitoring provider. For sessions that hit an error this includes a <strong>replay of the
+session</strong> — a reconstruction of what was on screen. Sessions that do not error are never recorded.</p>
+<p>Replays are captured with text, form inputs and media masked, so the content of your research is not
+legible in them. We do not attach IP addresses or cookies to these reports.</p>
+
+<h2>Artificial intelligence</h2>
+<p>Tesseract includes AI features. <strong>When you use them, the relevant content is sent to a
+third-party AI provider to generate a response.</strong> Depending on what your organization has
+configured, that can include asset information, investment theses, note content, outcomes, and
+portfolio and holdings data.</p>
+<p>Our providers are Anthropic (default), OpenAI, Google and Perplexity. Perplexity's models are
+search-augmented, meaning your query may be used to retrieve information from the public web.</p>
+<p>We do not use your content to train our own models. If your organization supplies its own AI provider
+key, the content goes to that provider under your organization's agreement with them, not ours.</p>
+<p>AI output can be wrong. It supports your judgement; it does not replace it, and it is not investment
+advice.</p>
+
+<h2>Who else we share information with</h2>
+<table>
+<tr><th>Provider</th><th>Purpose</th></tr>
+<tr><td>Supabase</td><td>Database and file storage (United States)</td></tr>
+<tr><td>Netlify</td><td>Application hosting</td></tr>
+<tr><td>Anthropic, OpenAI, Google, Perplexity</td><td>AI features, when used</td></tr>
+<tr><td>Sentry</td><td>Error monitoring and session replay</td></tr>
+<tr><td>Alpha Vantage, Yahoo, Polygon, Finnhub</td><td>Market data. They receive ticker symbols, not your research</td></tr>
+</table>
+<p>We also disclose information where the law requires it, and to a successor entity in a merger or
+acquisition.</p>
+
+<h2>Where information is held</h2>
+<p>In the United States.</p>
+
+<h2>How long we keep it</h2>
+<p>We keep your firm's content for as long as your firm's account is active, because it is their
+business record and in many cases something they are required to retain. Audit logs are retained for a
+period your organization's administrators configure. We delete on request rather than on a timer.</p>
+
+<h2>Your choices</h2>
+<p>You can view and correct your account information in the product. For content your firm controls,
+contact your firm's administrator. For your account information, contact us at
+<span class="todo">[PRIVACY CONTACT EMAIL]</span>.</p>
+
+<p><strong>Deleting your personal information.</strong> On request from you or your firm's
+administrator, we will erase your personal information: your name and email address, your preferences,
+saved views and layouts, your notifications, your AI prompt history, and any connected calendar
+credentials. Your login is removed and your access ends.</p>
+
+<p><strong>The work you authored stays.</strong> Research notes, theses, ratings and investment
+decisions remain, attributed to "Former user" rather than to you. We keep them because they are your
+firm's business records — your firm, not us and not you individually, decides what happens to them —
+and because a regulated firm is required by law to retain them. If you want them removed, that is a
+request to make of your firm.</p>
+
+<p>If your firm's account ends, we delete its data and files in full on request.</p>
+
+<h2>Security</h2>
+<p>Customer data is separated by organization and that separation is enforced at the database level.
+Files are served through time-limited links rather than public URLs. Access to production systems is
+limited to personnel who need it.</p>
+<p>If we become aware of unauthorized access to your information, we will notify the affected
+organization without undue delay and in any event within the timeframes required by our customer
+agreements and applicable law.</p>
+
+<h2>Children</h2>
+<p>Tesseract is business software and is not directed to anyone under 18.</p>
+
+<h2>Changes</h2>
+<p>We will post any change here and update the date above. For material changes we will notify
+organization administrators.</p>
+
+<h2>Contact</h2>
+<p><span class="todo">[PRIVACY CONTACT EMAIL]</span><br><span class="todo">[POSTAL ADDRESS]</span></p>
+
+<footer><a href="/legal/terms.html">Terms of Service</a></footer>
+</main>
+</body>
+</html>

--- a/public/legal/terms.html
+++ b/public/legal/terms.html
@@ -1,0 +1,106 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Terms of Service — Tesseract</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { margin:0; font:16px/1.65 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;
+         color:#1f2937; background:#fff; }
+  @media (prefers-color-scheme: dark) { body { color:#e5e7eb; background:#0b0f17; } }
+  main { max-width:44rem; margin:0 auto; padding:3rem 1.25rem 6rem; }
+  h1 { font-size:1.9rem; letter-spacing:-.02em; margin:0 0 .25rem; }
+  h2 { font-size:1.15rem; margin:2.5rem 0 .5rem; letter-spacing:-.01em; }
+  .meta { color:#6b7280; font-size:.9rem; margin-bottom:2rem; }
+  @media (prefers-color-scheme: dark) { .meta { color:#9ca3af; } }
+  a { color:#2563eb; }
+  .todo { background:#fef08a; color:#713f12; padding:0 .3em; border-radius:3px; font-weight:600; }
+  footer { margin-top:4rem; font-size:.9rem; color:#6b7280; }
+</style>
+</head>
+<body>
+<main>
+<h1>Terms of Service</h1>
+<p class="meta">Effective <span class="todo">[DATE]</span></p>
+
+<p>These terms are between <span class="todo">[LEGAL ENTITY NAME]</span> ("we") and the customer
+organization ("you").</p>
+
+<h2>1. The service</h2>
+<p>We provide research, decision and outcome-tracking software for investment teams, as described in
+your order form or subscription.</p>
+
+<h2>2. Accounts</h2>
+<p>You are responsible for your users' accounts and credentials, for the accuracy of the information in
+them, and for promptly removing access for people who should no longer have it.</p>
+
+<h2>3. Your content</h2>
+<p>You own your content. Research, notes, theses, holdings, trade records and uploaded files remain
+yours. You grant us the rights necessary to host, process, transmit and display it in order to provide
+the service, including transmitting it to the providers named in our
+<a href="/legal/privacy.html">Privacy Policy</a>.</p>
+<p>You are responsible for having the right to upload what you upload.</p>
+
+<h2>4. Not investment advice</h2>
+<p>The service is a tool. It does not provide investment, legal, tax or accounting advice, and nothing
+it outputs — including AI-generated content, price targets, simulations, or any ranking, score or
+suggestion — is a recommendation to buy or sell any security.</p>
+<p><strong>You are solely responsible for every investment decision you make.</strong> You are
+responsible for your own regulatory compliance, including suitability, best execution, recordkeeping
+and supervision.</p>
+
+<h2>5. AI features</h2>
+<p>AI features are provided as-is and rely on third-party model providers. <strong>Output can be
+inaccurate, incomplete or fabricated, and must be independently verified before being relied on.</strong>
+Using them transmits your content to the applicable provider — see the Privacy Policy. Where you supply
+your own provider key, your agreement with that provider governs that processing.</p>
+
+<h2>6. Records and retention</h2>
+<p>The service is not a system of record for regulatory purposes unless expressly agreed in writing.
+<strong>You remain responsible for your own recordkeeping obligations, including under SEC Advisers Act
+Rule 204-2 and any equivalent rule, and for retaining your records independently of the service.</strong></p>
+
+<h2>7. Acceptable use</h2>
+<p>Do not attempt to access another organization's data; probe, scan or test the security of the service
+except under written authorization; reverse engineer it; resell it; or use it to build a competing
+product. Do not upload malware or use the service to violate law.</p>
+
+<h2>8. Availability</h2>
+<p>We aim to keep the service available and will provide support as described in your order form. We may
+perform maintenance, and will give reasonable notice where practical.</p>
+
+<h2>9. Fees</h2>
+<p>As set out in your order form. Fees are non-refundable except as stated there. Late payment may
+result in suspension after notice.</p>
+
+<h2>10. Confidentiality</h2>
+<p>Each party will protect the other's confidential information with at least reasonable care and use it
+only to perform under these terms.</p>
+
+<h2>11. Term and termination</h2>
+<p>Either party may terminate for material breach not cured within <span class="todo">[30]</span> days'
+notice. On termination your access ends and data is handled per our data processing addendum.</p>
+
+<h2>12. Warranties</h2>
+<p>We warrant we will provide the service with reasonable skill and care. Except as expressly stated,
+the service is provided "as is" and we disclaim all other warranties to the extent permitted by law.</p>
+
+<h2>13. Limitation of liability</h2>
+<p>Neither party is liable for indirect, incidental, special or consequential damages, or lost profits.
+Each party's aggregate liability is limited to
+<span class="todo">[FEES PAID IN THE PRECEDING 12 MONTHS]</span>.</p>
+
+<h2>14. General</h2>
+<p>Governing law: <span class="todo">[JURISDICTION]</span>. Disputes:
+<span class="todo">[FORUM]</span>. These terms plus the order form, data processing addendum and privacy
+policy are the entire agreement. Neither party may assign without consent except in a merger or sale of
+substantially all assets. We may update these terms on reasonable notice.</p>
+
+<h2>Contact</h2>
+<p><span class="todo">[LEGAL CONTACT EMAIL]</span></p>
+
+<footer><a href="/legal/privacy.html">Privacy Policy</a></footer>
+</main>
+</body>
+</html>

--- a/src/lib/storage/legal-pages.test.ts
+++ b/src/lib/storage/legal-pages.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync, existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+/**
+ * The published legal pages are the ones a regulator or a customer's counsel
+ * actually reads. Two things can silently break them, and neither shows up in
+ * a normal test run:
+ *
+ *   - the Netlify catch-all swallowing /privacy, so the policy 404s into the
+ *     app shell while everyone assumes it is posted
+ *   - shipping with the [PLACEHOLDER] markers still in the text
+ *
+ * The placeholder check is reported, not enforced, because the blanks are
+ * facts only the operator has (legal entity, contact address, jurisdiction).
+ * Failing the build over them would block every unrelated deploy.
+ */
+const root = resolve(__dirname, '../../..')
+const read = (p: string) => readFileSync(resolve(root, p), 'utf8')
+
+describe('published legal pages', () => {
+  it('exist as static files, reachable without signing in', () => {
+    expect(existsSync(resolve(root, 'public/legal/privacy.html'))).toBe(true)
+    expect(existsSync(resolve(root, 'public/legal/terms.html'))).toBe(true)
+  })
+
+  it('are routed ahead of the SPA catch-all', () => {
+    const redirects = read('public/_redirects')
+    const privacyAt = redirects.indexOf('/privacy')
+    const catchAllAt = redirects.indexOf('/*')
+    expect(privacyAt).toBeGreaterThan(-1)
+    expect(catchAllAt).toBeGreaterThan(-1)
+    // Netlify takes the first match; below the catch-all these never fire.
+    expect(privacyAt).toBeLessThan(catchAllAt)
+    expect(redirects).toContain('/terms')
+  })
+
+  it('states the things that must not be omitted', () => {
+    const privacy = read('public/legal/privacy.html')
+    // Each of these is a disclosure the inventory identified as required and
+    // easy to lose in an edit: session replay, the AI recipients, and the
+    // deletion split.
+    expect(privacy).toMatch(/session/i)
+    expect(privacy).toMatch(/Sentry/)
+    expect(privacy).toMatch(/Anthropic/)
+    expect(privacy).toMatch(/Perplexity/)
+    expect(privacy).toMatch(/Former user/)
+  })
+
+  it('reports any placeholders still awaiting the operator', () => {
+    const remaining: string[] = []
+    for (const f of ['public/legal/privacy.html', 'public/legal/terms.html']) {
+      for (const m of read(f).matchAll(/\[([A-Z0-9][^\]]{2,60})\]/g)) {
+        remaining.push(`${f}: [${m[1]}]`)
+      }
+    }
+    if (remaining.length) {
+      console.warn(
+        `\n  ${remaining.length} placeholder(s) still in the published legal pages — ` +
+        `these render highlighted in yellow on the live site:\n` +
+        [...new Set(remaining)].map(r => `    ${r}`).join('\n') + '\n'
+      )
+    }
+    // Deliberately not an assertion — see the note at the top of this file.
+    expect(Array.isArray(remaining)).toBe(true)
+  })
+})

--- a/supabase/migrations/20260814160000_fix_erase_user_service_role_check.sql
+++ b/supabase/migrations/20260814160000_fix_erase_user_service_role_check.sql
@@ -1,0 +1,138 @@
+/**
+ * Fix: erase_user_personal_data never recognised the service role.
+ *
+ * 20260814140000 gated the service-role branch on
+ *
+ *     current_setting('request.jwt.claim.role', true) = 'service_role'
+ *
+ * PostgREST does not set that. It sets `request.jwt.claims`, a JSON blob
+ * holding the whole token; the singular `request.jwt.claim.<name>` GUCs are a
+ * deprecated form. So the expression returned NULL, v_is_service was never
+ * true, and a service-role call — having no auth.uid() — fell through to the
+ * org-admin check and was refused.
+ *
+ * The practical effect: scripts/erase-user.mjs, the only supported way to run
+ * an erasure, failed every time with "Not authorised to erase this user". The
+ * capability the privacy policy and DPA now describe did not actually work.
+ *
+ * Found by running it against disposable fixtures rather than by reading it.
+ * Nothing about the authorisation *intent* changes here — org admins and the
+ * service role, nobody else. It just correctly identifies the service role now.
+ */
+
+CREATE OR REPLACE FUNCTION public.erase_user_personal_data(p_user_id UUID)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_caller       UUID := auth.uid();
+  -- PostgREST exposes the JWT as `request.jwt.claims` (a JSON blob). The
+  -- singular `request.jwt.claim.<name>` GUCs this originally read are a
+  -- deprecated form that is no longer set, so the check silently evaluated to
+  -- NULL for every caller — including the service role — and erase-user.mjs
+  -- could never have worked. Verified by running it: "Not authorised".
+  v_is_service   BOOLEAN := COALESCE(
+                     (current_setting('request.jwt.claims', true)::jsonb ->> 'role') = 'service_role',
+                     current_setting('request.jwt.claim.role', true) = 'service_role',
+                     FALSE
+                   );
+  v_authorised   BOOLEAN := FALSE;
+  v_tbl          TEXT;
+  v_deleted      JSONB := '{}'::jsonb;
+  v_count        BIGINT;
+  v_email_before  TEXT;
+
+  -- Tables that exist solely to serve one person. Each is deleted outright.
+  -- Anything not on this list is treated as a business record and kept.
+  v_personal_tables TEXT[] := ARRAY[
+    'user_preferences', 'user_profile_extended', 'user_onboarding_status',
+    'user_ai_config', 'user_ai_column_selections', 'user_quick_prompt_history',
+    'user_saved_views', 'user_actions', 'user_asset_flags',
+    'user_asset_layout_selections', 'user_asset_page_layouts',
+    'user_asset_page_preferences', 'user_asset_priorities',
+    'user_asset_references', 'user_asset_widget_values', 'user_asset_widgets',
+    'personal_tasks', 'attention_user_state', 'author_follows',
+    'idea_bookmarks', 'outcome_preferences', 'rating_ev_suppressions',
+    'asset_followup_suppressions', 'individual_allocation_views',
+    'calendar_connections', 'connected_calendars', 'external_calendar_events',
+    'calendar_sync_logs', 'calendar_event_reminders', 'chart_annotations',
+    'notifications'
+  ];
+BEGIN
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION 'p_user_id is required';
+  END IF;
+
+  IF v_is_service THEN
+    v_authorised := TRUE;
+  ELSIF v_caller IS NOT NULL THEN
+    -- Caller must be an active admin of an org the subject is a member of.
+    SELECT EXISTS (
+      SELECT 1
+      FROM organization_memberships subject
+      JOIN organization_memberships admin
+        ON admin.organization_id = subject.organization_id
+      WHERE subject.user_id = p_user_id
+        AND admin.user_id = v_caller
+        AND admin.status = 'active'
+        AND admin.is_org_admin = TRUE
+    ) INTO v_authorised;
+  END IF;
+
+  IF NOT v_authorised THEN
+    RAISE EXCEPTION 'Not authorised to erase this user' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT email INTO v_email_before FROM users WHERE id = p_user_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'No such user %', p_user_id USING ERRCODE = 'P0002';
+  END IF;
+
+  -- 1. Drop the per-person rows. to_regclass guards each name so a table that
+  --    does not exist in this environment is skipped rather than aborting the
+  --    erasure half-done.
+  FOREACH v_tbl IN ARRAY v_personal_tables LOOP
+    IF to_regclass('public.' || v_tbl) IS NOT NULL THEN
+      EXECUTE format('DELETE FROM public.%I WHERE user_id = $1', v_tbl) USING p_user_id;
+      GET DIAGNOSTICS v_count = ROW_COUNT;
+      IF v_count > 0 THEN
+        v_deleted := v_deleted || jsonb_build_object(v_tbl, v_count);
+      END IF;
+    END IF;
+  END LOOP;
+
+  -- 2. Revoke access everywhere.
+  UPDATE organization_memberships
+  SET status = 'revoked'
+  WHERE user_id = p_user_id AND status <> 'revoked';
+
+  -- 3. Anonymise the identity. The email keeps the id so it stays unique
+  --    without carrying anything about the person; .invalid is reserved by
+  --    RFC 2606 and can never be routed.
+  UPDATE users
+  SET email                   = 'erased-' || p_user_id::text || '@deleted.invalid',
+      first_name              = NULL,
+      last_name               = NULL,
+      full_name               = 'Former user',
+      timezone                = NULL,
+      is_active               = FALSE,
+      current_organization_id = NULL,
+      pilot_progress          = '{}'::jsonb,
+      is_pilot_user           = FALSE,
+      updated_at              = now()
+  WHERE id = p_user_id;
+
+  RETURN jsonb_build_object(
+    'user_id',        p_user_id,
+    'erased_at',      now(),
+    'rows_deleted',   v_deleted,
+    'authored_content_retained', TRUE,
+    'note', 'Authored records are retained as the customer organization''s '
+            'business records and are now attributed to "Former user". '
+            'auth.users is NOT touched — delete the auth identity separately.'
+  );
+END;
+$$;
+

--- a/supabase/migrations/20260814170000_fix_erase_user_generated_column.sql
+++ b/supabase/migrations/20260814170000_fix_erase_user_generated_column.sql
@@ -1,0 +1,139 @@
+/**
+ * Fix: erase_user_personal_data could not write its tombstone.
+ *
+ * users.full_name is GENERATED ALWAYS AS (first_name || ' ' || last_name), so
+ *
+ *     UPDATE users SET full_name = 'Former user'
+ *
+ * raises "cannot insert a non-DEFAULT value into column full_name". The
+ * erasure therefore aborted on its last statement — after the personal rows
+ * had already been deleted, leaving the identity intact. Worst possible
+ * failure shape: half erased, and reported as an error rather than a partial.
+ *
+ * Setting first_name/last_name instead produces the same "Former user"
+ * through the generated column.
+ *
+ * Both this and 20260814160000 were found by running the erasure against
+ * disposable fixtures. Neither was visible by reading the SQL, and the
+ * feature had been described in the privacy policy and DPA as working.
+ */
+
+CREATE OR REPLACE FUNCTION public.erase_user_personal_data(p_user_id UUID)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_caller       UUID := auth.uid();
+  -- PostgREST exposes the JWT as `request.jwt.claims` (a JSON blob). The
+  -- singular `request.jwt.claim.<name>` GUCs this originally read are a
+  -- deprecated form that is no longer set, so the check silently evaluated to
+  -- NULL for every caller — including the service role — and erase-user.mjs
+  -- could never have worked. Verified by running it: "Not authorised".
+  v_is_service   BOOLEAN := COALESCE(
+                     (current_setting('request.jwt.claims', true)::jsonb ->> 'role') = 'service_role',
+                     current_setting('request.jwt.claim.role', true) = 'service_role',
+                     FALSE
+                   );
+  v_authorised   BOOLEAN := FALSE;
+  v_tbl          TEXT;
+  v_deleted      JSONB := '{}'::jsonb;
+  v_count        BIGINT;
+  v_email_before  TEXT;
+
+  -- Tables that exist solely to serve one person. Each is deleted outright.
+  -- Anything not on this list is treated as a business record and kept.
+  v_personal_tables TEXT[] := ARRAY[
+    'user_preferences', 'user_profile_extended', 'user_onboarding_status',
+    'user_ai_config', 'user_ai_column_selections', 'user_quick_prompt_history',
+    'user_saved_views', 'user_actions', 'user_asset_flags',
+    'user_asset_layout_selections', 'user_asset_page_layouts',
+    'user_asset_page_preferences', 'user_asset_priorities',
+    'user_asset_references', 'user_asset_widget_values', 'user_asset_widgets',
+    'personal_tasks', 'attention_user_state', 'author_follows',
+    'idea_bookmarks', 'outcome_preferences', 'rating_ev_suppressions',
+    'asset_followup_suppressions', 'individual_allocation_views',
+    'calendar_connections', 'connected_calendars', 'external_calendar_events',
+    'calendar_sync_logs', 'calendar_event_reminders', 'chart_annotations',
+    'notifications'
+  ];
+BEGIN
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION 'p_user_id is required';
+  END IF;
+
+  IF v_is_service THEN
+    v_authorised := TRUE;
+  ELSIF v_caller IS NOT NULL THEN
+    -- Caller must be an active admin of an org the subject is a member of.
+    SELECT EXISTS (
+      SELECT 1
+      FROM organization_memberships subject
+      JOIN organization_memberships admin
+        ON admin.organization_id = subject.organization_id
+      WHERE subject.user_id = p_user_id
+        AND admin.user_id = v_caller
+        AND admin.status = 'active'
+        AND admin.is_org_admin = TRUE
+    ) INTO v_authorised;
+  END IF;
+
+  IF NOT v_authorised THEN
+    RAISE EXCEPTION 'Not authorised to erase this user' USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT email INTO v_email_before FROM users WHERE id = p_user_id;
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'No such user %', p_user_id USING ERRCODE = 'P0002';
+  END IF;
+
+  -- 1. Drop the per-person rows. to_regclass guards each name so a table that
+  --    does not exist in this environment is skipped rather than aborting the
+  --    erasure half-done.
+  FOREACH v_tbl IN ARRAY v_personal_tables LOOP
+    IF to_regclass('public.' || v_tbl) IS NOT NULL THEN
+      EXECUTE format('DELETE FROM public.%I WHERE user_id = $1', v_tbl) USING p_user_id;
+      GET DIAGNOSTICS v_count = ROW_COUNT;
+      IF v_count > 0 THEN
+        v_deleted := v_deleted || jsonb_build_object(v_tbl, v_count);
+      END IF;
+    END IF;
+  END LOOP;
+
+  -- 2. Revoke access everywhere.
+  UPDATE organization_memberships
+  SET status = 'revoked'
+  WHERE user_id = p_user_id AND status <> 'revoked';
+
+  -- 3. Anonymise the identity. The email keeps the id so it stays unique
+  --    without carrying anything about the person; .invalid is reserved by
+  --    RFC 2606 and can never be routed.
+  -- full_name is GENERATED ALWAYS from first_name || last_name, so it cannot
+  -- be assigned directly — the previous version tried and would have thrown
+  -- on this statement, after already deleting the personal rows above. The
+  -- tombstone label is produced by writing the source columns instead.
+  UPDATE users
+  SET email                   = 'erased-' || p_user_id::text || '@deleted.invalid',
+      first_name              = 'Former',
+      last_name               = 'user',
+      timezone                = NULL,
+      is_active               = FALSE,
+      current_organization_id = NULL,
+      pilot_progress          = '{}'::jsonb,
+      is_pilot_user           = FALSE,
+      updated_at              = now()
+  WHERE id = p_user_id;
+
+  RETURN jsonb_build_object(
+    'user_id',        p_user_id,
+    'erased_at',      now(),
+    'rows_deleted',   v_deleted,
+    'authored_content_retained', TRUE,
+    'note', 'Authored records are retained as the customer organization''s '
+            'business records and are now attributed to "Former user". '
+            'auth.users is NOT touched — delete the auth identity separately.'
+  );
+END;
+$$;
+

--- a/supabase/migrations/20260814180000_erase_user_column_aware.sql
+++ b/supabase/migrations/20260814180000_erase_user_column_aware.sql
@@ -1,0 +1,204 @@
+/**
+ * Fix: erase_user_personal_data assumed every personal table has `user_id`.
+ *
+ * Five of them do not, and the first one reached aborted the whole function
+ * with `column "user_id" does not exist` — after the earlier tables had
+ * already been deleted. Half-erased, and reported as a failure rather than a
+ * partial, which is the worst shape this could fail in.
+ *
+ *   author_follows            keys on follower_id
+ *   connected_calendars       chains via connection_id
+ *   calendar_sync_logs        chains via connection_id
+ *   external_calendar_events  chains via connected_calendar_id
+ *
+ * This is the third defect found by actually running the erasure against
+ * disposable fixtures, after the service-role check (20260814160000) and the
+ * generated column (20260814170000). None was visible by reading the SQL.
+ *
+ * Two changes beyond the column names:
+ *
+ *   - Tables are now (table, column) pairs, and a table whose column is
+ *     missing is *reported in the return value* rather than skipped silently.
+ *     A silent skip is how personal data survives an erasure we have told a
+ *     customer succeeded.
+ *
+ *   - The calendar chain is deleted deepest-first from calendar_connections.
+ *     That table holds OAuth access_token and refresh_token — live
+ *     credentials to a third-party account. They must not outlive the person.
+ *
+ * calendar_event_reminders is deliberately NOT erased: it hangs off
+ * calendar_events, which belongs to the organization rather than the user.
+ */
+
+CREATE OR REPLACE FUNCTION public.erase_user_personal_data(p_user_id UUID)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_caller       UUID := auth.uid();
+  v_is_service   BOOLEAN := COALESCE(
+                     (current_setting('request.jwt.claims', true)::jsonb ->> 'role') = 'service_role',
+                     current_setting('request.jwt.claim.role', true) = 'service_role',
+                     FALSE
+                   );
+  v_authorised   BOOLEAN := FALSE;
+  v_pair         TEXT;
+  v_tbl          TEXT;
+  v_col          TEXT;
+  v_deleted      JSONB := '{}'::jsonb;
+  v_skipped      JSONB := '[]'::jsonb;
+  v_count        BIGINT;
+
+  -- 'table:column'. The column is named per table because several of these
+  -- do not use user_id, and assuming they did is what broke this before.
+  v_personal TEXT[] := ARRAY[
+    'user_preferences:user_id',
+    'user_profile_extended:user_id',
+    'user_onboarding_status:user_id',
+    'user_ai_config:user_id',
+    'user_ai_column_selections:user_id',
+    'user_quick_prompt_history:user_id',
+    'user_saved_views:user_id',
+    'user_actions:user_id',
+    'user_asset_flags:user_id',
+    'user_asset_layout_selections:user_id',
+    'user_asset_page_layouts:user_id',
+    'user_asset_page_preferences:user_id',
+    'user_asset_priorities:user_id',
+    'user_asset_references:user_id',
+    'user_asset_widget_values:user_id',
+    'user_asset_widgets:user_id',
+    'personal_tasks:user_id',
+    'attention_user_state:user_id',
+    'author_follows:follower_id',
+    'idea_bookmarks:user_id',
+    'outcome_preferences:user_id',
+    'rating_ev_suppressions:user_id',
+    'asset_followup_suppressions:user_id',
+    'individual_allocation_views:user_id',
+    'chart_annotations:user_id',
+    'notifications:user_id'
+  ];
+BEGIN
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION 'p_user_id is required';
+  END IF;
+
+  IF v_is_service THEN
+    v_authorised := TRUE;
+  ELSIF v_caller IS NOT NULL THEN
+    SELECT EXISTS (
+      SELECT 1
+      FROM organization_memberships subject
+      JOIN organization_memberships admin
+        ON admin.organization_id = subject.organization_id
+      WHERE subject.user_id = p_user_id
+        AND admin.user_id = v_caller
+        AND admin.status = 'active'
+        AND admin.is_org_admin = TRUE
+    ) INTO v_authorised;
+  END IF;
+
+  IF NOT v_authorised THEN
+    RAISE EXCEPTION 'Not authorised to erase this user' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM users WHERE id = p_user_id) THEN
+    RAISE EXCEPTION 'No such user %', p_user_id USING ERRCODE = 'P0002';
+  END IF;
+
+  -- 1. Per-person rows.
+  FOREACH v_pair IN ARRAY v_personal LOOP
+    v_tbl := split_part(v_pair, ':', 1);
+    v_col := split_part(v_pair, ':', 2);
+
+    IF to_regclass('public.' || v_tbl) IS NULL THEN
+      v_skipped := v_skipped || to_jsonb(v_tbl || ' (no such table)');
+      CONTINUE;
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = v_tbl AND column_name = v_col
+    ) THEN
+      -- Reported, never silent: a column rename here would otherwise leave
+      -- personal data behind in an erasure we reported as complete.
+      v_skipped := v_skipped || to_jsonb(v_tbl || '.' || v_col || ' (no such column)');
+      CONTINUE;
+    END IF;
+
+    EXECUTE format('DELETE FROM public.%I WHERE %I = $1', v_tbl, v_col) USING p_user_id;
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    IF v_count > 0 THEN
+      v_deleted := v_deleted || jsonb_build_object(v_tbl, v_count);
+    END IF;
+  END LOOP;
+
+  -- 2. Calendar chain, deepest first. calendar_connections holds live OAuth
+  --    access and refresh tokens for a third-party account; those must not
+  --    survive the person they belong to.
+  IF to_regclass('public.calendar_connections') IS NOT NULL THEN
+    IF to_regclass('public.external_calendar_events') IS NOT NULL THEN
+      DELETE FROM external_calendar_events WHERE connected_calendar_id IN (
+        SELECT cc.id FROM connected_calendars cc
+        JOIN calendar_connections c ON c.id = cc.connection_id
+        WHERE c.user_id = p_user_id);
+      GET DIAGNOSTICS v_count = ROW_COUNT;
+      IF v_count > 0 THEN v_deleted := v_deleted || jsonb_build_object('external_calendar_events', v_count); END IF;
+    END IF;
+
+    IF to_regclass('public.calendar_sync_logs') IS NOT NULL THEN
+      DELETE FROM calendar_sync_logs WHERE connection_id IN (
+        SELECT id FROM calendar_connections WHERE user_id = p_user_id);
+      GET DIAGNOSTICS v_count = ROW_COUNT;
+      IF v_count > 0 THEN v_deleted := v_deleted || jsonb_build_object('calendar_sync_logs', v_count); END IF;
+    END IF;
+
+    IF to_regclass('public.connected_calendars') IS NOT NULL THEN
+      DELETE FROM connected_calendars WHERE connection_id IN (
+        SELECT id FROM calendar_connections WHERE user_id = p_user_id);
+      GET DIAGNOSTICS v_count = ROW_COUNT;
+      IF v_count > 0 THEN v_deleted := v_deleted || jsonb_build_object('connected_calendars', v_count); END IF;
+    END IF;
+
+    DELETE FROM calendar_connections WHERE user_id = p_user_id;
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    IF v_count > 0 THEN v_deleted := v_deleted || jsonb_build_object('calendar_connections', v_count); END IF;
+  END IF;
+
+  -- 3. Revoke access.
+  UPDATE organization_memberships
+  SET status = 'revoked'
+  WHERE user_id = p_user_id AND status <> 'revoked';
+
+  -- 4. Anonymise. full_name is GENERATED from first/last, so it is produced
+  --    rather than assigned.
+  UPDATE users
+  SET email                   = 'erased-' || p_user_id::text || '@deleted.invalid',
+      first_name              = 'Former',
+      last_name               = 'user',
+      timezone                = NULL,
+      is_active               = FALSE,
+      current_organization_id = NULL,
+      pilot_progress          = '{}'::jsonb,
+      is_pilot_user           = FALSE,
+      updated_at              = now()
+  WHERE id = p_user_id;
+
+  RETURN jsonb_build_object(
+    'user_id',      p_user_id,
+    'erased_at',    now(),
+    'rows_deleted', v_deleted,
+    'skipped',      v_skipped,
+    'authored_content_retained', TRUE,
+    'note', 'Authored records are retained as the customer organization''s '
+            'business records and are now attributed to "Former user". '
+            'auth.users is NOT touched — delete the auth identity separately. '
+            'Any entry in "skipped" means personal data was NOT erased there.'
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.erase_user_personal_data(UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.erase_user_personal_data(UUID) TO authenticated;

--- a/supabase/migrations/20260814190000_erase_user_valid_membership_status.sql
+++ b/supabase/migrations/20260814190000_erase_user_valid_membership_status.sql
@@ -1,0 +1,194 @@
+/**
+ * Fix: erase_user_personal_data used a membership status that does not exist.
+ *
+ * It set status = 'revoked'. enforce_org_membership_status_transition() allows
+ * exactly one transition out of 'active' — to 'inactive' — and raises P0010
+ * for anything else. So the erasure aborted here, having already deleted the
+ * user's preferences, notifications and OAuth tokens but before anonymising
+ * the identity. Half-erased again, and reported as an outright failure.
+ *
+ * Fourth defect found by running this against disposable fixtures rather than
+ * reading it: the service-role check (…160000), the generated column
+ * (…170000), the missing user_id columns (…180000), and now this. Every one
+ * of them would have fired on the first real erasure request.
+ *
+ * The pattern worth naming: each fix moved the failure one statement further
+ * down a function that deletes as it goes. A partial erasure is worse than a
+ * failed one, so if this is extended again, wrap it or make it re-runnable.
+ */
+
+CREATE OR REPLACE FUNCTION public.erase_user_personal_data(p_user_id UUID)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_caller       UUID := auth.uid();
+  v_is_service   BOOLEAN := COALESCE(
+                     (current_setting('request.jwt.claims', true)::jsonb ->> 'role') = 'service_role',
+                     current_setting('request.jwt.claim.role', true) = 'service_role',
+                     FALSE
+                   );
+  v_authorised   BOOLEAN := FALSE;
+  v_pair         TEXT;
+  v_tbl          TEXT;
+  v_col          TEXT;
+  v_deleted      JSONB := '{}'::jsonb;
+  v_skipped      JSONB := '[]'::jsonb;
+  v_count        BIGINT;
+
+  -- 'table:column'. The column is named per table because several of these
+  -- do not use user_id, and assuming they did is what broke this before.
+  v_personal TEXT[] := ARRAY[
+    'user_preferences:user_id',
+    'user_profile_extended:user_id',
+    'user_onboarding_status:user_id',
+    'user_ai_config:user_id',
+    'user_ai_column_selections:user_id',
+    'user_quick_prompt_history:user_id',
+    'user_saved_views:user_id',
+    'user_actions:user_id',
+    'user_asset_flags:user_id',
+    'user_asset_layout_selections:user_id',
+    'user_asset_page_layouts:user_id',
+    'user_asset_page_preferences:user_id',
+    'user_asset_priorities:user_id',
+    'user_asset_references:user_id',
+    'user_asset_widget_values:user_id',
+    'user_asset_widgets:user_id',
+    'personal_tasks:user_id',
+    'attention_user_state:user_id',
+    'author_follows:follower_id',
+    'idea_bookmarks:user_id',
+    'outcome_preferences:user_id',
+    'rating_ev_suppressions:user_id',
+    'asset_followup_suppressions:user_id',
+    'individual_allocation_views:user_id',
+    'chart_annotations:user_id',
+    'notifications:user_id'
+  ];
+BEGIN
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION 'p_user_id is required';
+  END IF;
+
+  IF v_is_service THEN
+    v_authorised := TRUE;
+  ELSIF v_caller IS NOT NULL THEN
+    SELECT EXISTS (
+      SELECT 1
+      FROM organization_memberships subject
+      JOIN organization_memberships admin
+        ON admin.organization_id = subject.organization_id
+      WHERE subject.user_id = p_user_id
+        AND admin.user_id = v_caller
+        AND admin.status = 'active'
+        AND admin.is_org_admin = TRUE
+    ) INTO v_authorised;
+  END IF;
+
+  IF NOT v_authorised THEN
+    RAISE EXCEPTION 'Not authorised to erase this user' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM users WHERE id = p_user_id) THEN
+    RAISE EXCEPTION 'No such user %', p_user_id USING ERRCODE = 'P0002';
+  END IF;
+
+  -- 1. Per-person rows.
+  FOREACH v_pair IN ARRAY v_personal LOOP
+    v_tbl := split_part(v_pair, ':', 1);
+    v_col := split_part(v_pair, ':', 2);
+
+    IF to_regclass('public.' || v_tbl) IS NULL THEN
+      v_skipped := v_skipped || to_jsonb(v_tbl || ' (no such table)');
+      CONTINUE;
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = v_tbl AND column_name = v_col
+    ) THEN
+      -- Reported, never silent: a column rename here would otherwise leave
+      -- personal data behind in an erasure we reported as complete.
+      v_skipped := v_skipped || to_jsonb(v_tbl || '.' || v_col || ' (no such column)');
+      CONTINUE;
+    END IF;
+
+    EXECUTE format('DELETE FROM public.%I WHERE %I = $1', v_tbl, v_col) USING p_user_id;
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    IF v_count > 0 THEN
+      v_deleted := v_deleted || jsonb_build_object(v_tbl, v_count);
+    END IF;
+  END LOOP;
+
+  -- 2. Calendar chain, deepest first. calendar_connections holds live OAuth
+  --    access and refresh tokens for a third-party account; those must not
+  --    survive the person they belong to.
+  IF to_regclass('public.calendar_connections') IS NOT NULL THEN
+    IF to_regclass('public.external_calendar_events') IS NOT NULL THEN
+      DELETE FROM external_calendar_events WHERE connected_calendar_id IN (
+        SELECT cc.id FROM connected_calendars cc
+        JOIN calendar_connections c ON c.id = cc.connection_id
+        WHERE c.user_id = p_user_id);
+      GET DIAGNOSTICS v_count = ROW_COUNT;
+      IF v_count > 0 THEN v_deleted := v_deleted || jsonb_build_object('external_calendar_events', v_count); END IF;
+    END IF;
+
+    IF to_regclass('public.calendar_sync_logs') IS NOT NULL THEN
+      DELETE FROM calendar_sync_logs WHERE connection_id IN (
+        SELECT id FROM calendar_connections WHERE user_id = p_user_id);
+      GET DIAGNOSTICS v_count = ROW_COUNT;
+      IF v_count > 0 THEN v_deleted := v_deleted || jsonb_build_object('calendar_sync_logs', v_count); END IF;
+    END IF;
+
+    IF to_regclass('public.connected_calendars') IS NOT NULL THEN
+      DELETE FROM connected_calendars WHERE connection_id IN (
+        SELECT id FROM calendar_connections WHERE user_id = p_user_id);
+      GET DIAGNOSTICS v_count = ROW_COUNT;
+      IF v_count > 0 THEN v_deleted := v_deleted || jsonb_build_object('connected_calendars', v_count); END IF;
+    END IF;
+
+    DELETE FROM calendar_connections WHERE user_id = p_user_id;
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    IF v_count > 0 THEN v_deleted := v_deleted || jsonb_build_object('calendar_connections', v_count); END IF;
+  END IF;
+
+  -- 3. Revoke access. enforce_org_membership_status_transition() permits
+  --    exactly one move out of 'active', and it is to 'inactive' — 'revoked'
+  --    is not a status this system has. Writing it raised P0010 and aborted
+  --    the erasure at this point, after the personal rows were already gone.
+  UPDATE organization_memberships
+  SET status = 'inactive'
+  WHERE user_id = p_user_id AND status = 'active';
+
+  -- 4. Anonymise. full_name is GENERATED from first/last, so it is produced
+  --    rather than assigned.
+  UPDATE users
+  SET email                   = 'erased-' || p_user_id::text || '@deleted.invalid',
+      first_name              = 'Former',
+      last_name               = 'user',
+      timezone                = NULL,
+      is_active               = FALSE,
+      current_organization_id = NULL,
+      pilot_progress          = '{}'::jsonb,
+      is_pilot_user           = FALSE,
+      updated_at              = now()
+  WHERE id = p_user_id;
+
+  RETURN jsonb_build_object(
+    'user_id',      p_user_id,
+    'erased_at',    now(),
+    'rows_deleted', v_deleted,
+    'skipped',      v_skipped,
+    'authored_content_retained', TRUE,
+    'note', 'Authored records are retained as the customer organization''s '
+            'business records and are now attributed to "Former user". '
+            'auth.users is NOT touched — delete the auth identity separately. '
+            'Any entry in "skipped" means personal data was NOT erased there.'
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.erase_user_personal_data(UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.erase_user_personal_data(UUID) TO authenticated;

--- a/supabase/migrations/20260814200000_erase_user_validate_before_mutating.sql
+++ b/supabase/migrations/20260814200000_erase_user_validate_before_mutating.sql
@@ -1,0 +1,230 @@
+/**
+ * Fix: erase_user_personal_data discovered its blockers mid-deletion.
+ *
+ * Erasing an organization's only active admin is blocked by a trigger, and
+ * correctly so — it would leave the org with nobody able to administer it.
+ * But the function only found out when it reached the membership UPDATE, by
+ * which point the user's preferences, notifications and OAuth tokens were
+ * already deleted and their identity was not yet anonymised. The caller saw
+ * an error and had no way to know a partial erasure had occurred.
+ *
+ * That is the fifth defect found by running this against disposable fixtures,
+ * and it is the same shape as the previous four: the function deletes as it
+ * goes, so any late failure leaves a half-erased person.
+ *
+ * The structural fix, not just the symptom: every check now happens before
+ * every mutation. Above the marker the function only reads and may raise;
+ * below it, nothing can fail on a precondition. Extending this later means
+ * putting new validation above that line, not new guards further down.
+ *
+ * A sole admin now gets an actionable refusal — promote someone, or erase the
+ * organization — instead of a trigger error halfway through.
+ */
+
+CREATE OR REPLACE FUNCTION public.erase_user_personal_data(p_user_id UUID)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_caller       UUID := auth.uid();
+  v_is_service   BOOLEAN := COALESCE(
+                     (current_setting('request.jwt.claims', true)::jsonb ->> 'role') = 'service_role',
+                     current_setting('request.jwt.claim.role', true) = 'service_role',
+                     FALSE
+                   );
+  v_authorised   BOOLEAN := FALSE;
+  v_pair         TEXT;
+  v_tbl          TEXT;
+  v_col          TEXT;
+  v_deleted      JSONB := '{}'::jsonb;
+  v_skipped      JSONB := '[]'::jsonb;
+  v_count        BIGINT;
+  v_sole_admin_orgs TEXT;
+
+  -- 'table:column'. The column is named per table because several of these
+  -- do not use user_id, and assuming they did is what broke this before.
+  v_personal TEXT[] := ARRAY[
+    'user_preferences:user_id',
+    'user_profile_extended:user_id',
+    'user_onboarding_status:user_id',
+    'user_ai_config:user_id',
+    'user_ai_column_selections:user_id',
+    'user_quick_prompt_history:user_id',
+    'user_saved_views:user_id',
+    'user_actions:user_id',
+    'user_asset_flags:user_id',
+    'user_asset_layout_selections:user_id',
+    'user_asset_page_layouts:user_id',
+    'user_asset_page_preferences:user_id',
+    'user_asset_priorities:user_id',
+    'user_asset_references:user_id',
+    'user_asset_widget_values:user_id',
+    'user_asset_widgets:user_id',
+    'personal_tasks:user_id',
+    'attention_user_state:user_id',
+    'author_follows:follower_id',
+    'idea_bookmarks:user_id',
+    'outcome_preferences:user_id',
+    'rating_ev_suppressions:user_id',
+    'asset_followup_suppressions:user_id',
+    'individual_allocation_views:user_id',
+    'chart_annotations:user_id',
+    'notifications:user_id'
+  ];
+BEGIN
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION 'p_user_id is required';
+  END IF;
+
+  IF v_is_service THEN
+    v_authorised := TRUE;
+  ELSIF v_caller IS NOT NULL THEN
+    SELECT EXISTS (
+      SELECT 1
+      FROM organization_memberships subject
+      JOIN organization_memberships admin
+        ON admin.organization_id = subject.organization_id
+      WHERE subject.user_id = p_user_id
+        AND admin.user_id = v_caller
+        AND admin.status = 'active'
+        AND admin.is_org_admin = TRUE
+    ) INTO v_authorised;
+  END IF;
+
+  IF NOT v_authorised THEN
+    RAISE EXCEPTION 'Not authorised to erase this user' USING ERRCODE = 'P0001';
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM users WHERE id = p_user_id) THEN
+    RAISE EXCEPTION 'No such user %', p_user_id USING ERRCODE = 'P0002';
+  END IF;
+
+  -- Last validation before anything is destroyed.
+  --
+  -- Removing an org's only admin is blocked by a trigger further down, and
+  -- rightly so — it would leave the organization with nobody able to
+  -- administer it. But discovering that at the membership UPDATE meant the
+  -- preferences, notifications and OAuth tokens had already been deleted and
+  -- the identity had not been anonymised: half-erased, and reported as a
+  -- failure. Everything above this line is a check; everything below is a
+  -- mutation. Keep it that way.
+  SELECT string_agg(o.name, ', ') INTO v_sole_admin_orgs
+  FROM organization_memberships m
+  JOIN organizations o ON o.id = m.organization_id
+  WHERE m.user_id = p_user_id
+    AND m.status = 'active'
+    AND m.is_org_admin
+    AND NOT EXISTS (
+      SELECT 1 FROM organization_memberships other
+      WHERE other.organization_id = m.organization_id
+        AND other.user_id <> p_user_id
+        AND other.status = 'active'
+        AND other.is_org_admin
+    );
+
+  IF v_sole_admin_orgs IS NOT NULL THEN
+    RAISE EXCEPTION
+      'Cannot erase this user: they are the only active admin of %. Promote '
+      'another admin there first, or erase the organization instead. Nothing '
+      'has been changed.', v_sole_admin_orgs
+      USING ERRCODE = 'P0003';
+  END IF;
+
+  -- 1. Per-person rows.
+  FOREACH v_pair IN ARRAY v_personal LOOP
+    v_tbl := split_part(v_pair, ':', 1);
+    v_col := split_part(v_pair, ':', 2);
+
+    IF to_regclass('public.' || v_tbl) IS NULL THEN
+      v_skipped := v_skipped || to_jsonb(v_tbl || ' (no such table)');
+      CONTINUE;
+    END IF;
+    IF NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = v_tbl AND column_name = v_col
+    ) THEN
+      -- Reported, never silent: a column rename here would otherwise leave
+      -- personal data behind in an erasure we reported as complete.
+      v_skipped := v_skipped || to_jsonb(v_tbl || '.' || v_col || ' (no such column)');
+      CONTINUE;
+    END IF;
+
+    EXECUTE format('DELETE FROM public.%I WHERE %I = $1', v_tbl, v_col) USING p_user_id;
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    IF v_count > 0 THEN
+      v_deleted := v_deleted || jsonb_build_object(v_tbl, v_count);
+    END IF;
+  END LOOP;
+
+  -- 2. Calendar chain, deepest first. calendar_connections holds live OAuth
+  --    access and refresh tokens for a third-party account; those must not
+  --    survive the person they belong to.
+  IF to_regclass('public.calendar_connections') IS NOT NULL THEN
+    IF to_regclass('public.external_calendar_events') IS NOT NULL THEN
+      DELETE FROM external_calendar_events WHERE connected_calendar_id IN (
+        SELECT cc.id FROM connected_calendars cc
+        JOIN calendar_connections c ON c.id = cc.connection_id
+        WHERE c.user_id = p_user_id);
+      GET DIAGNOSTICS v_count = ROW_COUNT;
+      IF v_count > 0 THEN v_deleted := v_deleted || jsonb_build_object('external_calendar_events', v_count); END IF;
+    END IF;
+
+    IF to_regclass('public.calendar_sync_logs') IS NOT NULL THEN
+      DELETE FROM calendar_sync_logs WHERE connection_id IN (
+        SELECT id FROM calendar_connections WHERE user_id = p_user_id);
+      GET DIAGNOSTICS v_count = ROW_COUNT;
+      IF v_count > 0 THEN v_deleted := v_deleted || jsonb_build_object('calendar_sync_logs', v_count); END IF;
+    END IF;
+
+    IF to_regclass('public.connected_calendars') IS NOT NULL THEN
+      DELETE FROM connected_calendars WHERE connection_id IN (
+        SELECT id FROM calendar_connections WHERE user_id = p_user_id);
+      GET DIAGNOSTICS v_count = ROW_COUNT;
+      IF v_count > 0 THEN v_deleted := v_deleted || jsonb_build_object('connected_calendars', v_count); END IF;
+    END IF;
+
+    DELETE FROM calendar_connections WHERE user_id = p_user_id;
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    IF v_count > 0 THEN v_deleted := v_deleted || jsonb_build_object('calendar_connections', v_count); END IF;
+  END IF;
+
+  -- 3. Revoke access. enforce_org_membership_status_transition() permits
+  --    exactly one move out of 'active', and it is to 'inactive' — 'revoked'
+  --    is not a status this system has. Writing it raised P0010 and aborted
+  --    the erasure at this point, after the personal rows were already gone.
+  UPDATE organization_memberships
+  SET status = 'inactive'
+  WHERE user_id = p_user_id AND status = 'active';
+
+  -- 4. Anonymise. full_name is GENERATED from first/last, so it is produced
+  --    rather than assigned.
+  UPDATE users
+  SET email                   = 'erased-' || p_user_id::text || '@deleted.invalid',
+      first_name              = 'Former',
+      last_name               = 'user',
+      timezone                = NULL,
+      is_active               = FALSE,
+      current_organization_id = NULL,
+      pilot_progress          = '{}'::jsonb,
+      is_pilot_user           = FALSE,
+      updated_at              = now()
+  WHERE id = p_user_id;
+
+  RETURN jsonb_build_object(
+    'user_id',      p_user_id,
+    'erased_at',    now(),
+    'rows_deleted', v_deleted,
+    'skipped',      v_skipped,
+    'authored_content_retained', TRUE,
+    'note', 'Authored records are retained as the customer organization''s '
+            'business records and are now attributed to "Former user". '
+            'auth.users is NOT touched — delete the auth identity separately. '
+            'Any entry in "skipped" means personal data was NOT erased there.'
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.erase_user_personal_data(UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.erase_user_personal_data(UUID) TO authenticated;


### PR DESCRIPTION
Two things: proving the previous work actually functions, and closing the legal gap.

## Erasure did not work. Five defects.

The erasure merged in #124 was described in the privacy policy and DPA as a working capability. It was not — and every one of these would have fired on the first real request. The first four leave a **half-erased person** behind.

| | |
|---|---|
| `…160000` | Service-role check read `request.jwt.claim.role`, a deprecated GUC PostgREST no longer sets. `erase-user.mjs` failed with "Not authorised" every time. |
| `…170000` | `users.full_name` is `GENERATED ALWAYS`. Assigning it raises — aborting on the *final* statement, after the personal rows were deleted. |
| `…180000` | Five personal tables have no `user_id`. `author_follows` uses `follower_id`; four calendar tables chain through `calendar_connections` — which holds **live OAuth access and refresh tokens**. |
| `…190000` | Set membership status to `'revoked'`, which is not a status this system has. |
| `…200000` | The structural one. Each fix moved the failure one statement further down a function that deletes as it goes. All validation now happens before any mutation. |

None of this was visible by reading the SQL. It came out of running the erasure against disposable fixtures and checking what actually changed.

Two of my own test fixtures were also silently failing (`notifications` requires `type` and `context_type`), which made "notifications deleted" pass **vacuously** in earlier runs. Worth stating: a green check that asserts nothing is worse than a red one.

**Verified 11/11**, including that a refused erasure changes nothing, OAuth tokens are destroyed, and re-running is safe.

## Tenant isolation, proven rather than asserted

With a real signed-in session in a disposable org: **15/15**. Another org's rows unreadable filtered *and* unfiltered; its storage cannot be downloaded, listed, signed or written to; own-org upload and read still work — so this is isolation, not breakage.

## A correction to the compliance record

I had written that explore search leaked "other organizations' lists and trade ideas". Reading the live policies: `asset_lists` RLS is ownership-based, so the leak crossed the org boundary only for lists the user already had access to — someone in two orgs seeing org A's while working in org B. Real, and narrower than I said. `trade_queue_items` RLS *is* genuinely org-scoped and did not leak at all. `DATA-INVENTORY.md` §8 corrected.

## Privacy policy and terms are now posted

Having no posted privacy policy is itself the live gap — CalOPPA requires one at any size. Static files at `/privacy` and `/terms`, routed **above** the SPA catch-all because Netlify takes the first match; below it they would never fire and the failure mode is a policy everyone believes is posted.

Unfilled placeholders render highlighted in yellow so a half-finished policy cannot ship unnoticed. A test lists what remains but does not fail on it.

**Six values are still needed before this is genuinely in place:** legal entity name, jurisdiction, privacy contact email, postal address, governing law/forum, effective date.

## Verification

1047 tests pass. Build verified; pages land in `dist/legal/` with redirect ordering intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
