### PR TITLE
Feed: news attribution, layout fixes, portfolio lenses, curated filter

### DIFF
--- a/src/components/mobile/FeedFilterSheet.tsx
+++ b/src/components/mobile/FeedFilterSheet.tsx
@@ -1,0 +1,227 @@
+import { useMemo, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { clsx } from 'clsx'
+import { Check, Search, X } from 'lucide-react'
+import { useFeedFacets, type FeedFilter, EMPTY_FILTER, filterCount } from '../../hooks/mobile/useFeedFacets'
+
+interface FeedFilterSheetProps {
+  open: boolean
+  onClose: () => void
+  value: FeedFilter
+  onChange: (next: FeedFilter) => void
+  /** Human names for the feed's internal kind keys. */
+  kindLabels: Record<string, string>
+}
+
+type Facet = 'kinds' | 'sectors' | 'countries' | 'exchanges' | 'symbols'
+
+const TABS: { key: Facet; label: string }[] = [
+  { key: 'kinds', label: 'Type' },
+  { key: 'sectors', label: 'Sector' },
+  { key: 'countries', label: 'Country' },
+  { key: 'exchanges', label: 'Exchange' },
+  { key: 'symbols', label: 'Ticker' },
+]
+
+/**
+ * Curate the feed across several facets at once.
+ *
+ * The category chip on a tile answers "more like this" and sets exactly one
+ * kind, which is the right control for a glance and useless for building a
+ * view — you cannot say "European industrials, news and decisions only" by
+ * tapping a chip.
+ *
+ * Multi-select within a facet, intersected across facets: picking two sectors
+ * widens, adding a country narrows. That is the combination people expect from
+ * faceted filters and the opposite of what OR-ing everything would do.
+ *
+ * Applied on close rather than live. Editing five facets against a feed that
+ * re-shuffles under each tap is unusable, and the draft also makes Cancel mean
+ * something.
+ *
+ * Index membership is absent on purpose — nothing in the schema models index
+ * constituents, and guessing from exchange would be wrong often enough to
+ * mislead.
+ */
+export function FeedFilterSheet({ open, onClose, value, onChange, kindLabels }: FeedFilterSheetProps) {
+  const { data: facets } = useFeedFacets({ enabled: open })
+  const [tab, setTab] = useState<Facet>('kinds')
+  const [draft, setDraft] = useState<FeedFilter>(value)
+  const [symbolQuery, setSymbolQuery] = useState('')
+
+  // Re-seed the draft each time it opens, so a cancelled edit does not persist
+  // into the next one.
+  const [seenOpen, setSeenOpen] = useState(false)
+  if (open && !seenOpen) { setSeenOpen(true); setDraft(value); setSymbolQuery('') }
+  if (!open && seenOpen) setSeenOpen(false)
+
+  const options = useMemo(() => {
+    if (tab === 'kinds') return Object.keys(kindLabels)
+    if (tab === 'sectors') return facets?.sectors ?? []
+    if (tab === 'countries') return facets?.countries ?? []
+    if (tab === 'exchanges') return facets?.exchanges ?? []
+    const q = symbolQuery.trim().toLowerCase()
+    const all = facets?.symbols ?? []
+    // 900 tickers is a scroll, not a list. Selected ones stay pinned at the top
+    // so they can always be removed without searching for them again.
+    const selected = all.filter(s => draft.symbols.includes(s.symbol))
+    const rest = q
+      ? all.filter(s =>
+          !draft.symbols.includes(s.symbol) &&
+          (s.symbol.toLowerCase().includes(q) || (s.name ?? '').toLowerCase().includes(q)))
+      : []
+    return [...selected.map(s => s.symbol), ...rest.slice(0, 40).map(s => s.symbol)]
+  }, [tab, facets, kindLabels, symbolQuery, draft.symbols])
+
+  const labelFor = (opt: string) =>
+    tab === 'kinds' ? (kindLabels[opt] ?? opt) : opt
+
+  const toggle = (opt: string) => {
+    const current = draft[tab]
+    setDraft({
+      ...draft,
+      [tab]: current.includes(opt) ? current.filter(v => v !== opt) : [...current, opt],
+    })
+  }
+
+  const apply = () => { onChange(draft); onClose() }
+
+  if (!open) return null
+  const count = filterCount(draft)
+
+  return createPortal(
+    <div className="fixed inset-0 z-[95] flex flex-col justify-end">
+      <button
+        type="button"
+        aria-label="Close filters"
+        onClick={onClose}
+        className="absolute inset-0 bg-black/40"
+      />
+
+      {/* Tall enough to browse a facet without becoming a full-screen page —
+          the feed staying visible behind it is what makes this read as
+          adjusting a view rather than navigating away. */}
+      <div className="relative w-full h-[78dvh] flex flex-col rounded-t-3xl bg-white dark:bg-gray-900 shadow-2xl">
+        <div className="flex-shrink-0 flex items-center gap-2 px-4 pt-3 pb-2 border-b border-gray-200 dark:border-gray-800">
+          <h2 className="text-[17px] font-bold text-gray-900 dark:text-white">Curate feed</h2>
+          {count > 0 && (
+            <span className="px-2 py-0.5 rounded-full bg-primary-600 text-white text-[11px] font-bold">
+              {count}
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="ml-auto flex items-center justify-center h-9 w-9 rounded-full text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Facet tabs carry their own counts, so a narrowing set two tabs away
+            is visible without opening it — the commonest way a faceted filter
+            confuses people is a selection they have forgotten about. */}
+        <div className="flex-shrink-0 flex gap-1 px-3 py-2 overflow-x-auto border-b border-gray-200 dark:border-gray-800">
+          {TABS.map(t => {
+            const n = draft[t.key].length
+            const active = tab === t.key
+            return (
+              <button
+                key={t.key}
+                type="button"
+                onClick={() => setTab(t.key)}
+                className={clsx(
+                  'flex items-center gap-1.5 shrink-0 px-3 py-1.5 rounded-full text-[13px] font-semibold transition-colors no-touch-target',
+                  active
+                    ? 'bg-gray-900 text-white dark:bg-white dark:text-gray-900'
+                    : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300',
+                )}
+              >
+                {t.label}
+                {n > 0 && (
+                  <span className={clsx(
+                    'px-1.5 rounded-full text-[10px] font-bold',
+                    active ? 'bg-white/25' : 'bg-primary-600 text-white',
+                  )}>
+                    {n}
+                  </span>
+                )}
+              </button>
+            )
+          })}
+        </div>
+
+        {tab === 'symbols' && (
+          <div className="flex-shrink-0 px-4 py-2">
+            <div className="relative">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+              <input
+                value={symbolQuery}
+                onChange={e => setSymbolQuery(e.target.value)}
+                placeholder="Search ticker or company"
+                className="w-full h-10 pl-9 pr-3 rounded-xl bg-gray-100 dark:bg-gray-800 text-sm text-gray-900 dark:text-white placeholder-gray-400 focus:outline-none"
+              />
+            </div>
+          </div>
+        )}
+
+        <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain px-2 pb-2">
+          {options.length === 0 ? (
+            <p className="px-4 py-8 text-center text-sm text-gray-400">
+              {tab === 'symbols' && !symbolQuery
+                ? 'Search for a ticker to add it.'
+                : 'Nothing to filter by here.'}
+            </p>
+          ) : (
+            options.map(opt => {
+              const on = draft[tab].includes(opt)
+              return (
+                <button
+                  key={opt}
+                  type="button"
+                  onClick={() => toggle(opt)}
+                  className="w-full flex items-center gap-3 min-h-[46px] px-3 rounded-xl text-left hover:bg-gray-50 dark:hover:bg-gray-800"
+                >
+                  <span className={clsx(
+                    'flex items-center justify-center h-5 w-5 rounded-md border-2 shrink-0 transition-colors',
+                    on
+                      ? 'bg-primary-600 border-primary-600'
+                      : 'border-gray-300 dark:border-gray-600',
+                  )}>
+                    {on && <Check className="h-3.5 w-3.5 text-white" strokeWidth={3} />}
+                  </span>
+                  <span className={clsx(
+                    'flex-1 min-w-0 truncate text-[15px]',
+                    on ? 'font-semibold text-gray-900 dark:text-white' : 'text-gray-700 dark:text-gray-300',
+                  )}>
+                    {labelFor(opt)}
+                  </span>
+                </button>
+              )
+            })
+          )}
+        </div>
+
+        <div className="flex-shrink-0 flex items-center gap-2 px-4 pt-3 [padding-bottom:calc(0.75rem+env(safe-area-inset-bottom))] border-t border-gray-200 dark:border-gray-800">
+          <button
+            type="button"
+            onClick={() => setDraft(EMPTY_FILTER)}
+            disabled={count === 0}
+            className="h-11 px-4 rounded-xl text-[15px] font-semibold text-gray-600 dark:text-gray-300 disabled:opacity-40"
+          >
+            Clear all
+          </button>
+          <button
+            type="button"
+            onClick={apply}
+            className="flex-1 h-11 rounded-xl bg-primary-600 text-white text-[15px] font-bold"
+          >
+            {count === 0 ? 'Show everything' : `Apply ${count} filter${count === 1 ? '' : 's'}`}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}

--- a/src/components/mobile/FeedTileHeader.tsx
+++ b/src/components/mobile/FeedTileHeader.tsx
@@ -62,7 +62,10 @@ export function FeedTileHeader({
       {badge}
 
       {headline && (
-        <span className="min-w-0 flex-1 text-[13px] font-semibold text-gray-900 dark:text-gray-100 truncate">
+        // Two lines rather than one. Anything short still occupies one, and a
+        // headline that needs two gets them instead of an ellipsis — the band
+        // grows by 16px, which is cheaper than an unreadable card.
+        <span className="min-w-0 flex-1 text-[13px] font-semibold leading-snug text-gray-900 dark:text-gray-100 line-clamp-2">
           {headline}
         </span>
       )}

--- a/src/components/mobile/MobileDashboard.tsx
+++ b/src/components/mobile/MobileDashboard.tsx
@@ -19,6 +19,8 @@ import { useSignalCards } from '../../hooks/ideas/useSignalCards'
 import { SignalFeedTile } from './SignalFeedTile'
 import { DerivedInsightTile } from './DerivedInsightTile'
 import { NewsFeedTile } from './NewsFeedTile'
+import { ConvictionGapTile, CrowdedNameTile } from './PortfolioLensTile'
+import { usePortfolioLenses } from '../../hooks/mobile/usePortfolioLenses'
 import { TemplateFeedTile } from './TemplateFeedTile'
 import { useMarketNews } from '../../hooks/useMarketNews'
 import { useMarketEvents } from '../../hooks/useMarketEvents'
@@ -45,6 +47,7 @@ const KIND_LABELS: Record<string, string> = {
   insight: 'insights',
   news: 'news',
   template: 'market events',
+  lens: 'portfolio lenses',
 }
 
 interface MobileDashboardProps {
@@ -103,6 +106,12 @@ export function MobileDashboard({
   // cards; the `prompt` type is excluded because those are canned questions
   // with no finding behind them, which is precisely the filler complained of.
   const { data: derivedInsights = [], isLoading: insightsLoading } = useDerivedInsights()
+
+  // Portfolio lenses: questions about the book that no other screen asks.
+  // Deliberately part of the feed rather than a separate destination — the
+  // whole point is that nobody goes looking for "is this position the right
+  // size", so it has to arrive unprompted.
+  const { data: lenses } = usePortfolioLenses()
   const { signals, isLoading: signalsLoading } = useSignalCards()
   const realSignals = useMemo(
     () => (signals ?? []).filter(sig => sig.signalType !== 'prompt'),
@@ -465,7 +474,23 @@ export function MobileDashboard({
       card: c,
     }))
 
-    const all = [...attentionEntries, ...ideaEntries, ...signalEntries, ...insightEntries, ...newsEntries, ...templateEntries]
+    // Both lenses share one kind so the interleaver treats them as a single
+    // stream, for the same reason the templates do: two sparse kinds would
+    // otherwise take two slots in every rotation.
+    const lensEntries = [
+      ...((lenses?.conviction ?? []).map((g, idx) => ({
+        kind: 'lens' as const,
+        score: 40 - idx,
+        lens: { type: 'conviction' as const, gap: g },
+      }))),
+      ...((lenses?.crowded ?? []).map((c, idx) => ({
+        kind: 'lens' as const,
+        score: 38 - idx,
+        lens: { type: 'crowded' as const, name: c },
+      }))),
+    ]
+
+    const all = [...attentionEntries, ...ideaEntries, ...signalEntries, ...insightEntries, ...newsEntries, ...templateEntries, ...lensEntries]
 
     // Filtering before the interleave rather than after: interleaving exists to
     // stop one kind running consecutively, and with a single kind selected that
@@ -661,6 +686,33 @@ export function MobileDashboard({
                     name: linked?.company_name ?? null,
                   })}
                 />
+              </section>
+            )
+          }
+
+          if (entry.kind === 'lens') {
+            const l = entry.lens
+            const key = l.type === 'conviction'
+              ? `lens-conv-${l.gap.assetId}-${l.gap.portfolioId}`
+              : `lens-crowd-${l.name.assetId}`
+            return (
+              <section
+                key={key}
+                className="relative h-full w-full snap-start snap-always border-b-8 border-gray-200 dark:border-gray-800"
+              >
+                {l.type === 'conviction' ? (
+                  <ConvictionGapTile
+                    gap={l.gap}
+                    onAssetClick={openAsset}
+                    onFilterKind={() => setKindFilter('lens')}
+                  />
+                ) : (
+                  <CrowdedNameTile
+                    name={l.name}
+                    onAssetClick={openAsset}
+                    onFilterKind={() => setKindFilter('lens')}
+                  />
+                )}
               </section>
             )
           }

--- a/src/components/mobile/MobileDashboard.tsx
+++ b/src/components/mobile/MobileDashboard.tsx
@@ -19,7 +19,7 @@ import { useSignalCards } from '../../hooks/ideas/useSignalCards'
 import { SignalFeedTile } from './SignalFeedTile'
 import { DerivedInsightTile } from './DerivedInsightTile'
 import { NewsFeedTile } from './NewsFeedTile'
-import { ConvictionGapTile, CrowdedNameTile } from './PortfolioLensTile'
+import { ConvictionGapTile, CrowdedNameTile, TargetBreachTile, StaleTargetTile } from './PortfolioLensTile'
 import { usePortfolioLenses } from '../../hooks/mobile/usePortfolioLenses'
 import { TemplateFeedTile } from './TemplateFeedTile'
 import { useMarketNews } from '../../hooks/useMarketNews'
@@ -488,6 +488,19 @@ export function MobileDashboard({
         score: 38 - idx,
         lens: { type: 'crowded' as const, name: c },
       }))),
+      // Scored above the other two: a target that has been hit or has expired
+      // is a decision waiting on someone, where sizing and crowding are
+      // observations. Attention should outrank interest.
+      ...((lenses?.breaches ?? []).map((b, idx) => ({
+        kind: 'lens' as const,
+        score: 60 - idx,
+        lens: { type: 'breach' as const, breach: b },
+      }))),
+      ...((lenses?.stale ?? []).map((t, idx) => ({
+        kind: 'lens' as const,
+        score: 58 - idx,
+        lens: { type: 'stale' as const, target: t },
+      }))),
     ]
 
     const all = [...attentionEntries, ...ideaEntries, ...signalEntries, ...insightEntries, ...newsEntries, ...templateEntries, ...lensEntries]
@@ -692,26 +705,28 @@ export function MobileDashboard({
 
           if (entry.kind === 'lens') {
             const l = entry.lens
-            const key = l.type === 'conviction'
-              ? `lens-conv-${l.gap.assetId}-${l.gap.portfolioId}`
-              : `lens-crowd-${l.name.assetId}`
+            const key =
+              l.type === 'conviction' ? `lens-conv-${l.gap.assetId}-${l.gap.portfolioId}`
+              : l.type === 'crowded'  ? `lens-crowd-${l.name.assetId}`
+              : l.type === 'breach'   ? `lens-breach-${l.breach.assetId}`
+              :                         `lens-stale-${l.target.assetId}`
             return (
               <section
                 key={key}
                 className="relative h-full w-full snap-start snap-always border-b-8 border-gray-200 dark:border-gray-800"
               >
                 {l.type === 'conviction' ? (
-                  <ConvictionGapTile
-                    gap={l.gap}
-                    onAssetClick={openAsset}
-                    onFilterKind={() => setKindFilter('lens')}
-                  />
+                  <ConvictionGapTile gap={l.gap} onAssetClick={openAsset}
+                    onFilterKind={() => setKindFilter('lens')} />
+                ) : l.type === 'crowded' ? (
+                  <CrowdedNameTile name={l.name} onAssetClick={openAsset}
+                    onFilterKind={() => setKindFilter('lens')} />
+                ) : l.type === 'breach' ? (
+                  <TargetBreachTile breach={l.breach} onAssetClick={openAsset}
+                    onFilterKind={() => setKindFilter('lens')} />
                 ) : (
-                  <CrowdedNameTile
-                    name={l.name}
-                    onAssetClick={openAsset}
-                    onFilterKind={() => setKindFilter('lens')}
-                  />
+                  <StaleTargetTile target={l.target} onAssetClick={openAsset}
+                    onFilterKind={() => setKindFilter('lens')} />
                 )}
               </section>
             )

--- a/src/components/mobile/MobileDashboard.tsx
+++ b/src/components/mobile/MobileDashboard.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Lightbulb, X } from 'lucide-react'
+import { Lightbulb, SlidersHorizontal, X } from 'lucide-react'
 import { ReelsFeedItem } from '../feed/ReelsFeedItem'
 import { ACTION_BAR_HEIGHT, MobileFeedActionRail } from './MobileFeedActionRail'
 import { ReadthroughSheet } from './ReadthroughSheet'
@@ -21,6 +21,8 @@ import { DerivedInsightTile } from './DerivedInsightTile'
 import { NewsFeedTile } from './NewsFeedTile'
 import { ConvictionGapTile, CrowdedNameTile, TargetBreachTile, StaleTargetTile } from './PortfolioLensTile'
 import { usePortfolioLenses } from '../../hooks/mobile/usePortfolioLenses'
+import { FeedFilterSheet } from './FeedFilterSheet'
+import { EMPTY_FILTER, filterCount, useFeedFacets, type FeedFilter } from '../../hooks/mobile/useFeedFacets'
 import { TemplateFeedTile } from './TemplateFeedTile'
 import { useMarketNews } from '../../hooks/useMarketNews'
 import { useMarketEvents } from '../../hooks/useMarketEvents'
@@ -138,6 +140,17 @@ export function MobileDashboard({
    * having it do nothing was a dead affordance on every tile.
    */
   const [kindFilter, setKindFilter] = useState<string | null>(null)
+
+  /**
+   * The curated view: several facets at once, intersected.
+   *
+   * kindFilter above stays as the tile chip's one-tap "more like this" — it is
+   * the right control for a glance. This is the other half: you cannot express
+   * "European industrials, news and decisions only" by tapping a chip.
+   */
+  const [feedFilter, setFeedFilter] = useState<FeedFilter>(EMPTY_FILTER)
+  const [filterSheetOpen, setFilterSheetOpen] = useState(false)
+  const { data: facets } = useFeedFacets()
 
   const [resumed] = useState(() => loadFeedSession())
   const [shuffleSeed, setShuffleSeed] = useState(() => resumed?.seed ?? Math.floor(Math.random() * 2 ** 31))
@@ -509,14 +522,61 @@ export function MobileDashboard({
     // stop one kind running consecutively, and with a single kind selected that
     // constraint has nothing to do — applying it first would just be a shuffle
     // fighting a rule that can never be satisfied.
-    const pool = kindFilter ? all.filter(e => e.kind === kindFilter) : all
+    /**
+     * The symbol a tile is about, where it has one.
+     *
+     * Every kind stores it somewhere different, and a tile with no symbol —
+     * a macro event, an unattributed story — is *kept* when only kind filters
+     * are set and dropped when an asset facet is. Dropping it either way would
+     * silently remove whole categories from a "European only" view that the
+     * reader never meant to exclude.
+     */
+    const symbolOf = (e: any): string | null => {
+      switch (e.kind) {
+        case 'news':      return e.news?.primarySymbol ?? null
+        case 'template':  return e.card?.symbol ?? null
+        case 'insight':   return e.insight?.symbol ?? null
+        case 'lens':
+          return e.lens?.gap?.symbol ?? e.lens?.name?.symbol
+              ?? e.lens?.breach?.symbol ?? e.lens?.target?.symbol ?? null
+        case 'idea':      return (e.item as any)?.asset?.symbol ?? null
+        case 'attention': return null
+        default:          return null
+      }
+    }
+
+    const assetFacetsActive =
+      feedFilter.sectors.length > 0 || feedFilter.countries.length > 0 ||
+      feedFilter.exchanges.length > 0 || feedFilter.symbols.length > 0
+
+    const matchesFilter = (e: any): boolean => {
+      if (feedFilter.kinds.length && !feedFilter.kinds.includes(e.kind)) return false
+      if (!assetFacetsActive) return true
+
+      const sym = symbolOf(e)
+      // No symbol and an asset facet is set: this tile cannot be shown to
+      // satisfy it, so it is excluded rather than assumed to qualify.
+      if (!sym) return false
+      if (feedFilter.symbols.length && !feedFilter.symbols.includes(sym)) return false
+
+      const f = facets?.bySymbol.get(sym.toUpperCase())
+      if (feedFilter.sectors.length && !(f?.sector && feedFilter.sectors.includes(f.sector))) return false
+      if (feedFilter.countries.length && !(f?.country && feedFilter.countries.includes(f.country))) return false
+      if (feedFilter.exchanges.length && !(f?.exchange && feedFilter.exchanges.includes(f.exchange))) return false
+      return true
+    }
+
+    // Facets intersect: two sectors widen, adding a country narrows. The chip
+    // filter stays a separate one-tap override on top.
+    const curated = filterCount(feedFilter) ? all.filter(matchesFilter) : all
+    const pool = kindFilter ? curated.filter(e => e.kind === kindFilter) : curated
 
     return interleaveByKind<any>(pool, {
       maxRun: 1,
       leadWith: kindFilter ? undefined : 'attention',
       seed: shuffleSeed,
     })
-  }, [dedupedAttention, visibleItems, realSignals, derivedInsights, newsItems, templateCards, cycle, interestAtMount, shuffleSeed, kindFilter])
+  }, [dedupedAttention, visibleItems, realSignals, derivedInsights, newsItems, templateCards, cycle, interestAtMount, shuffleSeed, kindFilter, lenses, feedFilter, facets])
 
   useEffect(() => {
     const sentinel = sentinelRef.current
@@ -646,12 +706,40 @@ export function MobileDashboard({
       {/* Active filter. Occupies its own row so it cannot scroll away and
           cannot cover the feed — a filter you cannot see is a feed that looks
           broken, and one that hides the tile beneath it is worse. */}
+      {/* Always-present entry point. The chip filter below only appears once
+          something is filtered, which is correct for a state indicator and
+          wrong for a control — there was no way to *start* curating. */}
+      <div className="flex-shrink-0 flex items-center gap-2 px-3 pb-2 pt-2.5 [padding-top:calc(0.625rem+env(safe-area-inset-top))] border-b border-gray-200 dark:border-gray-800">
+        <button
+          type="button"
+          onClick={() => setFilterSheetOpen(true)}
+          className="flex items-center gap-1.5 h-8 px-3 rounded-full bg-gray-100 dark:bg-gray-800 text-[12px] font-bold text-gray-700 dark:text-gray-200 no-touch-target"
+        >
+          <SlidersHorizontal className="h-3.5 w-3.5" />
+          Curate
+          {filterCount(feedFilter) > 0 && (
+            <span className="px-1.5 rounded-full bg-primary-600 text-white text-[10px]">
+              {filterCount(feedFilter)}
+            </span>
+          )}
+        </button>
+        {filterCount(feedFilter) > 0 && (
+          <button
+            type="button"
+            onClick={() => setFeedFilter(EMPTY_FILTER)}
+            className="text-[12px] font-semibold text-gray-500 dark:text-gray-400 underline underline-offset-2 no-touch-target"
+          >
+            Reset
+          </button>
+        )}
+      </div>
+
       {kindFilter && (
         // pt-safe alone collapses to zero on a phone with no notch, which is
         // why the band read as cramped against the top edge. A real 10px floor
         // plus the inset, and more room below it, gives the row a band rather
         // than a stripe.
-        <div className="flex-shrink-0 z-40 flex items-center gap-2 px-3 pb-2.5 pt-2.5 [padding-top:calc(0.625rem+env(safe-area-inset-top))] bg-gray-900 text-white dark:bg-gray-800">
+        <div className="flex-shrink-0 z-40 flex items-center gap-2 px-3 py-2.5 bg-gray-900 text-white dark:bg-gray-800">
           <span className="text-[11px] font-bold uppercase tracking-[0.06em]">
             {KIND_LABELS[kindFilter] ?? kindFilter} only
           </span>
@@ -888,6 +976,14 @@ export function MobileDashboard({
           }}
         />
       )}
+
+      <FeedFilterSheet
+        open={filterSheetOpen}
+        onClose={() => setFilterSheetOpen(false)}
+        value={feedFilter}
+        onChange={setFeedFilter}
+        kindLabels={KIND_LABELS}
+      />
 
       {readthroughFor && (
         <ReadthroughSheet

--- a/src/components/mobile/MobileDashboard.tsx
+++ b/src/components/mobile/MobileDashboard.tsx
@@ -609,7 +609,11 @@ export function MobileDashboard({
           cannot cover the feed — a filter you cannot see is a feed that looks
           broken, and one that hides the tile beneath it is worse. */}
       {kindFilter && (
-        <div className="flex-shrink-0 z-40 flex items-center gap-2 px-3 py-2 bg-gray-900 text-white pt-safe dark:bg-gray-800">
+        // pt-safe alone collapses to zero on a phone with no notch, which is
+        // why the band read as cramped against the top edge. A real 10px floor
+        // plus the inset, and more room below it, gives the row a band rather
+        // than a stripe.
+        <div className="flex-shrink-0 z-40 flex items-center gap-2 px-3 pb-2.5 pt-2.5 [padding-top:calc(0.625rem+env(safe-area-inset-top))] bg-gray-900 text-white dark:bg-gray-800">
           <span className="text-[11px] font-bold uppercase tracking-[0.06em]">
             {KIND_LABELS[kindFilter] ?? kindFilter} only
           </span>

--- a/src/components/mobile/MobileSearchOverlay.tsx
+++ b/src/components/mobile/MobileSearchOverlay.tsx
@@ -130,7 +130,9 @@ export function MobileSearchOverlay({ open, onClose, onSelectResult }: MobileSea
         key,
         kind: r.kind,
         title: r.title,
-        matchedIn: r.matchedIn,
+        // A relaxed hit says so. It matched some of the query, not all of it,
+        // and the row has to admit that or a suggestion reads as an answer.
+        matchedIn: r.related ? `related — ${r.matchedIn}` : r.matchedIn,
         excerpt: r.excerpt,
         score: r.score,
         select: () => {
@@ -219,11 +221,22 @@ export function MobileSearchOverlay({ open, onClose, onSelectResult }: MobileSea
         ) : results.length === 0 ? (
           <div className="px-4 py-10 text-center">
             <p className="text-sm text-gray-500 dark:text-gray-400">
-              Nothing matches “{trimmed}”.
+              Nothing written up on “{trimmed}” yet.
             </p>
             <p className="mt-1 text-xs text-gray-400">
-              Apps, assets, portfolios, themes, lists, notes and trade rationales
-              are all searched.
+              Assets, themes, lists, research notes, captured thoughts and trade
+              rationales were all searched, for any word in that phrase.
+            </p>
+            {/* An empty result is itself information: nobody has written this
+                up. That is a prompt to start, not a dead end — and telling the
+                reader where the gap is, is the whole point of a search meant
+                to help decide what to work on next. */}
+            <p className="mt-5 text-xs font-semibold uppercase tracking-wider text-gray-400">
+              That might be the opportunity
+            </p>
+            <p className="mt-1.5 text-[13px] text-gray-500 dark:text-gray-400">
+              Capture a thought on it, or start a theme — a gap in the book is
+              worth more than another note on something already covered.
             </p>
           </div>
         ) : (

--- a/src/components/mobile/NewsFeedTile.tsx
+++ b/src/components/mobile/NewsFeedTile.tsx
@@ -64,9 +64,14 @@ export function NewsFeedTile({ item, assetForSymbol, onAssetClick, onCapture, on
    * dropped — we have no chart to draw for it.
    */
   const chartable = useMemo(() => {
-    const ordered = item.primarySymbol
-      ? [item.primarySymbol, ...item.symbols.filter(s => s !== item.primarySymbol)]
-      : item.symbols
+    // No subject means no chart. market-news now attributes from the story's
+    // own words and leaves `primarySymbol` unset when the text names nobody —
+    // a fund or macro story. Falling back to `symbols` here would put the
+    // queried ticker back on screen, which is the wrong-chart bug by another
+    // route: "Tiger Global cuts stakes in Big Tech" would draw Microsoft
+    // again purely because Microsoft's query found it.
+    if (!item.primarySymbol) return []
+    const ordered = [item.primarySymbol, ...item.symbols.filter(s => s !== item.primarySymbol)]
     const seen = new Set<string>()
     return ordered
       .map(sym => assetForSymbol?.(sym) ?? null)
@@ -78,6 +83,10 @@ export function NewsFeedTile({ item, assetForSymbol, onAssetClick, onCapture, on
       .slice(0, 5)
   }, [item.primarySymbol, item.symbols, assetForSymbol])
 
+  // Chips name what the story is about, not what query surfaced it. Showing
+  // the queried ticker on a story that never mentions it is what put GOOGL on
+  // half the feed.
+  const attributed = item.primarySymbol ? item.symbols : []
   const [chartIndex, setChartIndex] = useState(0)
   const [readerOpen, setReaderOpen] = useState(false)
   const covered = chartable[chartIndex] ?? null
@@ -109,6 +118,26 @@ export function NewsFeedTile({ item, assetForSymbol, onAssetClick, onCapture, on
           can exceed a phone screen, and clipping the story is the one thing
           this tile must not do. */}
       <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain">
+        {/* Above the headline, edge to edge, and shorter.
+            Below the title it split the story in two — headline, picture,
+            then the rest of the prose — so the summary read as a caption to
+            an image that had already interrupted it. A masthead photo is the
+            arrangement every news app uses because it sets the scene before
+            the words rather than between them. h-24 to h-[104px] full-bleed
+            reads as larger while occupying less vertical space than an inset
+            band did. */}
+        {showImage && (
+          <img
+            src={item.imageUrl}
+            alt=""
+            loading="lazy"
+            // A broken image URL should cost the picture, not leave a torn
+            // frame at the top of the story.
+            onError={() => setImageFailed(true)}
+            className="w-full h-[104px] object-cover bg-gray-100 dark:bg-gray-800"
+          />
+        )}
+
         <div className="px-3 pt-2.5 pb-2">
           <h2 className={clsx(
             'font-bold text-gray-900 dark:text-white leading-snug',
@@ -118,7 +147,7 @@ export function NewsFeedTile({ item, assetForSymbol, onAssetClick, onCapture, on
             {item.headline}
           </h2>
 
-          {(sentiment || item.symbols.length > 0) && (
+          {(sentiment || attributed.length > 0) && (
             <div className="flex items-center gap-1.5 flex-wrap mt-2">
               {sentiment && SentimentIcon && (
                 <span className={clsx('inline-flex items-center gap-1 px-1.5 py-0.5 rounded-full text-[11px] font-medium', sentiment.chip)}>
@@ -126,7 +155,7 @@ export function NewsFeedTile({ item, assetForSymbol, onAssetClick, onCapture, on
                   {sentiment.label}
                 </span>
               )}
-              {item.symbols.slice(0, 5).map(sym => {
+              {attributed.slice(0, 5).map(sym => {
                 const asset = assetForSymbol?.(sym) ?? null
                 return (
                   <button
@@ -149,24 +178,6 @@ export function NewsFeedTile({ item, assetForSymbol, onAssetClick, onCapture, on
           )}
         </div>
 
-        {showImage && (
-          <div className="px-3 pb-2">
-            <img
-              src={item.imageUrl}
-              alt=""
-              loading="lazy"
-              // A broken image URL should cost the picture, not leave a torn
-              // frame in the middle of the story.
-              onError={() => setImageFailed(true)}
-              // Deliberately a band rather than a hero. At h-40 the picture was
-              // the tile: most stories carry an image and few carry prose, so
-              // the screen read as a photo with a caption. It is supporting
-              // material and now takes supporting height.
-              className="w-full h-24 object-cover rounded-lg bg-gray-100 dark:bg-gray-800"
-            />
-          </div>
-        )}
-
         {item.summary && (
           <div className="px-3 pb-2">
             <ExpandableText text={item.summary} lines={6} />
@@ -177,45 +188,60 @@ export function NewsFeedTile({ item, assetForSymbol, onAssetClick, onCapture, on
             did about it — but only for names actually in the book. */}
         {covered && (
           <div className="px-3 pb-3">
-            {/* One chart at a time, swapped by the pager below, rather than a
-                horizontal scroller: this sits inside a vertically-swiped feed,
-                and a nested horizontal scroll region steals the gesture that
-                moves between stories. */}
-            <WhenNearViewport
-              className="h-[220px]"
-              placeholder={
-                <div className="w-full h-full rounded-lg bg-gray-50 dark:bg-gray-800/50 animate-pulse" />
-              }
-            >
-              <ReelsChartPanel key={covered.symbol} symbol={covered.symbol} hideHeader />
-            </WhenNearViewport>
-
-            {chartable.length > 1 && (
-              <div className="mt-2 flex items-center justify-center gap-1.5">
-                {chartable.map((a, i) => (
-                  <button
-                    key={a.id}
-                    type="button"
-                    onClick={() => setChartIndex(i)}
-                    aria-label={`Show ${a.symbol} chart`}
-                    aria-current={i === chartIndex}
-                    className={clsx(
-                      'px-2.5 py-1 rounded-full text-[11px] font-semibold tracking-wide transition-colors no-touch-target',
-                      i === chartIndex
-                        ? 'bg-gray-900 text-white dark:bg-white dark:text-gray-900'
-                        : 'bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400'
-                    )}
-                  >
-                    {a.symbol}
-                  </button>
-                ))}
+            {/* The switcher sits on the chart, not under it.
+                Detached pills below made you look away from the chart to find
+                out what you were looking at, and read as page dots rather than
+                as a control. Naming the symbol on the chart's own header means
+                the answer is where the eye already is; the other tickers are a
+                segmented control beside it, which reads as "these are the
+                choices" instead of "you are on slide 2". */}
+            <div className="rounded-xl border border-gray-200 dark:border-gray-800 overflow-hidden">
+              <div className="flex items-center gap-2 px-2.5 py-1.5 bg-gray-50 dark:bg-white/[0.04] border-b border-gray-200 dark:border-gray-800">
+                <span className="text-[13px] font-bold tracking-tight text-gray-900 dark:text-white">
+                  {covered.symbol}
+                </span>
+                {chartable.length > 1 && (
+                  <div className="ml-auto flex items-center rounded-lg bg-gray-200/70 dark:bg-white/10 p-0.5">
+                    {chartable.map((a, i) => (
+                      <button
+                        key={a.id}
+                        type="button"
+                        onClick={() => setChartIndex(i)}
+                        aria-label={`Show ${a.symbol} chart`}
+                        aria-current={i === chartIndex}
+                        className={clsx(
+                          'px-2 py-[3px] rounded-md text-[11px] font-bold tracking-wide transition-colors no-touch-target',
+                          i === chartIndex
+                            ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-900 dark:text-white'
+                            : 'text-gray-500 dark:text-gray-400'
+                        )}
+                      >
+                        {a.symbol}
+                      </button>
+                    ))}
+                  </div>
+                )}
               </div>
-            )}
+              <WhenNearViewport
+                className="h-[200px]"
+                placeholder={
+                  <div className="w-full h-full bg-gray-50 dark:bg-gray-800/50 animate-pulse" />
+                }
+              >
+                <ReelsChartPanel key={covered.symbol} symbol={covered.symbol} hideHeader />
+              </WhenNearViewport>
+            </div>
+
+
           </div>
         )}
       </div>
 
-      <div className="flex-shrink-0 flex items-stretch gap-2 px-3 py-2 pb-safe border-t border-gray-200 dark:border-gray-700">
+      {/* pb-safe alone only clears the home indicator — on a phone without
+          one it resolves to zero, so the buttons sat flush against the screen
+          edge. A real 12px floor plus the safe area gives the row somewhere to
+          sit either way. */}
+      <div className="flex-shrink-0 flex items-stretch gap-2 px-3 pt-2 pb-3 [padding-bottom:calc(0.75rem+env(safe-area-inset-bottom))] border-t border-gray-200 dark:border-gray-700">
         <button
           type="button"
           onClick={onCapture}

--- a/src/components/mobile/PortfolioLensTile.tsx
+++ b/src/components/mobile/PortfolioLensTile.tsx
@@ -1,0 +1,221 @@
+import { clsx } from 'clsx'
+import { Scale, Layers3 } from 'lucide-react'
+import { FeedTileHeader } from './FeedTileHeader'
+import { FeedKindBadge } from './FeedKindBadge'
+import type { ConvictionGap, CrowdedName } from '../../hooks/mobile/usePortfolioLenses'
+
+interface ConvictionTileProps {
+  gap: ConvictionGap
+  onAssetClick?: (assetId: string, symbol: string) => void
+  onFilterKind?: () => void
+}
+
+const money = (n: number) =>
+  n >= 1e9 ? `$${(n / 1e9).toFixed(1)}B`
+  : n >= 1e6 ? `$${(n / 1e6).toFixed(1)}M`
+  : n >= 1e3 ? `$${(n / 1e3).toFixed(0)}K`
+  : `$${n.toFixed(0)}`
+
+/**
+ * Conviction against position size.
+ *
+ * Every other portfolio surface reports what a position *is*. This asks
+ * whether its size matches the view being taken on it, which is a question
+ * nobody is otherwise prompted to answer — and the two corners it surfaces are
+ * the ones that go unnoticed longest. A name everyone agrees is cheap, held at
+ * 0.4%, earns nothing if it works. A 6% position whose own base target implies
+ * no upside is a bet on a view that has already been abandoned on paper.
+ *
+ * Conviction is the base price target rather than a rating: a rating is a
+ * label picked from a list, a target is a number someone had to defend.
+ */
+export function ConvictionGapTile({ gap, onAssetClick, onFilterKind }: ConvictionTileProps) {
+  const under = gap.direction === 'underweight'
+  const upside = Math.round(gap.upsidePct * 100)
+
+  return (
+    <div className="relative w-full h-full flex flex-col bg-white dark:bg-gray-900">
+      <FeedTileHeader
+        badge={
+          <FeedKindBadge
+            icon={Scale}
+            label="Sizing"
+            chip="bg-violet-100 text-violet-700 dark:bg-violet-900/30 dark:text-violet-300"
+            onFilter={onFilterKind}
+            filterLabel="Show only sizing checks"
+          />
+        }
+        headline={under ? 'Conviction without size' : 'Size without conviction'}
+      />
+
+      <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain px-4 pt-5 pb-4">
+        <button
+          type="button"
+          onClick={() => onAssetClick?.(gap.assetId, gap.symbol)}
+          className="text-left no-touch-target"
+        >
+          <div className="text-[34px] font-black leading-none tracking-[-0.035em] text-gray-900 dark:text-white">
+            {gap.symbol}
+          </div>
+          {gap.companyName && (
+            <div className="mt-1 text-[13px] font-medium text-gray-500 dark:text-gray-400 truncate">
+              {gap.companyName}
+            </div>
+          )}
+        </button>
+
+        {/* The two numbers side by side, because the tension between them is
+            the entire point — reading either alone says nothing. */}
+        <div className="mt-6 grid grid-cols-2 gap-3">
+          <Figure
+            label="Implied upside"
+            value={`${upside > 0 ? '+' : ''}${upside}%`}
+            tone={upside >= 25 ? 'good' : upside <= 5 ? 'bad' : 'flat'}
+            note="to base target"
+          />
+          <Figure
+            label="Position"
+            value={`${gap.weightPct.toFixed(1)}%`}
+            tone={under ? 'bad' : 'good'}
+            note={gap.portfolioName}
+          />
+        </div>
+
+        <p className="mt-6 text-[15px] leading-relaxed text-gray-700 dark:text-gray-300">
+          {under ? (
+            <>
+              The base case says <strong>{gap.symbol}</strong> is worth {upside}% more
+              than it trades at, and it is {gap.weightPct.toFixed(1)}% of{' '}
+              {gap.portfolioName}. If the view is right, the position is too small
+              to matter.
+            </>
+          ) : (
+            <>
+              <strong>{gap.symbol}</strong> is {gap.weightPct.toFixed(1)}% of{' '}
+              {gap.portfolioName}, and the base target implies{' '}
+              {upside <= 0 ? 'no upside left' : `only ${upside}% upside`}. The size
+              is carrying a view the target no longer supports.
+            </>
+          )}
+        </p>
+
+        <p className="mt-4 text-[12px] text-gray-400 dark:text-gray-500">
+          Based on the most recent base price target. If that number is stale, this
+          is telling you that too.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+interface CrowdedTileProps {
+  name: CrowdedName
+  onAssetClick?: (assetId: string, symbol: string) => void
+  onFilterKind?: () => void
+}
+
+/**
+ * One name, several portfolios.
+ *
+ * Per-portfolio views are correct and individually reassuring: 3% here, 4%
+ * there, nothing out of line anywhere. The exposure only becomes visible when
+ * the books are looked at together, which no other screen does — so a name can
+ * become the firm's largest single bet without any one view ever showing it.
+ */
+export function CrowdedNameTile({ name, onAssetClick, onFilterKind }: CrowdedTileProps) {
+  return (
+    <div className="relative w-full h-full flex flex-col bg-white dark:bg-gray-900">
+      <FeedTileHeader
+        badge={
+          <FeedKindBadge
+            icon={Layers3}
+            label="Crowding"
+            chip="bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300"
+            onFilter={onFilterKind}
+            filterLabel="Show only crowding"
+          />
+        }
+        headline={`Held in ${name.portfolioCount} portfolios`}
+      />
+
+      <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain px-4 pt-5 pb-4">
+        <button
+          type="button"
+          onClick={() => onAssetClick?.(name.assetId, name.symbol)}
+          className="text-left no-touch-target"
+        >
+          <div className="text-[34px] font-black leading-none tracking-[-0.035em] text-gray-900 dark:text-white">
+            {name.symbol}
+          </div>
+          {name.companyName && (
+            <div className="mt-1 text-[13px] font-medium text-gray-500 dark:text-gray-400 truncate">
+              {name.companyName}
+            </div>
+          )}
+        </button>
+
+        <div className="mt-6 grid grid-cols-2 gap-3">
+          <Figure
+            label="Portfolios"
+            value={String(name.portfolioCount)}
+            tone={name.portfolioCount >= 4 ? 'bad' : 'flat'}
+            note="hold this name"
+          />
+          <Figure
+            label="Largest weight"
+            value={`${name.maxWeightPct.toFixed(1)}%`}
+            tone={name.maxWeightPct >= 5 ? 'bad' : 'flat'}
+            note="in one book"
+          />
+        </div>
+
+        <p className="mt-6 text-[15px] leading-relaxed text-gray-700 dark:text-gray-300">
+          <strong>{name.symbol}</strong> is held across {name.portfolioCount}{' '}
+          portfolios, {money(name.totalValue)} in total. Each position looks
+          reasonable on its own — the concentration only exists at the firm level.
+        </p>
+
+        <div className="mt-4 flex flex-wrap gap-1.5">
+          {name.portfolioNames.slice(0, 6).map(p => (
+            <span
+              key={p}
+              className="px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-800 text-[11px] font-medium text-gray-600 dark:text-gray-300"
+            >
+              {p}
+            </span>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Figure({
+  label, value, note, tone,
+}: {
+  label: string
+  value: string
+  note?: string
+  tone: 'good' | 'bad' | 'flat'
+}) {
+  return (
+    <div className="rounded-2xl border border-gray-200 dark:border-gray-800 px-3.5 py-3">
+      <div className="text-[10px] font-bold uppercase tracking-[0.06em] text-gray-400">
+        {label}
+      </div>
+      <div
+        className={clsx(
+          'mt-1 text-[26px] font-black leading-none tracking-[-0.03em]',
+          tone === 'good' && 'text-emerald-500 dark:text-emerald-400',
+          tone === 'bad' && 'text-rose-500 dark:text-rose-400',
+          tone === 'flat' && 'text-gray-900 dark:text-white',
+        )}
+      >
+        {value}
+      </div>
+      {note && (
+        <div className="mt-1 text-[11px] text-gray-400 dark:text-gray-500 truncate">{note}</div>
+      )}
+    </div>
+  )
+}

--- a/src/components/mobile/PortfolioLensTile.tsx
+++ b/src/components/mobile/PortfolioLensTile.tsx
@@ -1,8 +1,8 @@
 import { clsx } from 'clsx'
-import { Scale, Layers3 } from 'lucide-react'
+import { Scale, Layers3, Target, CalendarClock } from 'lucide-react'
 import { FeedTileHeader } from './FeedTileHeader'
 import { FeedKindBadge } from './FeedKindBadge'
-import type { ConvictionGap, CrowdedName } from '../../hooks/mobile/usePortfolioLenses'
+import type { ConvictionGap, CrowdedName, TargetBreach, StaleTarget } from '../../hooks/mobile/usePortfolioLenses'
 
 interface ConvictionTileProps {
   gap: ConvictionGap
@@ -79,6 +79,13 @@ export function ConvictionGapTile({ gap, onAssetClick, onFilterKind }: Convictio
             tone={under ? 'bad' : 'good'}
             note={gap.portfolioName}
           />
+          {gap.conviction && (
+            <div className="col-span-2 -mt-1 text-[12px] text-gray-500 dark:text-gray-400">
+              Stated conviction: <strong className="text-gray-700 dark:text-gray-200">{gap.conviction}</strong>
+              {' — '}the rating and the target are separate claims, and this tile
+              fires when either one is out of step with the size.
+            </div>
+          )}
         </div>
 
         <p className="mt-6 text-[15px] leading-relaxed text-gray-700 dark:text-gray-300">
@@ -216,6 +223,147 @@ function Figure({
       {note && (
         <div className="mt-1 text-[11px] text-gray-400 dark:text-gray-500 truncate">{note}</div>
       )}
+    </div>
+  )
+}
+
+interface BreachTileProps {
+  breach: TargetBreach
+  onAssetClick?: (assetId: string, symbol: string) => void
+  onFilterKind?: () => void
+}
+
+/**
+ * The price reached the target and nobody was told.
+ *
+ * This is the quietest way a book goes stale. The thesis worked, which feels
+ * like success and therefore prompts nothing — but the position is now held
+ * with no stated upside at all, and that is a decision being made by default.
+ * Either the target moves or the position does.
+ */
+export function TargetBreachTile({ breach, onAssetClick, onFilterKind }: BreachTileProps) {
+  const over = Math.round(breach.overshootPct * 100)
+
+  return (
+    <div className="relative w-full h-full flex flex-col bg-white dark:bg-gray-900">
+      <FeedTileHeader
+        badge={
+          <FeedKindBadge
+            icon={Target}
+            label="Target hit"
+            chip="bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300"
+            onFilter={onFilterKind}
+            filterLabel="Show only target checks"
+          />
+        }
+        headline="Trading at or above the target"
+      />
+
+      <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain px-4 pt-5 pb-4">
+        <button
+          type="button"
+          onClick={() => onAssetClick?.(breach.assetId, breach.symbol)}
+          className="text-left no-touch-target"
+        >
+          <div className="text-[34px] font-black leading-none tracking-[-0.035em] text-gray-900 dark:text-white">
+            {breach.symbol}
+          </div>
+          {breach.companyName && (
+            <div className="mt-1 text-[13px] font-medium text-gray-500 dark:text-gray-400 truncate">
+              {breach.companyName}
+            </div>
+          )}
+        </button>
+
+        <div className="mt-6 grid grid-cols-2 gap-3">
+          <Figure label="Price" value={`$${breach.price.toFixed(2)}`} tone="good"
+            note={over > 0 ? `${over}% past target` : 'at target'} />
+          <Figure label="Target" value={`$${breach.target.toFixed(2)}`} tone="flat"
+            note={breach.conviction ? `${breach.conviction} conviction` : 'no rating'} />
+        </div>
+
+        <p className="mt-6 text-[15px] leading-relaxed text-gray-700 dark:text-gray-300">
+          <strong>{breach.symbol}</strong> has reached the target. The position is
+          now held with no stated upside — raise the target if the thesis has more
+          in it, or the size is being carried on a view that is finished.
+        </p>
+
+        {breach.heldIn.length > 0 && (
+          <div className="mt-4 flex flex-wrap gap-1.5">
+            {breach.heldIn.slice(0, 6).map(p => (
+              <span key={p} className="px-2 py-0.5 rounded-full bg-gray-100 dark:bg-gray-800 text-[11px] font-medium text-gray-600 dark:text-gray-300">
+                {p}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+interface StaleTileProps {
+  target: StaleTarget
+  onAssetClick?: (assetId: string, symbol: string) => void
+  onFilterKind?: () => void
+}
+
+/**
+ * The view has outlived its own horizon.
+ *
+ * A 12-month target set 18 months ago is not a view any more, it is a number
+ * left on a page — and it will keep being read as current by everything that
+ * consumes it, including the sizing lens next door. Nothing else expires it,
+ * because nothing else knows the horizon was ever stated.
+ */
+export function StaleTargetTile({ target, onAssetClick, onFilterKind }: StaleTileProps) {
+  const upside = Math.round(((target.target - target.price) / target.price) * 100)
+
+  return (
+    <div className="relative w-full h-full flex flex-col bg-white dark:bg-gray-900">
+      <FeedTileHeader
+        badge={
+          <FeedKindBadge
+            icon={CalendarClock}
+            label="Expired"
+            chip="bg-rose-100 text-rose-700 dark:bg-rose-900/30 dark:text-rose-300"
+            onFilter={onFilterKind}
+            filterLabel="Show only target checks"
+          />
+        }
+        headline={`${target.timeframe ?? 'Target'} horizon ran out`}
+      />
+
+      <div className="flex-1 min-h-0 overflow-y-auto overscroll-contain px-4 pt-5 pb-4">
+        <button
+          type="button"
+          onClick={() => onAssetClick?.(target.assetId, target.symbol)}
+          className="text-left no-touch-target"
+        >
+          <div className="text-[34px] font-black leading-none tracking-[-0.035em] text-gray-900 dark:text-white">
+            {target.symbol}
+          </div>
+          {target.companyName && (
+            <div className="mt-1 text-[13px] font-medium text-gray-500 dark:text-gray-400 truncate">
+              {target.companyName}
+            </div>
+          )}
+        </button>
+
+        <div className="mt-6 grid grid-cols-2 gap-3">
+          <Figure label="Set" value={`${target.ageMonths}mo ago`} tone="bad"
+            note={`${target.overdueMonths}mo past horizon`} />
+          <Figure label="Still implies" value={`${upside > 0 ? '+' : ''}${upside}%`} tone="flat"
+            note={`$${target.target.toFixed(2)} target`} />
+        </div>
+
+        <p className="mt-6 text-[15px] leading-relaxed text-gray-700 dark:text-gray-300">
+          This was a {target.timeframe ?? 'dated'} view set {target.ageMonths} months
+          ago. It is still being read as current — by the sizing check, and by
+          anyone looking at the name — {target.overdueMonths} months after the
+          horizon it was written for ended.
+        </p>
+      </div>
     </div>
   )
 }

--- a/src/components/mobile/TemplateFeedTile.tsx
+++ b/src/components/mobile/TemplateFeedTile.tsx
@@ -77,10 +77,16 @@ export function TemplateFeedTile({ card, onAssetClick, onCapture, onFilterKind }
             filterLabel="Show only market events"
           />
         }
-        headline={card.headline}
       />
 
-      <FeedTileTitle quoteSymbol={card.symbol ?? undefined} />
+      {/* The headline is this tile's content, not its chrome, so it belongs in
+          the title band where it can wrap. In the header it shared one line
+          with the badge and got truncated — "Active risk in KKR is 2.4x the
+          book…" is not a sentence you can cut and still act on. */}
+      <FeedTileTitle
+        headline={card.headline}
+        quoteSymbol={card.symbol ?? undefined}
+      />
 
       {card.symbol && (
         <WhenNearViewport className="flex-shrink-0 h-[33%] min-h-[170px] max-h-[300px] px-3" placeholder={<div className="w-full h-full rounded-lg bg-gray-50 dark:bg-gray-800/50 animate-pulse" />}>

--- a/src/hooks/mobile/useFeedFacets.ts
+++ b/src/hooks/mobile/useFeedFacets.ts
@@ -1,0 +1,95 @@
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../../lib/supabase'
+import { useOrganizationOptional } from '../../contexts/OrganizationContext'
+
+/**
+ * The values the feed can actually be filtered by.
+ *
+ * Read from the assets the org holds or covers rather than from a fixed list,
+ * so the picker only ever offers facets that will match something. A filter
+ * that can return nothing is worse than no filter — the reader cannot tell an
+ * empty result from a broken one.
+ *
+ * Index membership is deliberately absent: `assets` carries sector, country
+ * and exchange, but nothing models index constituents, and inferring "S&P 500"
+ * from an exchange would be wrong often enough to be misleading. It needs a
+ * real join table before it can be offered.
+ */
+
+export interface FeedFacets {
+  sectors: string[]
+  countries: string[]
+  exchanges: string[]
+  /** Tickers held or covered, for the ticker picker's search. */
+  symbols: { symbol: string; name: string | null }[]
+  /**
+   * Symbol to its facets, so the feed can decide whether a tile matches
+   * without a second query. Keyed uppercase because feed items carry symbols
+   * in whatever case their source used.
+   */
+  bySymbol: Map<string, { sector: string | null; country: string | null; exchange: string | null }>
+}
+
+export function useFeedFacets(options?: { enabled?: boolean }) {
+  const currentOrgId = useOrganizationOptional()?.currentOrgId ?? null
+
+  return useQuery<FeedFacets>({
+    queryKey: ['feed-facets', currentOrgId],
+    enabled: (options?.enabled ?? true) && !!currentOrgId,
+    // Facets change when coverage changes, which is rarely and never mid-session.
+    staleTime: 30 * 60 * 1000,
+    queryFn: async () => {
+      const { data } = await supabase
+        .from('assets')
+        .select('symbol, company_name, sector, country, exchange')
+        .order('symbol')
+        .limit(2000)
+
+      const rows = (data ?? []) as any[]
+      const uniq = (vals: (string | null)[]) =>
+        Array.from(new Set(vals.filter(Boolean) as string[])).sort()
+
+      const bySymbol = new Map<string, { sector: string | null; country: string | null; exchange: string | null }>()
+      for (const r of rows) {
+        if (!r.symbol) continue
+        bySymbol.set(String(r.symbol).toUpperCase(), {
+          sector: r.sector ?? null,
+          country: r.country ?? null,
+          exchange: r.exchange ?? null,
+        })
+      }
+
+      return {
+        bySymbol,
+        sectors: uniq(rows.map(r => r.sector)),
+        countries: uniq(rows.map(r => r.country)),
+        exchanges: uniq(rows.map(r => r.exchange)),
+        symbols: rows
+          .filter(r => r.symbol)
+          .map(r => ({ symbol: r.symbol as string, name: r.company_name ?? null })),
+      }
+    },
+  })
+}
+
+/** Everything the reader has narrowed the feed to. Empty sets mean "all". */
+export interface FeedFilter {
+  kinds: string[]
+  sectors: string[]
+  countries: string[]
+  exchanges: string[]
+  symbols: string[]
+}
+
+export const EMPTY_FILTER: FeedFilter = {
+  kinds: [], sectors: [], countries: [], exchanges: [], symbols: [],
+}
+
+export function filterCount(f: FeedFilter): number {
+  return f.kinds.length + f.sectors.length + f.countries.length +
+         f.exchanges.length + f.symbols.length
+}
+
+export function isFilterEmpty(f: FeedFilter): boolean {
+  return filterCount(f) === 0
+}

--- a/src/hooks/mobile/usePortfolioLenses.ts
+++ b/src/hooks/mobile/usePortfolioLenses.ts
@@ -1,0 +1,186 @@
+import { useQuery } from '@tanstack/react-query'
+import { supabase } from '../../lib/supabase'
+import { useOrganizationOptional } from '../../contexts/OrganizationContext'
+
+/**
+ * Two views of the book that no existing screen answers.
+ *
+ * Everything else in the product reports a portfolio one portfolio at a time,
+ * and reports what a position *is*. These ask questions instead — is the size
+ * consistent with the view, and is a name a bigger bet than any single
+ * portfolio shows — which is what makes them worth a full screen in a feed
+ * rather than a row in a table.
+ *
+ * Both are computed from holdings the org already has. Nothing here needs a
+ * new provider or a new column.
+ */
+
+export interface ConvictionGap {
+  assetId: string
+  symbol: string
+  companyName: string | null
+  /** Position size as a share of the portfolio it sits in. */
+  weightPct: number
+  /** Upside to the base price target, as a fraction of current price. */
+  upsidePct: number
+  portfolioId: string
+  portfolioName: string
+  /**
+   * `underweight` — the view is strong and the position is not.
+   * `overweight`  — the position is large and the view no longer supports it.
+   */
+  direction: 'underweight' | 'overweight'
+  /** How far apart the two are, for ranking. */
+  tension: number
+}
+
+export interface CrowdedName {
+  assetId: string
+  symbol: string
+  companyName: string | null
+  /** How many portfolios in the org hold it. */
+  portfolioCount: number
+  /** Total value across those portfolios. */
+  totalValue: number
+  /** The heaviest single weight it takes in any one of them. */
+  maxWeightPct: number
+  portfolioNames: string[]
+}
+
+interface HoldingRow {
+  portfolio_id: string
+  asset_id: string
+  shares: number | null
+  price: number | null
+  assets: { symbol: string | null; company_name: string | null } | null
+  portfolios: { name: string | null } | null
+}
+
+/**
+ * Conviction is taken from the base price target rather than a rating.
+ *
+ * A rating is a label someone picked from a list; the base target is a number
+ * they had to defend, and the gap between it and the current price is the
+ * upside actually being claimed. Using it means "conviction" here is derived
+ * from the team's own published numbers rather than from a sentiment field
+ * that may never have been revisited.
+ */
+const STRONG_UPSIDE = 0.25
+const WEAK_UPSIDE = 0.05
+/** Below this a position is too small to be worth flagging either way. */
+const MIN_WEIGHT_PCT = 0.5
+
+export function usePortfolioLenses(options?: { enabled?: boolean }) {
+  const currentOrgId = useOrganizationOptional()?.currentOrgId ?? null
+
+  return useQuery({
+    queryKey: ['portfolio-lenses', currentOrgId],
+    enabled: (options?.enabled ?? true) && !!currentOrgId,
+    staleTime: 5 * 60 * 1000,
+    queryFn: async (): Promise<{ conviction: ConvictionGap[]; crowded: CrowdedName[] }> => {
+      const { data: holdingsRaw } = await supabase
+        .from('portfolio_holdings')
+        .select('portfolio_id, asset_id, shares, price, assets(symbol, company_name), portfolios!inner(name, organization_id)')
+        .eq('portfolios.organization_id', currentOrgId!)
+        .limit(5000)
+
+      const holdings = (holdingsRaw ?? []) as unknown as HoldingRow[]
+      if (!holdings.length) return { conviction: [], crowded: [] }
+
+      const value = (h: HoldingRow) => (Number(h.shares) || 0) * (Number(h.price) || 0)
+
+      // Portfolio totals first: a weight is meaningless without its denominator.
+      const totals = new Map<string, number>()
+      for (const h of holdings) {
+        totals.set(h.portfolio_id, (totals.get(h.portfolio_id) ?? 0) + value(h))
+      }
+
+      // ── Crowding ──────────────────────────────────────────────────────────
+      const byAsset = new Map<string, { rows: HoldingRow[]; portfolios: Set<string> }>()
+      for (const h of holdings) {
+        if (!h.asset_id) continue
+        const e = byAsset.get(h.asset_id) ?? { rows: [], portfolios: new Set<string>() }
+        e.rows.push(h)
+        e.portfolios.add(h.portfolio_id)
+        byAsset.set(h.asset_id, e)
+      }
+
+      const crowded: CrowdedName[] = []
+      for (const [assetId, e] of byAsset) {
+        if (e.portfolios.size < 2) continue
+        const totalValue = e.rows.reduce((n, h) => n + value(h), 0)
+        const maxWeightPct = Math.max(
+          ...e.rows.map(h => {
+            const t = totals.get(h.portfolio_id) ?? 0
+            return t > 0 ? (value(h) / t) * 100 : 0
+          })
+        )
+        crowded.push({
+          assetId,
+          symbol: e.rows[0].assets?.symbol ?? '—',
+          companyName: e.rows[0].assets?.company_name ?? null,
+          portfolioCount: e.portfolios.size,
+          totalValue,
+          maxWeightPct,
+          portfolioNames: Array.from(
+            new Set(e.rows.map(h => h.portfolios?.name).filter(Boolean) as string[])
+          ),
+        })
+      }
+      crowded.sort((a, b) => b.portfolioCount - a.portfolioCount || b.totalValue - a.totalValue)
+
+      // ── Conviction vs weight ──────────────────────────────────────────────
+      const assetIds = Array.from(byAsset.keys())
+      const { data: targets } = await supabase
+        .from('price_targets')
+        .select('asset_id, price, type, created_at')
+        .eq('organization_id', currentOrgId!)
+        .eq('type', 'base')
+        .in('asset_id', assetIds.slice(0, 500))
+        .order('created_at', { ascending: false })
+
+      // Most recent base target per asset — an older one is a superseded view.
+      const baseTarget = new Map<string, number>()
+      for (const t of (targets ?? []) as any[]) {
+        if (!t.asset_id || baseTarget.has(t.asset_id)) continue
+        const p = Number(t.price)
+        if (Number.isFinite(p) && p > 0) baseTarget.set(t.asset_id, p)
+      }
+
+      const conviction: ConvictionGap[] = []
+      for (const h of holdings) {
+        const target = baseTarget.get(h.asset_id)
+        const price = Number(h.price) || 0
+        const total = totals.get(h.portfolio_id) ?? 0
+        if (!target || price <= 0 || total <= 0) continue
+
+        const weightPct = (value(h) / total) * 100
+        if (weightPct < MIN_WEIGHT_PCT) continue
+        const upsidePct = (target - price) / price
+
+        // The two interesting corners. A big position with big upside is
+        // simply a good position, and a small one with none is correctly
+        // ignored — neither is worth a screen.
+        const isUnder = upsidePct >= STRONG_UPSIDE && weightPct < 2
+        const isOver = upsidePct <= WEAK_UPSIDE && weightPct >= 4
+        if (!isUnder && !isOver) continue
+
+        conviction.push({
+          assetId: h.asset_id,
+          symbol: h.assets?.symbol ?? '—',
+          companyName: h.assets?.company_name ?? null,
+          weightPct,
+          upsidePct,
+          portfolioId: h.portfolio_id,
+          portfolioName: h.portfolios?.name ?? 'Portfolio',
+          direction: isUnder ? 'underweight' : 'overweight',
+          // Underweights rank on upside forgone, overweights on size at risk.
+          tension: isUnder ? upsidePct * 100 : weightPct,
+        })
+      }
+      conviction.sort((a, b) => b.tension - a.tension)
+
+      return { conviction: conviction.slice(0, 12), crowded: crowded.slice(0, 12) }
+    },
+  })
+}

--- a/src/hooks/mobile/usePortfolioLenses.ts
+++ b/src/hooks/mobile/usePortfolioLenses.ts
@@ -3,16 +3,16 @@ import { supabase } from '../../lib/supabase'
 import { useOrganizationOptional } from '../../contexts/OrganizationContext'
 
 /**
- * Two views of the book that no existing screen answers.
+ * Four questions about the book that no existing screen asks.
  *
  * Everything else in the product reports a portfolio one portfolio at a time,
- * and reports what a position *is*. These ask questions instead — is the size
- * consistent with the view, and is a name a bigger bet than any single
- * portfolio shows — which is what makes them worth a full screen in a feed
- * rather than a row in a table.
+ * and reports what a position *is*. These ask something instead — is the size
+ * consistent with the view, is a name a bigger bet than any single portfolio
+ * shows, has the thesis already played out, has the view expired — which is
+ * what earns a full screen in a feed rather than a row in a table.
  *
- * Both are computed from holdings the org already has. Nothing here needs a
- * new provider or a new column.
+ * All four are computed from data the org already has. Nothing needs a new
+ * provider or a new column.
  */
 
 export interface ConvictionGap {
@@ -21,8 +21,17 @@ export interface ConvictionGap {
   companyName: string | null
   /** Position size as a share of the portfolio it sits in. */
   weightPct: number
-  /** Upside to the base price target, as a fraction of current price. */
+  /** Upside to the price target, as a fraction of current price. */
   upsidePct: number
+  /**
+   * Stated conviction, where one exists.
+   *
+   * Conviction and upside are different claims and the tile needs both. A
+   * high-conviction name with no upside left is a different problem from a
+   * low-conviction name trading far below target, and reading either number
+   * alone gets both wrong.
+   */
+  conviction: string | null
   portfolioId: string
   portfolioName: string
   /**
@@ -32,6 +41,33 @@ export interface ConvictionGap {
   direction: 'underweight' | 'overweight'
   /** How far apart the two are, for ranking. */
   tension: number
+}
+
+/** A target the price has already reached or passed. */
+export interface TargetBreach {
+  assetId: string
+  symbol: string
+  companyName: string | null
+  price: number
+  target: number
+  /** How far past the target the price is, as a fraction. */
+  overshootPct: number
+  conviction: string | null
+  heldIn: string[]
+}
+
+/** A target whose own stated horizon has run out. */
+export interface StaleTarget {
+  assetId: string
+  symbol: string
+  companyName: string | null
+  target: number
+  price: number
+  timeframe: string | null
+  ageMonths: number
+  /** Months past the end of its horizon. */
+  overdueMonths: number
+  heldIn: string[]
 }
 
 export interface CrowdedName {
@@ -47,6 +83,13 @@ export interface CrowdedName {
   portfolioNames: string[]
 }
 
+export interface PortfolioLenses {
+  conviction: ConvictionGap[]
+  crowded: CrowdedName[]
+  breaches: TargetBreach[]
+  stale: StaleTarget[]
+}
+
 interface HoldingRow {
   portfolio_id: string
   asset_id: string
@@ -56,28 +99,51 @@ interface HoldingRow {
   portfolios: { name: string | null } | null
 }
 
+interface TargetInfo {
+  price: number
+  timeframe: string | null
+  rolling: boolean
+  createdAt: string
+}
+
 /**
- * Conviction is taken from the base price target rather than a rating.
+ * Conviction is a mosaic, not one number.
  *
- * A rating is a label someone picked from a list; the base target is a number
- * they had to defend, and the gap between it and the current price is the
- * upside actually being claimed. Using it means "conviction" here is derived
- * from the team's own published numbers rather than from a sentiment field
- * that may never have been revisited.
+ * `analyst_ratings.conviction` is what the analyst says; the gap to the price
+ * target is what their own numbers imply. They disagree often, and the
+ * disagreement is the signal — high conviction with no upside left means
+ * either the target needs raising or the position needs trimming, and neither
+ * field says that on its own.
  */
+const CONVICTION_RANK: Record<string, number> = { high: 3, medium: 2, low: 1 }
+
 const STRONG_UPSIDE = 0.25
 const WEAK_UPSIDE = 0.05
 /** Below this a position is too small to be worth flagging either way. */
 const MIN_WEIGHT_PCT = 0.5
+/** A target this far past its own horizon has stopped being a view. */
+const OVERDUE_MONTHS = 2
+
+/** Parse "12M", "18M", "3Y" into months. */
+function timeframeMonths(tf: string | null | undefined): number | null {
+  if (!tf) return null
+  const m = /^(\d+)\s*([MY])$/i.exec(tf.trim())
+  if (!m) return null
+  const n = Number(m[1])
+  if (!Number.isFinite(n) || n <= 0) return null
+  return m[2].toUpperCase() === 'Y' ? n * 12 : n
+}
 
 export function usePortfolioLenses(options?: { enabled?: boolean }) {
   const currentOrgId = useOrganizationOptional()?.currentOrgId ?? null
 
-  return useQuery({
+  return useQuery<PortfolioLenses>({
     queryKey: ['portfolio-lenses', currentOrgId],
     enabled: (options?.enabled ?? true) && !!currentOrgId,
     staleTime: 5 * 60 * 1000,
-    queryFn: async (): Promise<{ conviction: ConvictionGap[]; crowded: CrowdedName[] }> => {
+    queryFn: async () => {
+      const empty: PortfolioLenses = { conviction: [], crowded: [], breaches: [], stale: [] }
+
       const { data: holdingsRaw } = await supabase
         .from('portfolio_holdings')
         .select('portfolio_id, asset_id, shares, price, assets(symbol, company_name), portfolios!inner(name, organization_id)')
@@ -85,7 +151,7 @@ export function usePortfolioLenses(options?: { enabled?: boolean }) {
         .limit(5000)
 
       const holdings = (holdingsRaw ?? []) as unknown as HoldingRow[]
-      if (!holdings.length) return { conviction: [], crowded: [] }
+      if (!holdings.length) return empty
 
       const value = (h: HoldingRow) => (Number(h.shares) || 0) * (Number(h.price) || 0)
 
@@ -95,7 +161,6 @@ export function usePortfolioLenses(options?: { enabled?: boolean }) {
         totals.set(h.portfolio_id, (totals.get(h.portfolio_id) ?? 0) + value(h))
       }
 
-      // ── Crowding ──────────────────────────────────────────────────────────
       const byAsset = new Map<string, { rows: HoldingRow[]; portfolios: Set<string> }>()
       for (const h of holdings) {
         if (!h.asset_id) continue
@@ -105,82 +170,169 @@ export function usePortfolioLenses(options?: { enabled?: boolean }) {
         byAsset.set(h.asset_id, e)
       }
 
+      const heldIn = (assetId: string) =>
+        Array.from(new Set(
+          (byAsset.get(assetId)?.rows ?? [])
+            .map(h => h.portfolios?.name)
+            .filter(Boolean) as string[]
+        ))
+
+      // ── Crowding ──────────────────────────────────────────────────────────
       const crowded: CrowdedName[] = []
       for (const [assetId, e] of byAsset) {
         if (e.portfolios.size < 2) continue
-        const totalValue = e.rows.reduce((n, h) => n + value(h), 0)
-        const maxWeightPct = Math.max(
-          ...e.rows.map(h => {
-            const t = totals.get(h.portfolio_id) ?? 0
-            return t > 0 ? (value(h) / t) * 100 : 0
-          })
-        )
         crowded.push({
           assetId,
-          symbol: e.rows[0].assets?.symbol ?? '—',
+          symbol: e.rows[0].assets?.symbol ?? '?',
           companyName: e.rows[0].assets?.company_name ?? null,
           portfolioCount: e.portfolios.size,
-          totalValue,
-          maxWeightPct,
-          portfolioNames: Array.from(
-            new Set(e.rows.map(h => h.portfolios?.name).filter(Boolean) as string[])
-          ),
+          totalValue: e.rows.reduce((n, h) => n + value(h), 0),
+          maxWeightPct: Math.max(...e.rows.map(h => {
+            const t = totals.get(h.portfolio_id) ?? 0
+            return t > 0 ? (value(h) / t) * 100 : 0
+          })),
+          portfolioNames: heldIn(assetId),
         })
       }
       crowded.sort((a, b) => b.portfolioCount - a.portfolioCount || b.totalValue - a.totalValue)
 
-      // ── Conviction vs weight ──────────────────────────────────────────────
-      const assetIds = Array.from(byAsset.keys())
-      const { data: targets } = await supabase
-        .from('price_targets')
-        .select('asset_id, price, type, created_at')
-        .eq('organization_id', currentOrgId!)
-        .eq('type', 'base')
-        .in('asset_id', assetIds.slice(0, 500))
-        .order('created_at', { ascending: false })
+      // ── Targets and conviction ────────────────────────────────────────────
+      // analyst_price_targets rather than price_targets: it is the table the
+      // product actually writes to, and it carries the horizon — which is what
+      // makes "this view has expired" answerable at all.
+      const assetIds = Array.from(byAsset.keys()).slice(0, 500)
+      const [{ data: targets }, { data: ratings }] = await Promise.all([
+        supabase
+          .from('analyst_price_targets')
+          .select('asset_id, price, timeframe, is_rolling, is_official, created_at')
+          .eq('organization_id', currentOrgId!)
+          .in('asset_id', assetIds)
+          .order('is_official', { ascending: false })
+          .order('created_at', { ascending: false }),
+        supabase
+          .from('analyst_ratings')
+          .select('asset_id, conviction, created_at')
+          .in('asset_id', assetIds)
+          .order('created_at', { ascending: false }),
+      ])
 
-      // Most recent base target per asset — an older one is a superseded view.
-      const baseTarget = new Map<string, number>()
+      // Official first, then most recent. An older or unofficial target is a
+      // superseded view, not a second opinion.
+      const target = new Map<string, TargetInfo>()
       for (const t of (targets ?? []) as any[]) {
-        if (!t.asset_id || baseTarget.has(t.asset_id)) continue
+        if (!t.asset_id || target.has(t.asset_id)) continue
         const p = Number(t.price)
-        if (Number.isFinite(p) && p > 0) baseTarget.set(t.asset_id, p)
+        if (!Number.isFinite(p) || p <= 0) continue
+        target.set(t.asset_id, {
+          price: p,
+          timeframe: t.timeframe ?? null,
+          rolling: !!t.is_rolling,
+          createdAt: t.created_at,
+        })
       }
 
+      const convictionOf = new Map<string, string>()
+      for (const r of (ratings ?? []) as any[]) {
+        if (!r.asset_id || convictionOf.has(r.asset_id) || !r.conviction) continue
+        convictionOf.set(r.asset_id, String(r.conviction).toLowerCase())
+      }
+
+      // ── Target reached, and target expired ────────────────────────────────
+      const breaches: TargetBreach[] = []
+      const stale: StaleTarget[] = []
+      const now = Date.now()
+
+      for (const [assetId, e] of byAsset) {
+        const t = target.get(assetId)
+        if (!t) continue
+        const price = Number(e.rows[0].price) || 0
+        if (price <= 0) continue
+        const symbol = e.rows[0].assets?.symbol ?? '?'
+        const companyName = e.rows[0].assets?.company_name ?? null
+
+        // The thesis played out and nothing in the product says so. Either the
+        // target is raised or the position is a hold with no stated upside —
+        // both are decisions, and neither happens if nobody is told.
+        if (price >= t.price) {
+          breaches.push({
+            assetId, symbol, companyName,
+            price, target: t.price,
+            overshootPct: (price - t.price) / t.price,
+            conviction: convictionOf.get(assetId) ?? null,
+            heldIn: heldIn(assetId),
+          })
+        }
+
+        // A rolling target re-bases continuously and by definition never
+        // expires, so flagging it as overdue would be wrong.
+        const months = timeframeMonths(t.timeframe)
+        if (!t.rolling && months) {
+          const ageMonths = (now - new Date(t.createdAt).getTime()) / (30.44 * 86400_000)
+          const overdue = ageMonths - months
+          if (Number.isFinite(overdue) && overdue >= OVERDUE_MONTHS) {
+            stale.push({
+              assetId, symbol, companyName,
+              target: t.price, price,
+              timeframe: t.timeframe,
+              ageMonths: Math.round(ageMonths),
+              overdueMonths: Math.round(overdue),
+              heldIn: heldIn(assetId),
+            })
+          }
+        }
+      }
+      breaches.sort((a, b) => b.overshootPct - a.overshootPct)
+      stale.sort((a, b) => b.overdueMonths - a.overdueMonths)
+
+      // ── Conviction against size ───────────────────────────────────────────
       const conviction: ConvictionGap[] = []
       for (const h of holdings) {
-        const target = baseTarget.get(h.asset_id)
+        const t = target.get(h.asset_id)
         const price = Number(h.price) || 0
         const total = totals.get(h.portfolio_id) ?? 0
-        if (!target || price <= 0 || total <= 0) continue
+        if (price <= 0 || total <= 0) continue
 
         const weightPct = (value(h) / total) * 100
         if (weightPct < MIN_WEIGHT_PCT) continue
-        const upsidePct = (target - price) / price
 
-        // The two interesting corners. A big position with big upside is
-        // simply a good position, and a small one with none is correctly
-        // ignored — neither is worth a screen.
-        const isUnder = upsidePct >= STRONG_UPSIDE && weightPct < 2
-        const isOver = upsidePct <= WEAK_UPSIDE && weightPct >= 4
+        const stated = convictionOf.get(h.asset_id) ?? null
+        const rank = stated ? (CONVICTION_RANK[stated] ?? 0) : 0
+        const upsidePct = t ? (t.price - price) / price : 0
+        // Needs at least one of the two signals to say anything at all.
+        if (!t && !rank) continue
+
+        // The mosaic: either a strong stated conviction or a large implied
+        // upside makes the underweight case. A "high" rating on a 0.4%
+        // position is as much a mismatch as a 30% upside on one, and neither
+        // field alone would catch both.
+        const isUnder = (upsidePct >= STRONG_UPSIDE || rank >= 3) && weightPct < 2
+        // Overweight needs both to be weak — a big position with a stale
+        // target but genuine high conviction is not obviously wrong.
+        const isOver = !!t && upsidePct <= WEAK_UPSIDE && rank <= 2 && weightPct >= 4
         if (!isUnder && !isOver) continue
 
         conviction.push({
           assetId: h.asset_id,
-          symbol: h.assets?.symbol ?? '—',
+          symbol: h.assets?.symbol ?? '?',
           companyName: h.assets?.company_name ?? null,
           weightPct,
           upsidePct,
+          conviction: stated,
           portfolioId: h.portfolio_id,
           portfolioName: h.portfolios?.name ?? 'Portfolio',
           direction: isUnder ? 'underweight' : 'overweight',
           // Underweights rank on upside forgone, overweights on size at risk.
-          tension: isUnder ? upsidePct * 100 : weightPct,
+          tension: isUnder ? Math.max(upsidePct * 100, rank * 20) : weightPct,
         })
       }
       conviction.sort((a, b) => b.tension - a.tension)
 
-      return { conviction: conviction.slice(0, 12), crowded: crowded.slice(0, 12) }
+      return {
+        conviction: conviction.slice(0, 12),
+        crowded: crowded.slice(0, 12),
+        breaches: breaches.slice(0, 12),
+        stale: stale.slice(0, 12),
+      }
     },
   })
 }

--- a/src/hooks/useExploreSearch.ts
+++ b/src/hooks/useExploreSearch.ts
@@ -44,6 +44,13 @@ export interface ExploreResult {
   symbol?: string
   updatedAt?: string | null
   score: number
+  /**
+   * True when this came from the relaxed pass — it matched some of the query,
+   * not all of it. Surfaced separately so "related" never masquerades as an
+   * answer, which is the difference between a useful suggestion and a wrong
+   * result.
+   */
+  related?: boolean
   data: any
 }
 
@@ -109,6 +116,26 @@ function withTokens<T>(query: T, fields: string[], tokens: string[]): T {
   return q as T
 }
 
+/**
+ * One OR-group spanning every field *and* every token — "any word, anywhere".
+ *
+ * The counterpart to withTokens, used only when the strict pass came back
+ * near-empty. Searching "margin pressure" found nothing because no single
+ * document contained both words, which is a correct answer to the question
+ * asked and a useless one to the person asking: they want the margin
+ * discussion and the pressure discussion, and to judge the connection
+ * themselves.
+ */
+function withAnyToken<T>(query: T, fields: string[], tokens: string[]): T {
+  const clauses: string[] = []
+  for (const t of tokens) {
+    const esc = t.replace(/[%,()\\]/g, '')
+    if (!esc) continue
+    for (const f of fields) clauses.push(`${f}.ilike.%${esc}%`)
+  }
+  return (clauses.length ? (query as any).or(clauses.join(',')) : query) as T
+}
+
 /** Escape PostgREST `or` filter metacharacters so a query cannot break out. */
 function safe(term: string): string {
   return term.replace(/[%,()\\]/g, ' ').trim()
@@ -152,33 +179,38 @@ export function useExploreSearch(query: string, options?: { enabled?: boolean })
       // A one-word query is its own token, so phrase and token matching agree.
       const phrase = term
 
-      const [assets, themes, lists, portfolioNotes, ideas, assetNotes, thoughts] = await Promise.all([
-        withTokens(
+      /**
+       * Both passes hit the same sources; only the token combinator differs.
+       * `apply` is withTokens for the strict pass ("every word") and
+       * withAnyToken for the relaxed one ("any word").
+       */
+      const runPass = (apply: typeof withTokens) => Promise.all([
+        apply(
           supabase.from('assets')
             .select('id, symbol, company_name, sector, thesis, where_different, risks_to_thesis, updated_at'),
           ['symbol', 'company_name', 'sector', 'thesis', 'where_different', 'risks_to_thesis'],
           tokens,
         ).limit(25),
-        withTokens(
+        apply(
           supabase.from('themes').select('id, name, description, updated_at'),
           ['name', 'description'],
           tokens,
         ).limit(15),
-        withTokens(
+        apply(
           supabase.from('asset_lists')
             .select('id, name, description, brief, updated_at')
             .eq('organization_id', currentOrgId!),
           ['name', 'description', 'brief'],
           tokens,
         ).limit(15),
-        withTokens(
+        apply(
           supabase.from('portfolio_notes')
             .select('id, title, content, content_preview, updated_at, portfolio_id')
             .neq('is_deleted', true),
           ['title', 'content'],
           tokens,
         ).limit(15),
-        withTokens(
+        apply(
           supabase.from('trade_queue_items')
             .select('id, rationale, thesis_text, updated_at, asset_id, assets(id, symbol, company_name)')
             .eq('organization_id', currentOrgId!),
@@ -189,7 +221,7 @@ export function useExploreSearch(query: string, options?: { enabled?: boolean })
         // asset_notes was missing entirely, which is the single biggest gap in
         // this search: it is where the actual research is written. Everything
         // else here is a name, a rationale or a portfolio-level note.
-        withTokens(
+        apply(
           supabase.from('asset_notes')
             .select('id, title, content, content_preview, updated_at, asset_id, assets(symbol, company_name)')
             .eq('organization_id', currentOrgId!)
@@ -200,7 +232,7 @@ export function useExploreSearch(query: string, options?: { enabled?: boolean })
 
         // Captured thoughts are half-formed by definition, which is exactly
         // what someone asking "what should I look at next" wants to find.
-        withTokens(
+        apply(
           supabase.from('quick_thoughts')
             .select('id, content, source_title, tags, updated_at, asset_id, assets(symbol, company_name)')
             .eq('organization_id', currentOrgId!)
@@ -209,6 +241,33 @@ export function useExploreSearch(query: string, options?: { enabled?: boolean })
           tokens,
         ).limit(15),
       ])
+
+      let [assets, themes, lists, portfolioNotes, ideas, assetNotes, thoughts] =
+        await runPass(withTokens)
+
+      /**
+       * Nothing matched every word — so ask for any word instead.
+       *
+       * "margin pressure" is the example the search box itself suggests, and
+       * it returned nothing because no single document contained both. That is
+       * a correct answer to the question asked and a useless one to the person
+       * asking: they want the margin discussion and the pressure discussion,
+       * and to judge the connection themselves. Only runs when the strict pass
+       * is thin, so the common case is still one round trip, and results are
+       * marked `related` so a partial match never poses as a full one.
+       */
+      let relaxed = false
+      if (tokens.length > 1) {
+        const strictCount =
+          (assets.data?.length ?? 0) + (themes.data?.length ?? 0) + (lists.data?.length ?? 0) +
+          (portfolioNotes.data?.length ?? 0) + (ideas.data?.length ?? 0) +
+          (assetNotes.data?.length ?? 0) + (thoughts.data?.length ?? 0)
+        if (strictCount < 3) {
+          relaxed = true
+          ;[assets, themes, lists, portfolioNotes, ideas, assetNotes, thoughts] =
+            await runPass(withAnyToken)
+        }
+      }
 
       for (const a of ((assets.data as any[]) ?? [])) {
         const symbolHit = (a.symbol ?? '').toLowerCase() === term.toLowerCase()
@@ -319,6 +378,10 @@ export function useExploreSearch(query: string, options?: { enabled?: boolean })
           data: t,
         })
       }
+
+      // A relaxed hit is a suggestion, not an answer, and is scored and
+      // labelled as one so it can never outrank a genuine match.
+      if (relaxed) for (const r of out) { r.related = true; r.score *= 0.5 }
 
       // Highest first. Ties on score fall back to recency so the ordering is
       // stable between renders rather than depending on which promise settled

--- a/supabase/functions/market-news/index.ts
+++ b/supabase/functions/market-news/index.ts
@@ -364,6 +364,118 @@ function merge(lists: NewsItem[][]): NewsItem[] {
   return [...byKey.values()]
 }
 
+/**
+ * Re-attribute a story from its own text rather than from which query found it.
+ *
+ * Every provider here is asked "news for SYMBOL", so a story comes back tagged
+ * with whatever was queried. That answers *why we found it*, not *what it is
+ * about* — "Tiger Global cuts stake in big tech, buys into SpaceX" arrives
+ * tagged MSFT because Microsoft is one of the big-tech holdings, and the tile
+ * then draws a Microsoft chart on a story about Tiger Global.
+ *
+ * So: read the headline and summary, and only claim a ticker the story
+ * actually mentions. A story that names none of them is left unattributed —
+ * a macro or fund story with no chart is honest, and better than a confident
+ * chart of a company that appears nowhere in the text.
+ */
+
+interface AssetName {
+  symbol: string
+  name?: string | null
+}
+
+/** `(NASDAQ: AAPL)`, `(NYSE:BRK.B)`, `$AAPL`, `NASDAQ:AAPL`. */
+const EXPLICIT_TICKER =
+  /(?:\((?:NASDAQ|NYSE|AMEX|OTC|TSX|LSE)\s*:\s*([A-Z][A-Z0-9.\-]{0,9})\)|(?:NASDAQ|NYSE|AMEX|OTC)\s*:\s*([A-Z][A-Z0-9.\-]{0,9})|\$([A-Z]{1,5})\b)/g
+
+/**
+ * Company words that identify nobody.
+ *
+ * Matching a bare "Corp" or "Inc" against a headline would attribute every
+ * story to whichever company happened to be first in the list.
+ */
+const NAME_NOISE = new Set([
+  'inc', 'inc.', 'corp', 'corp.', 'corporation', 'co', 'co.', 'company',
+  'ltd', 'ltd.', 'limited', 'plc', 'holdings', 'group', 'the', 'and',
+  'technologies', 'technology', 'systems', 'international', 'industries',
+])
+
+/** The distinguishing part of a company name — "Apple" from "Apple Inc.". */
+function nameStem(name: string): string | null {
+  const first = name
+    .replace(/[.,]/g, ' ')
+    .split(/\s+/)
+    .map(w => w.trim())
+    .filter(w => w && !NAME_NOISE.has(w.toLowerCase()))[0]
+  if (!first || first.length < 3) return null
+  return first
+}
+
+function mentions(haystack: string, needle: string): boolean {
+  // Word-boundary match so "Reddit" does not hit inside "Reddit-like" noise
+  // and, more importantly, so a two-letter ticker does not match inside an
+  // ordinary word.
+  const escaped = needle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  return new RegExp(`(?:^|[^A-Za-z0-9])${escaped}(?:$|[^A-Za-z0-9])`, 'i').test(haystack)
+}
+
+interface Attribution {
+  /** Tickers the story actually mentions, most confident first. */
+  symbols: string[]
+  /** The one it is most about, or undefined when the text names nobody. */
+  primarySymbol?: string
+}
+
+/**
+ * @param text     headline + summary
+ * @param queried  the symbols this story came back under
+ * @param universe symbol → company name, for name matching
+ */
+function attributeFromText(
+  text: string,
+  queried: string[],
+  universe: AssetName[],
+): Attribution {
+  const hay = text || ''
+  const scored = new Map<string, number>()
+  const bump = (sym: string, by: number) => {
+    if (!sym) return
+    scored.set(sym.toUpperCase(), Math.max(scored.get(sym.toUpperCase()) ?? 0, by))
+  }
+
+  // 1. Explicit exchange-qualified tickers are unambiguous — the publisher
+  //    is telling us who the story is about.
+  for (const m of hay.matchAll(EXPLICIT_TICKER)) {
+    bump(m[1] ?? m[2] ?? m[3] ?? '', 100)
+  }
+
+  // 2. A company from the universe named in the text.
+  for (const a of universe) {
+    if (!a.symbol) continue
+    const stem = a.name ? nameStem(a.name) : null
+    if (stem && mentions(hay, stem)) bump(a.symbol, 80)
+    // A bare ticker in prose is weaker evidence than a company name: plenty of
+    // three-letter tickers are also ordinary words.
+    else if (a.symbol.length >= 3 && mentions(hay, a.symbol)) bump(a.symbol, 60)
+  }
+
+  const ranked = [...scored.entries()]
+    .sort((x, y) => y[1] - x[1])
+    .map(([sym]) => sym)
+
+  if (ranked.length) {
+    // Queried symbols the text also mentions stay, in rank order; ones it does
+    // not mention are dropped rather than trailing along as chips.
+    return { symbols: ranked.slice(0, 6), primarySymbol: ranked[0] }
+  }
+
+  // Nothing named. Keep the queried symbols as provenance so the story is
+  // still reachable, but claim no subject — the tile shows no chart rather
+  // than the wrong one.
+  return { symbols: queried.slice(0, 6), primarySymbol: undefined }
+}
+
+
 serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: corsHeaders })
   if (req.method !== 'POST') {
@@ -434,8 +546,40 @@ serve(async (req) => {
     'yahoo-rss': true,
   }
 
+  /**
+   * Company names for the queried symbols, so attribution can match "SpaceX"
+   * or "Microsoft" in a headline and not only a bare ticker. One query; the
+   * function already holds an admin client for the cache.
+   */
+  let universe: { symbol: string; name?: string | null }[] = symbols.map(s => ({ symbol: s }))
+  try {
+    const { data } = await admin
+      .from('assets')
+      .select('symbol, company_name')
+      .in('symbol', symbols)
+    if (Array.isArray(data) && data.length) {
+      universe = (data as any[]).map(a => ({ symbol: a.symbol, name: a.company_name }))
+    }
+  } catch { /* fall back to ticker-only matching */ }
+
   const items = merge(lists)
     .filter(i => new Date(i.publishedAt).getTime() >= from.getTime())
+    // Re-attribute from the story's own words. Every source here is asked
+    // "news for SYMBOL", so what comes back is tagged with whatever was
+    // queried — which answers why we found it, not what it is about. "Tiger
+    // Global cuts stake in big tech, buys into SpaceX" arrived tagged MSFT
+    // because Microsoft is one of the holdings, and the tile drew a Microsoft
+    // chart on a story about a fund. A story naming nobody now carries no
+    // subject at all, so the tile shows no chart rather than a confident wrong
+    // one.
+    .map(i => {
+      const attribution = attributeFromText(
+        `${i.headline} ${i.summary ?? ''}`,
+        i.symbols,
+        universe,
+      )
+      return { ...i, symbols: attribution.symbols, primarySymbol: attribution.primarySymbol }
+    })
     .sort((a, b) => {
       // Relevance first where a provider supplied it, recency otherwise. A
       // highly-relevant story from this morning should outrank a passing


### PR DESCRIPTION
Feed work from the review pass, plus two new sources.

## News attributed from the story, not from the query

The previous fix was not enough, and the reason is structural: every provider is asked *"news for SYMBOL"*, so what comes back is tagged with whatever was queried. That answers **why we found it**, not **what it is about**. "Tiger Global Management cuts stakes in Big Tech, buys into SpaceX" arrived tagged MSFT because Microsoft is one of the holdings, and the tile drew a Microsoft chart on a story about a fund. Same cause put GOOGL across much of the feed.

`market-news` now re-reads the headline and summary and only claims a ticker the story actually names — exchange-qualified tickers first, then company names matched against the org's own asset universe. A story naming nobody carries no subject at all, and the tile then shows no chart and no chips rather than a confident wrong one.

Verified live: **5 of 14 attributed, 9 correctly blank**, Tiger Global among them.

## Layout

- **Image** above the headline, full-bleed, 104px. Below the title it split the story so the summary read as a caption
- **Chart switcher** on the chart's own header, not floating pills underneath — those read as page dots, not a control
- **Bottom buttons** — `pb-safe` resolves to *zero* on a phone with no home indicator, so Capture and Read story sat flush on the edge
- **Filter banner** — same bug at the top
- **Active Risk title** truncated because template tiles put their headline in the single-line header band; it is content, not chrome, so it moved to the title band where it wraps

## Search falls back to any word

"margin pressure" returned nothing — and it is the example the search box itself suggests. Cause was my own AND-across-words change. The strict pass runs first; when it comes back thin the same sources are re-queried with any-word semantics, halved in score and marked `related` so a partial match cannot pose as a full one.

## Four portfolio lenses

Questions about the book that no screen asks, delivered unprompted because nobody goes looking for "is this position the right size":

| Lens | Populates today |
|---|---|
| Crowding — one name across several books | **48 names** |
| Target reached — held with no stated upside left | **5 holdings** |
| Conviction vs size — mosaic of rating *and* implied upside | a few |
| Target expired — a view past its own horizon | 0, switches on by itself |

Conviction is both claims: `analyst_ratings.conviction` is what the analyst says, the gap to target is what their numbers imply, and the disagreement is the signal. Source switched to `analyst_price_targets` — the table the product actually writes to (30 rows vs 4) and the only one carrying a horizon.

## Curate the feed

Multi-select across content type, sector, country, exchange and ticker; intersected across facets. Values read from the org's own assets so the picker never offers something that returns nothing — all populated: 14 sectors, 18 countries, 4 exchanges.

Index membership is deliberately absent: nothing models index constituents, and inferring it from exchange would mislead.

## Verification

Typecheck clean on every touched file. Tests 1047 pass. Build verified. `market-news` deployed.

**Not verified in a browser** — four layout bugs this cycle were caught by looking, not by reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
