### PR TITLE
feat(signals): active risk, recommendation and news builders

### DIFF
--- a/docs/tickets/netlify-branch-deploy-gate-unproven.md
+++ b/docs/tickets/netlify-branch-deploy-gate-unproven.md
@@ -1,0 +1,65 @@
+# Deploy gate is proven locally, unproven on Netlify
+
+**Status:** parked
+**Opened:** 2026-08-15
+**Priority:** medium — the gate is believed to work; what is missing is the remote proof
+
+## Claim under test
+
+`netlify.toml` now sets:
+
+```toml
+command = "npm run guard && npm run build"
+```
+
+If `npm run guard` fails, the build must fail and no `dist/` must be published.
+Before this line existed there was **no build command at all**, which is why
+main's CI could be red across three merges and every one of them still shipped.
+
+## What is proven
+
+**Locally: definitive.** With `MAX_KNOWN_UNSCOPED` raised to 110 on branch
+`ci/prove-deploy-gate`, the exact Netlify command exits non-zero and produces
+no output directory:
+
+```
+$ npm run guard && npm run build
+  ... ratchet assertion fails ...
+exit: 1
+$ ls dist
+  ABSENT
+```
+
+That is the shell semantics of `&&` and it cannot behave differently on
+Netlify's runner.
+
+## What is not proven
+
+**Remotely: inconclusive.** Both the deliberately-red and the restored-green
+commits on `ci/prove-deploy-gate` returned **HTTP 404** for the branch deploy
+URL, and Netlify reported **0 checks** against either SHA. A 404 on both the
+red and the green state proves nothing about the gate — it means Netlify is
+not building this branch at all.
+
+Branch deploys were switched on mid-investigation, so the most likely cause is
+simply that the branch-deploy scope does not include this branch (Netlify
+defaults to "none" or to a named allowlist). It has not been confirmed.
+
+## To close
+
+1. Netlify → Site configuration → Build & deploy → Branches: confirm branch
+   deploys include `ci/prove-deploy-gate` (or "all branches").
+2. Push the red commit. Expect: deploy **failed**, no branch URL.
+3. Push the green commit. Expect: deploy **succeeded**, branch URL serves.
+4. Record both deploy IDs here. A green-only result does not close this — the
+   red one is the whole test.
+
+## Why it is parked rather than dropped
+
+The local proof is strong enough that the gate is not treated as unknown, and
+the branch is preserved. But "the build command is set" and "a failing test
+stops a deploy" are different claims, and only the first has an artifact
+against the real runner. Until step 2 above produces a *failed* Netlify
+deploy, the deploy gate is believed, not verified.
+
+Branch: `ci/prove-deploy-gate` (pushed, do not delete)

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "analyze": "vite build --mode analyze",
     "lint": "eslint .",
     "preview": "vite preview",
-    "guard": "vitest run --project unit src/lib/org-scope src/lib/signals",
+    "guard": "vitest run --project unit src/lib/org-scope src/lib/signals src/components/signals",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage",

--- a/src/components/signals/__tests__/SignalCardView.render.test.tsx
+++ b/src/components/signals/__tests__/SignalCardView.render.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { SignalCardView } from '../SignalCardView'
+import { buildActiveRiskCard } from '../../../lib/signals/builders/activeRisk'
+import { buildRecommendationCard } from '../../../lib/signals/builders/recommendation'
+import { buildNewsCard } from '../../../lib/signals/builders/news'
+import type { CardResult, SignalCard } from '../../../lib/signals/contract'
+
+/**
+ * The point of these tests is not that the component renders — it is that
+ * three unrelated card types render through *one* component with no per-type
+ * branch anywhere.
+ *
+ * The old surface had seven bespoke card components, which produced three
+ * header patterns, four action bars and two cards that were dead ends. The
+ * only durable defence against that is a test that fails the moment a type
+ * needs special handling to look right.
+ */
+
+const unwrap = (r: CardResult): SignalCard => {
+  if (!r.ok) throw new Error(`suppressed: ${r.reason}`)
+  return r.card
+}
+
+const RISK = unwrap(buildActiveRiskCard({
+  assetId: 'a1', symbol: 'MSFT', companyName: 'Microsoft',
+  weightPct: 6.2, benchmarkWeightPct: 3.1,
+  portfolioId: 'p1', portfolioName: 'Core Equity',
+  asOf: '2026-07-31T00:00:00.000Z',
+}))
+
+const REC = unwrap(buildRecommendationCard({
+  id: 'r1', assetId: 'a2', symbol: 'DASH', action: 'trim',
+  proposedWeightPct: 1.5, currentWeightPct: 4.0,
+  currentWeightAsOf: '2026-07-31T00:00:00.000Z',
+  rationale: 'Multiple has re-rated past our bull case and the margin story is now consensus.',
+  recommendedBy: 'Priya Raman',
+  portfolioId: 'p1', portfolioName: 'Core Equity',
+  createdAt: new Date(Date.now() - 86_400_000).toISOString(),
+}))
+
+const NEWS = unwrap(buildNewsCard({
+  id: 'n1',
+  headline: 'Microsoft raises quarterly dividend and expands buyback authorisation',
+  summary: 'The company lifted its payout by 10% and added $60bn to its repurchase programme.',
+  url: 'https://example.com/story', source: 'Reuters',
+  publishedAt: new Date(Date.now() - 3_600_000).toISOString(),
+  primarySymbol: 'MSFT',
+  asset: { id: 'a1', symbol: 'MSFT', companyName: 'Microsoft' },
+  heldIn: ['Core Equity', 'Growth'], maxWeightPct: 6.2,
+}))
+
+const ALL: [string, SignalCard][] = [
+  ['active_risk', RISK],
+  ['recommendation', REC],
+  ['news', NEWS],
+]
+
+const noop = () => {}
+
+describe('SignalCardView renders every builder output', () => {
+  it.each(ALL)('%s', (_name, card) => {
+    render(<SignalCardView card={card} onAction={noop} onOpen={noop} onWhy={noop} />)
+    expect(screen.getByText(card.headline)).toBeTruthy()
+    expect(screen.getByText(card.actions.primary.label)).toBeTruthy()
+    expect(screen.getByText(card.actions.open.label)).toBeTruthy()
+  })
+
+  it('shows the surface, not the type, in the eyebrow', () => {
+    // "Risk", "Research", "Market" — four surfaces. Not seventeen type labels,
+    // and never the shouting ACTIVE RISK badge the old card led with.
+    const { rerender } = render(<SignalCardView card={RISK} onAction={noop} onOpen={noop} onWhy={noop} />)
+    expect(screen.getByText('Risk')).toBeTruthy()
+    rerender(<SignalCardView card={REC} onAction={noop} onOpen={noop} onWhy={noop} />)
+    expect(screen.getByText('Research')).toBeTruthy()
+    rerender(<SignalCardView card={NEWS} onAction={noop} onOpen={noop} onWhy={noop} />)
+    expect(screen.getByText('Market')).toBeTruthy()
+  })
+
+  it('flags a number that came from the book rather than a live quote', () => {
+    render(<SignalCardView card={RISK} onAction={noop} onOpen={noop} onWhy={noop} />)
+    // The active weight is 15 days old. The eyebrow says so.
+    expect(screen.getByText(/^book /)).toBeTruthy()
+  })
+
+  it('does not flag a live quote as book data', () => {
+    render(<SignalCardView card={NEWS} onAction={noop} onOpen={noop} onWhy={noop} />)
+    expect(screen.queryByText(/^book /)).toBeNull()
+  })
+
+  it('renders a card with no metric without leaving a hole', () => {
+    const noMetric = unwrap(buildRecommendationCard({
+      id: 'r2', assetId: 'a3', symbol: 'NVDA', action: 'sell',
+      proposedWeightPct: null, currentWeightPct: null, currentWeightAsOf: null,
+      rationale: 'Position has no owner since Sam left and nobody is maintaining the model.',
+      recommendedBy: null, portfolioId: 'p1', portfolioName: 'Core Equity',
+      createdAt: new Date().toISOString(),
+    }))
+    render(<SignalCardView card={noMetric} onAction={noop} onOpen={noop} onWhy={noop} />)
+    expect(screen.getByText(noMetric.headline)).toBeTruthy()
+    expect(screen.getByText('Approve')).toBeTruthy()
+  })
+
+  it('routes every action through the same two callbacks', () => {
+    const onAction = vi.fn()
+    const onOpen = vi.fn()
+    render(<SignalCardView card={REC} onAction={onAction} onOpen={onOpen} onWhy={noop} />)
+
+    fireEvent.click(screen.getByText('Approve'))
+    fireEvent.click(screen.getByText('Decline'))
+    fireEvent.click(screen.getByText('Open DASH'))
+
+    expect(onAction.mock.calls.map(c => c[0])).toEqual(['approve', 'reject'])
+    expect(onOpen).toHaveBeenCalledTimes(1)
+  })
+
+  it('every card can be asked why it is here', () => {
+    const onWhy = vi.fn()
+    for (const [, card] of ALL) {
+      const { unmount } = render(
+        <SignalCardView card={card} onAction={noop} onOpen={noop} onWhy={onWhy} />,
+      )
+      fireEvent.click(screen.getByLabelText('Why am I seeing this'))
+      unmount()
+    }
+    expect(onWhy).toHaveBeenCalledTimes(3)
+  })
+
+  it('omits evidence entirely when no card argues for it', () => {
+    // A chart needs a reason to appear. None of the three has one, so none
+    // gets a slot — the previous tiles rendered an empty chart panel anyway.
+    const { container } = render(
+      <SignalCardView card={NEWS} onAction={noop} onOpen={noop} onWhy={noop}
+        evidence={<div data-testid="chart" />} />,
+    )
+    expect(container.querySelector('[data-testid="chart"]')).toBeNull()
+  })
+})

--- a/src/lib/signals/builders/__tests__/builders.test.ts
+++ b/src/lib/signals/builders/__tests__/builders.test.ts
@@ -1,0 +1,389 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { buildActiveRiskCard, selectActiveRisk, type ActiveRiskInput } from '../activeRisk'
+import { buildRecommendationCard, type RecommendationInput } from '../recommendation'
+import { buildNewsCard, type NewsInput } from '../news'
+import { readSuppressionLog } from '../../suppression'
+import type { CardResult, SignalCard } from '../../contract'
+
+/**
+ * These tests exist to hold one line: no card renders a null or contradictory
+ * value. Each builder is checked against the specific bad data that reached
+ * production — mash rationales, zero-price placeholders, unit-confused
+ * weights — rather than against invented edge cases.
+ *
+ * The invariant block at the bottom runs over every card all three builders
+ * can emit, so a fourth builder added later cannot quietly ship a card with no
+ * primary action or a metric with no date.
+ */
+
+const iso = (daysAgo: number) => new Date(Date.now() - daysAgo * 86_400_000).toISOString()
+
+const card = (r: CardResult): SignalCard => {
+  if (!r.ok) throw new Error(`expected a card, got suppression: ${r.reason} (${r.detail})`)
+  return r.card
+}
+const reason = (r: CardResult): string => {
+  if (r.ok) throw new Error('expected suppression, got a card')
+  return r.reason
+}
+
+beforeEach(() => localStorage.clear())
+
+// ── active risk ────────────────────────────────────────────────────────────
+
+const RISK: ActiveRiskInput = {
+  assetId: 'a1',
+  symbol: 'MSFT',
+  companyName: 'Microsoft',
+  weightPct: 6.2,
+  benchmarkWeightPct: 3.1,
+  portfolioId: 'p1',
+  portfolioName: 'Core Equity',
+  asOf: '2026-07-31T00:00:00.000Z',
+}
+
+describe('active risk', () => {
+  it('states the difference from the benchmark, not the position size', () => {
+    const c = card(buildActiveRiskCard(RISK))
+    expect(c.headline).toBe('MSFT is a +3.1% overweight in Core Equity')
+    expect(c.metric?.value).toBe('+3.1%')
+    expect(c.metric?.label).toBe('Active weight')
+  })
+
+  it('marks the number as coming from the book, not a live quote', () => {
+    // The eyebrow renders "book 31 Jul" off this. A weight from a snapshot and
+    // a live one must not look identical on screen.
+    expect(card(buildActiveRiskCard(RISK)).metric?.source).toBe('holdings')
+    expect(card(buildActiveRiskCard(RISK)).metric?.asOf).toBe('2026-07-31T00:00:00.000Z')
+  })
+
+  it('treats an absent benchmark weight as a genuine zero, not missing data', () => {
+    const c = card(buildActiveRiskCard({ ...RISK, benchmarkWeightPct: null }))
+    expect(c.metric?.value).toBe('+6.2%')
+    expect(c.body).toContain('the benchmark does not hold it')
+    expect(c.context.some(x => x.label === 'Off benchmark')).toBe(true)
+  })
+
+  it('escalates an off-benchmark position that has nothing offsetting it', () => {
+    expect(card(buildActiveRiskCard({ ...RISK, weightPct: 3.5, benchmarkWeightPct: null })).severity)
+      .toBe('critical')
+    // Same active size, but half of it is offset by the index.
+    expect(card(buildActiveRiskCard({ ...RISK, weightPct: 6.6, benchmarkWeightPct: 3.1 })).severity)
+      .toBe('attention')
+  })
+
+  it('never colours an overweight as good or bad', () => {
+    expect(card(buildActiveRiskCard(RISK)).metric?.direction).toBe('neutral')
+    expect(card(buildActiveRiskCard({ ...RISK, weightPct: 1 })).metric?.direction).toBe('neutral')
+  })
+
+  it('suppresses a weight outside 0-100 rather than rendering a unit error', () => {
+    // 0.062 stored where 6.2 was expected is the shape this catches.
+    expect(reason(buildActiveRiskCard({ ...RISK, weightPct: 620 }))).toBe('inconsistent_numbers')
+  })
+
+  it('suppresses a zero weight — that is an unheld name, not a 0% bet', () => {
+    expect(reason(buildActiveRiskCard({ ...RISK, weightPct: 0 }))).toBe('missing_number')
+  })
+
+  it('suppresses an unusable snapshot date', () => {
+    expect(reason(buildActiveRiskCard({ ...RISK, asOf: '' }))).toBe('missing_number')
+  })
+
+  it('re-fires on a new snapshot but not within one', () => {
+    const a = card(buildActiveRiskCard(RISK)).dedupeKey
+    const b = card(buildActiveRiskCard({ ...RISK, weightPct: 6.3 })).dedupeKey
+    const c = card(buildActiveRiskCard({ ...RISK, asOf: '2026-08-31T00:00:00.000Z' })).dedupeKey
+    expect(b).toBe(a)
+    expect(c).not.toBe(a)
+  })
+
+  describe('selection', () => {
+    const rows: ActiveRiskInput[] = [
+      { ...RISK, assetId: 'x', symbol: 'AAA', weightPct: 2.0, benchmarkWeightPct: 1.9 },
+      { ...RISK, assetId: 'y', symbol: 'BBB', weightPct: 8.0, benchmarkWeightPct: 1.0 },
+      { ...RISK, assetId: 'z', symbol: 'CCC', weightPct: 0.2, benchmarkWeightPct: 4.0 },
+    ]
+
+    it('ranks by size of the bet in either direction', () => {
+      const picked = selectActiveRisk(rows, { limit: 2 }).map(r => r.symbol)
+      expect(picked).toEqual(['BBB', 'CCC'])
+    })
+
+    it('does not log below-threshold rows as suppressions', () => {
+      selectActiveRisk(rows)
+      // Thresholding is selection, not suppression. Logging it would bury the
+      // genuine data faults under thousands of routine lines.
+      expect(readSuppressionLog()).toHaveLength(0)
+    })
+  })
+})
+
+// ── recommendation ─────────────────────────────────────────────────────────
+
+const REC: RecommendationInput = {
+  id: 'r1',
+  assetId: 'a2',
+  symbol: 'DASH',
+  action: 'trim',
+  proposedWeightPct: 1.5,
+  currentWeightPct: 4.0,
+  currentWeightAsOf: '2026-07-31T00:00:00.000Z',
+  rationale: 'Multiple has re-rated past our bull case and the delivery margin story is now consensus.',
+  recommendedBy: 'Priya Raman',
+  portfolioId: 'p1',
+  portfolioName: 'Core Equity',
+  createdAt: iso(1),
+}
+
+describe('recommendation', () => {
+  it('leads with the size change, not the verb', () => {
+    const c = card(buildRecommendationCard(REC))
+    expect(c.headline).toBe('Priya Raman wants DASH down to 1.5% in Core Equity')
+    expect(c.metric?.value).toBe('-2.50%')
+    expect(c.metric?.label).toBe('4.0% → 1.5%')
+  })
+
+  it('dates the delta by its stalest input, not by the recommendation', () => {
+    // The delta mixes a stated weight with one read off a snapshot. Stamping
+    // it with today would claim a freshness it does not have.
+    const c = card(buildRecommendationCard(REC))
+    expect(c.metric?.source).toBe('computed')
+    expect(c.metric?.asOf).toBe('2026-07-31T00:00:00.000Z')
+  })
+
+  it('suppresses a proposal that contradicts its own verb', () => {
+    expect(reason(buildRecommendationCard({ ...REC, action: 'add' })))
+      .toBe('inconsistent_numbers')
+    expect(reason(buildRecommendationCard({ ...REC, action: 'buy', proposedWeightPct: 1.5 })))
+      .toBe('inconsistent_numbers')
+  })
+
+  it('suppresses a change that changes nothing', () => {
+    expect(reason(buildRecommendationCard({ ...REC, proposedWeightPct: 4.0 })))
+      .toBe('inconsistent_numbers')
+  })
+
+  it('allows hold to propose the current weight', () => {
+    const c = card(buildRecommendationCard({ ...REC, action: 'hold', proposedWeightPct: 4.0 }))
+    expect(c.type).toBe('recommendation')
+  })
+
+  it('suppresses a mash rationale', () => {
+    // Both of these reached production.
+    expect(reason(buildRecommendationCard({ ...REC, rationale: 'NDDFKJSDNFKJ' }))).toBe('content_quality')
+    expect(reason(buildRecommendationCard({ ...REC, rationale: 'ksadjfnskdjn' }))).toBe('content_quality')
+    expect(reason(buildRecommendationCard({ ...REC, rationale: 'test' }))).toBe('content_quality')
+    expect(reason(buildRecommendationCard({ ...REC, rationale: null }))).toBe('content_quality')
+  })
+
+  it('distinguishes a new position from a failed lookup', () => {
+    // currentWeightPct 0 — we hold none of it. A real buy.
+    const fresh = card(buildRecommendationCard({
+      ...REC, action: 'buy', currentWeightPct: 0, proposedWeightPct: 2,
+    }))
+    expect(fresh.metric?.value).toBe('+2.00%')
+
+    // currentWeightPct null — we could not look it up. Falls back to the
+    // proposal alone rather than inventing a 0% position.
+    const unknown = card(buildRecommendationCard({
+      ...REC, action: 'buy', currentWeightPct: null, currentWeightAsOf: null, proposedWeightPct: 2,
+    }))
+    expect(unknown.metric?.label).toBe('Proposed weight')
+    expect(unknown.metric?.source).toBe('stated')
+  })
+
+  it('renders a recommendation carrying no weights at all', () => {
+    const c = card(buildRecommendationCard({
+      ...REC, proposedWeightPct: null, currentWeightPct: null, currentWeightAsOf: null,
+    }))
+    expect(c.metric).toBeNull()
+    expect(c.headline).toBe('Priya Raman recommends you trim DASH in Core Equity')
+  })
+
+  it('gets louder rather than expiring while it waits', () => {
+    expect(card(buildRecommendationCard(REC)).severity).toBe('attention')
+    const old = card(buildRecommendationCard({ ...REC, createdAt: iso(9) }))
+    expect(old.severity).toBe('critical')
+    expect(old.context.some(x => x.label === 'Waiting 9 days')).toBe(true)
+  })
+
+  it('can be answered without leaving the feed', () => {
+    const c = card(buildRecommendationCard(REC))
+    expect(c.actions.primary).toEqual({ id: 'approve', label: 'Approve', inline: true })
+    expect(c.actions.quick.some(a => a.id === 'reject')).toBe(true)
+  })
+})
+
+// ── news ───────────────────────────────────────────────────────────────────
+
+const NEWS: NewsInput = {
+  id: 'n1',
+  headline: 'Microsoft raises quarterly dividend and expands buyback authorisation',
+  summary: 'The company lifted its payout by 10% and added $60bn to its repurchase programme.',
+  url: 'https://example.com/story',
+  source: 'Reuters',
+  publishedAt: iso(0.2),
+  primarySymbol: 'MSFT',
+  symbols: ['MSFT'],
+  asset: { id: 'a1', symbol: 'MSFT', companyName: 'Microsoft' },
+  heldIn: ['Core Equity', 'Growth'],
+  maxWeightPct: 6.2,
+}
+
+describe('news', () => {
+  it('adds the stake to the story', () => {
+    const c = card(buildNewsCard(NEWS))
+    expect(c.headline).toBe(NEWS.headline)
+    expect(c.body).toContain('You hold it in 2 portfolios, up to 6.2% in Core Equity.')
+    expect(c.severity).toBe('attention')
+  })
+
+  it('is informational when the org does not own it', () => {
+    const c = card(buildNewsCard({ ...NEWS, heldIn: [], maxWeightPct: null }))
+    expect(c.severity).toBe('informational')
+  })
+
+  it('is never critical', () => {
+    for (const held of [[], ['Core Equity'], ['a', 'b', 'c']]) {
+      expect(card(buildNewsCard({ ...NEWS, heldIn: held })).severity).not.toBe('critical')
+    }
+  })
+
+  it('drops a stale price move without dropping the story', () => {
+    const stale = card(buildNewsCard({
+      ...NEWS,
+      quote: { changePercent: -4.2, asOf: new Date(Date.now() - 60 * 60_000).toISOString() },
+    }))
+    // The story is still news; only the number is gone.
+    expect(stale.metric).toBeNull()
+    expect(stale.headline).toBe(NEWS.headline)
+
+    const fresh = card(buildNewsCard({
+      ...NEWS,
+      quote: { changePercent: -4.2, asOf: new Date().toISOString() },
+    }))
+    expect(fresh.metric?.value).toBe('-4.2%')
+    expect(fresh.metric?.source).toBe('quote')
+    expect(fresh.metric?.direction).toBe('bad')
+  })
+
+  it('shows a flat tape as flat rather than suppressing it', () => {
+    const c = card(buildNewsCard({
+      ...NEWS, quote: { changePercent: 0, asOf: new Date().toISOString() },
+    }))
+    expect(c.metric?.value).toBe('+0.0%')
+  })
+
+  it('carries a macro story with no asset behind it', () => {
+    const c = card(buildNewsCard({
+      ...NEWS,
+      primarySymbol: null,
+      asset: null,
+      heldIn: [],
+      headline: 'US CPI rises 0.3% in July, above expectations',
+      summary: 'Core inflation held at 3.2% year on year.',
+    }))
+    expect(c.entity.kind).toBe('market')
+    expect(c.entity.id).toBe('market')
+    expect(c.actions.open.href).toBe('https://example.com/story')
+  })
+
+  it('suppresses a headline-only story nobody holds', () => {
+    // The old tile repeated the headline underneath itself when the provider
+    // gave no summary. Entire batches of thirty arrived that way.
+    expect(reason(buildNewsCard({ ...NEWS, summary: null, heldIn: [] }))).toBe('content_quality')
+  })
+
+  it('keeps a headline-only story about a name you hold', () => {
+    const c = card(buildNewsCard({ ...NEWS, summary: null }))
+    expect(c.body).toBe('You hold it in 2 portfolios, up to 6.2% in Core Equity.')
+  })
+
+  it('suppresses a story it cannot place in time or open', () => {
+    expect(reason(buildNewsCard({ ...NEWS, publishedAt: 'not a date' }))).toBe('content_quality')
+    expect(reason(buildNewsCard({ ...NEWS, url: '' }))).toBe('content_quality')
+  })
+
+  it('drops history', () => {
+    expect(reason(buildNewsCard({ ...NEWS, publishedAt: iso(9) }))).toBe('resolved')
+  })
+
+  it('treats two stories about one name on one day as two claims', () => {
+    const a = card(buildNewsCard(NEWS)).dedupeKey
+    const b = card(buildNewsCard({ ...NEWS, id: 'n2' })).dedupeKey
+    expect(b).not.toBe(a)
+  })
+})
+
+// ── every suppression is logged, and every card is well-formed ─────────────
+
+describe('the gate', () => {
+  it('logs each suppression with its reason, type and entity', () => {
+    buildActiveRiskCard({ ...RISK, weightPct: 0 })
+    buildRecommendationCard({ ...REC, rationale: 'asdfgh' })
+    buildNewsCard({ ...NEWS, url: '' })
+
+    const log = readSuppressionLog()
+    expect(log.map(e => e.type)).toEqual(['active_risk', 'recommendation', 'news'])
+    expect(log.map(e => e.reason)).toEqual(['missing_number', 'content_quality', 'content_quality'])
+    expect(log.every(e => !!e.entity && !!e.detail && !!e.at)).toBe(true)
+  })
+})
+
+describe('contract invariants', () => {
+  const all: SignalCard[] = [
+    card(buildActiveRiskCard(RISK)),
+    card(buildActiveRiskCard({ ...RISK, benchmarkWeightPct: null })),
+    card(buildRecommendationCard(REC)),
+    card(buildRecommendationCard({ ...REC, proposedWeightPct: null, currentWeightPct: null, currentWeightAsOf: null })),
+    card(buildNewsCard(NEWS)),
+    card(buildNewsCard({ ...NEWS, asset: null, primarySymbol: null })),
+  ]
+
+  it('every card has exactly one primary action and a way out', () => {
+    for (const c of all) {
+      expect(c.actions.primary.id).toBeTruthy()
+      expect(c.actions.open.href).toBeTruthy()
+      expect(c.actions.quick.length).toBeGreaterThan(0)
+      expect(c.actions.quick.length).toBeLessThanOrEqual(3)
+      expect(c.actions.quick.every(a => a.inline)).toBe(true)
+    }
+  })
+
+  it('every displayed number carries a source and a date', () => {
+    for (const c of all) {
+      if (!c.metric) continue
+      expect(c.metric.source).toBeTruthy()
+      expect(Number.isNaN(new Date(c.metric.asOf).getTime())).toBe(false)
+      expect(c.metric.value).not.toMatch(/NaN|undefined|null/)
+    }
+  })
+
+  it('no headline is a category label', () => {
+    for (const c of all) {
+      // The old cards led with "ACTIVE RISK" in a coloured badge. A headline
+      // is a sentence about a thing, so it contains a space and is not the
+      // type in disguise.
+      expect(c.headline).toContain(' ')
+      expect(c.headline.toLowerCase()).not.toBe(c.type.replace('_', ' '))
+    }
+  })
+
+  it('every card can explain itself', () => {
+    for (const c of all) {
+      expect(c.provenance.reason.length).toBeGreaterThan(20)
+      expect(Number.isNaN(new Date(c.provenance.occurredAt).getTime())).toBe(false)
+      expect(c.expiry.staleAfterDays).toBeGreaterThan(0)
+      expect(c.dedupeKey.startsWith(c.type)).toBe(true)
+    }
+  })
+
+  it('no evidence is attached without an argument for it', () => {
+    // Charts require a reason to appear, not a reason to suppress. None of
+    // these three has one yet.
+    for (const c of all) {
+      expect(c.evidence == null || c.evidence.kind === 'none').toBe(true)
+    }
+  })
+})

--- a/src/lib/signals/builders/activeRisk.ts
+++ b/src/lib/signals/builders/activeRisk.ts
@@ -1,0 +1,181 @@
+import {
+  emit,
+  suppress,
+  type CardResult,
+  type Severity,
+  type SignalCard,
+} from '../contract'
+import { gate, isDisplayableNumber, isQualityContent } from '../suppression'
+import { actions, assetHref, dayKey, pct, TRIAGE } from './shared'
+
+/**
+ * Active risk: where the book differs from the benchmark.
+ *
+ * A position is not a bet; the difference between the position and the index
+ * is. A 6% weight in a name the benchmark holds at 5.8% expresses almost no
+ * view, and the old card said "6% of the book" without that denominator — true
+ * and useless.
+ *
+ * The number here comes from `portfolio_holdings`, an upload-time mark carried
+ * forward nightly. That is legitimate for a *weight*, which is a ratio of two
+ * marks taken on the same day and therefore survives both being stale — and
+ * illegitimate for anything compared against a live quote. This builder
+ * touches only weights, so it never trips `snapshot_vs_live`. The eyebrow
+ * still renders "book 31 Jul" via `source: 'holdings'`, because a fifteen-day-
+ * old weight and a live one should not look identical on screen.
+ */
+
+export interface ActiveRiskInput {
+  assetId: string
+  symbol: string
+  companyName?: string | null
+  /** Portfolio weight, percent. */
+  weightPct: number
+  /** Benchmark weight, percent. Null when the name is not in the index. */
+  benchmarkWeightPct: number | null
+  portfolioId: string
+  portfolioName: string
+  /** Date of the holdings snapshot both weights come from. ISO. */
+  asOf: string
+}
+
+/**
+ * Where an active bet stops being a rounding difference.
+ *
+ * 1.5% because below it the position is inside the noise of a monthly rebalance
+ * and flagging it would fire on most of the book — a filter wearing a finding's
+ * clothes.
+ */
+export const MIN_ACTIVE_PCT = 1.5
+/** A bet this size is the portfolio's identity, not a tilt. */
+const CRITICAL_ACTIVE_PCT = 5
+
+function severityFor(active: number, offBenchmark: boolean): Severity {
+  const size = Math.abs(active)
+  if (size >= CRITICAL_ACTIVE_PCT) return 'critical'
+  // An off-benchmark name has no offset at all: the entire position is the
+  // bet. That earns a step up even at a moderate size.
+  if (offBenchmark && size >= MIN_ACTIVE_PCT * 2) return 'critical'
+  return 'attention'
+}
+
+export function buildActiveRiskCard(input: ActiveRiskInput): CardResult {
+  return gate('active_risk', () => {
+    const { assetId, symbol, weightPct, benchmarkWeightPct, portfolioName, asOf } = input
+    const entity = symbol || assetId
+
+    if (!isQualityContent(symbol)) {
+      return suppress('content_quality', entity, `symbol: ${JSON.stringify(symbol)}`)
+    }
+    // Weight zero is a name that is not held — no position, no bet, nothing to
+    // say. Rejecting it here rather than treating it as "0% active" matters
+    // because a missing join produces exactly that shape.
+    if (!isDisplayableNumber(weightPct)) {
+      return suppress('missing_number', entity, `weightPct: ${weightPct}`)
+    }
+    if (!asOf || Number.isNaN(new Date(asOf).getTime())) {
+      return suppress('missing_number', entity, `asOf: ${JSON.stringify(asOf)}`)
+    }
+
+    // A null benchmark weight means the index does not hold the name; a zero
+    // means the same thing. Both are genuinely zero, so `allowZero` — this is
+    // the case the contract's default rejection is wrong about.
+    const bench = benchmarkWeightPct ?? 0
+    if (!isDisplayableNumber(bench, { allowZero: true }) || bench < 0) {
+      return suppress('missing_number', entity, `benchmarkWeightPct: ${benchmarkWeightPct}`)
+    }
+    if (weightPct < 0 || weightPct > 100 || bench > 100) {
+      // A weight outside 0–100 is a unit error — fractions stored where
+      // percents were expected, or the reverse. Rendering it would put an
+      // impossible number on a card that claims to be checkable.
+      return suppress(
+        'inconsistent_numbers',
+        entity,
+        `weight ${weightPct}% vs benchmark ${bench}% — outside 0–100`,
+      )
+    }
+
+    const active = weightPct - bench
+    const offBenchmark = benchmarkWeightPct == null || benchmarkWeightPct === 0
+    const over = active > 0
+
+    const card: SignalCard = {
+      id: `active_risk:${input.portfolioId}:${assetId}`,
+      type: 'active_risk',
+      surface: 'risk',
+      severity: severityFor(active, offBenchmark),
+      headline: `${symbol} is a ${pct(active)} ${over ? 'overweight' : 'underweight'} in ${portfolioName}`,
+      metric: {
+        value: pct(active),
+        label: 'Active weight',
+        // Deliberately neutral. An overweight is not "good" and an underweight
+        // is not "bad" — colouring them would editorialise the portfolio
+        // manager's own decision back at them.
+        direction: 'neutral',
+        source: 'holdings',
+        asOf,
+      },
+      body: offBenchmark
+        ? `The position is ${weightPct.toFixed(1)}% of the book and the benchmark does not hold it, so all of it is active risk. Nothing offsets this if the thesis is wrong.`
+        : `${weightPct.toFixed(1)}% of the book against ${bench.toFixed(1)}% in the benchmark. This is where the portfolio is expressing a view.`,
+      entity: {
+        kind: 'asset',
+        id: assetId,
+        name: input.companyName || symbol,
+        ticker: symbol,
+      },
+      context: [
+        { label: portfolioName },
+        offBenchmark ? { label: 'Off benchmark' } : { label: `Bench ${bench.toFixed(1)}%` },
+      ],
+      // No evidence. A sparkline of price says nothing about active weight,
+      // and the contract's rule is that a chart needs an argument to appear.
+      actions: actions(
+        // Recording a view is the one thing genuinely resolvable from a feed.
+        // Changing the size is not, and pretending otherwise with an inline
+        // control would be a lie about what the button does.
+        { id: 'log_view', label: 'Log a view', inline: true },
+        { label: `Open ${symbol}`, href: assetHref(assetId) },
+        TRIAGE,
+      ),
+      provenance: {
+        occurredAt: asOf,
+        reason: `${symbol} carries ${pct(active)} of active weight in ${portfolioName}, the ${
+          over ? 'largest overweights' : 'largest underweights'
+        } being where the book can differ from its benchmark.`,
+      },
+      expiry: {
+        // Weights move with the market daily, but the *bet* does not. A week
+        // is roughly how long an active position stays the same decision.
+        staleAfterDays: 7,
+      },
+      // Trigger period is the snapshot date: the same overweight on a new
+      // book is a new statement of the same claim, and should re-surface once
+      // the numbers behind it have actually changed.
+      dedupeKey: `active_risk:${assetId}:${dayKey(asOf)}`,
+    }
+
+    return emit(card)
+  })
+}
+
+/**
+ * Rank candidates and keep the ones worth a card.
+ *
+ * Thresholding lives here rather than in the builder on purpose: "too small to
+ * mention" is a selection decision, not a suppression, and logging it as one
+ * would bury the genuine data faults — the unit errors and missing joins the
+ * builder does catch — under thousands of routine below-threshold lines.
+ */
+export function selectActiveRisk(
+  holdings: ActiveRiskInput[],
+  opts: { minActivePct?: number; limit?: number } = {},
+): ActiveRiskInput[] {
+  const { minActivePct = MIN_ACTIVE_PCT, limit = 3 } = opts
+  return holdings
+    .map(h => ({ h, active: h.weightPct - (h.benchmarkWeightPct ?? 0) }))
+    .filter(({ active }) => Number.isFinite(active) && Math.abs(active) >= minActivePct)
+    .sort((a, b) => Math.abs(b.active) - Math.abs(a.active))
+    .slice(0, limit)
+    .map(({ h }) => h)
+}

--- a/src/lib/signals/builders/index.ts
+++ b/src/lib/signals/builders/index.ts
@@ -1,0 +1,8 @@
+export { buildActiveRiskCard, selectActiveRisk, MIN_ACTIVE_PCT } from './activeRisk'
+export type { ActiveRiskInput } from './activeRisk'
+
+export { buildRecommendationCard } from './recommendation'
+export type { RecommendationInput, RecommendationAction } from './recommendation'
+
+export { buildNewsCard } from './news'
+export type { NewsInput } from './news'

--- a/src/lib/signals/builders/news.ts
+++ b/src/lib/signals/builders/news.ts
@@ -1,0 +1,182 @@
+import {
+  emit,
+  suppress,
+  type CardEntity,
+  type CardMetric,
+  type CardResult,
+  type SignalCard,
+} from '../contract'
+import { gate, isDisplayableNumber, isQualityContent, isQuoteFresh } from '../suppression'
+import { actions, assetHref, dayKey, pct, TRIAGE } from './shared'
+
+/**
+ * A news story, with the book's stake in it.
+ *
+ * News is the only card type whose content arrives from outside the product,
+ * which changes what the card is for. The other two tell you something about
+ * your own book that you did not know; this one tells you something the world
+ * did, and the value it adds is the second half — that you hold the name, and
+ * at what size.
+ *
+ * A story about nothing the org owns is still worth a card (a CPI print moves
+ * everything), which is why `EntityKind` has a `market` member. Making the
+ * entity nullable instead would have broken dedupeKey, which needs one.
+ */
+
+export interface NewsInput {
+  /** Stable per story. Syndicated reposts of one story share it. */
+  id: string
+  headline: string
+  summary?: string | null
+  url: string
+  source: string
+  /** ISO. */
+  publishedAt: string
+  /** The ticker the story is *about*, as opposed to ones it merely mentions. */
+  primarySymbol?: string | null
+  symbols?: string[]
+  sentiment?: 'positive' | 'negative' | 'neutral' | null
+  /** The asset in the book, when the primary symbol resolves to one. */
+  asset?: { id: string; symbol: string; companyName?: string | null } | null
+  /** Portfolios holding it, for the stake line. */
+  heldIn?: string[]
+  /** Largest weight the name takes in any one of them, percent. */
+  maxWeightPct?: number | null
+  /** Today's move for the primary symbol, if a quote is on hand. */
+  quote?: { changePercent: number; asOf: string } | null
+}
+
+/** How old a story may be and still be news rather than history. */
+const MAX_AGE_DAYS = 3
+const DAY_MS = 86_400_000
+
+export function buildNewsCard(input: NewsInput): CardResult {
+  return gate('news', () => {
+    const { id, headline, summary, url, source, publishedAt, asset, heldIn = [] } = input
+    const entity = input.primarySymbol || asset?.symbol || id
+
+    if (!isQualityContent(headline)) {
+      return suppress('content_quality', entity, `headline: ${JSON.stringify(headline)}`)
+    }
+    if (!url) {
+      return suppress('content_quality', entity, 'url is empty — the card would not open')
+    }
+    const published = new Date(publishedAt).getTime()
+    if (!Number.isFinite(published)) {
+      // No date means the eyebrow cannot say when this happened, and a news
+      // card that cannot place itself in time is not fit to display. Routed
+      // through content_quality rather than a new reason because the failure
+      // is the same one: a field arrived unusable.
+      return suppress('content_quality', entity, `publishedAt: ${JSON.stringify(publishedAt)}`)
+    }
+    const ageDays = (Date.now() - published) / DAY_MS
+    if (ageDays > MAX_AGE_DAYS) {
+      return suppress('resolved', entity, `published ${Math.round(ageDays)} days ago`)
+    }
+
+    const held = heldIn.length > 0
+    const weight = input.maxWeightPct
+
+    /**
+     * The move is attached only when the quote is fresh.
+     *
+     * A stale quote does not suppress the *card* — the story is still news
+     * whether or not we can price it — it suppresses the *number*. That
+     * distinction is the whole reason a number carries its own `asOf`: the
+     * alternative is a card showing "-4.2% today" from a quote taken
+     * yesterday, which is worse than showing no number at all.
+     */
+    let metric: CardMetric | null = null
+    const q = input.quote
+    if (q && isDisplayableNumber(q.changePercent, { allowZero: true }) && isQuoteFresh(q.asOf)) {
+      metric = {
+        value: pct(q.changePercent),
+        label: 'Today',
+        direction: q.changePercent >= 0 ? 'good' : 'bad',
+        source: 'quote',
+        asOf: q.asOf,
+      }
+    }
+
+    const cardEntity: CardEntity = asset
+      ? {
+          kind: 'asset',
+          id: asset.id,
+          name: asset.companyName || asset.symbol,
+          ticker: asset.symbol,
+        }
+      : {
+          // Not a thing the product owns. A macro print, or a name nobody here
+          // covers — both are still worth reading, neither is an asset row.
+          kind: 'market',
+          id: input.primarySymbol || 'market',
+          name: input.primarySymbol || 'Market',
+          ticker: input.primarySymbol || undefined,
+        }
+
+    const stake = held && isDisplayableNumber(weight)
+      ? `You hold it in ${heldIn.length} portfolio${heldIn.length === 1 ? '' : 's'}, up to ${weight!.toFixed(1)}% in ${heldIn[0]}.`
+      : held
+        ? `You hold it in ${heldIn.length} portfolio${heldIn.length === 1 ? '' : 's'}.`
+        : ''
+
+    // The summary, then the stake. If the provider gave no summary the stake
+    // carries the body alone — better than repeating the headline underneath
+    // itself, which is what the old tile did whenever a summary was missing,
+    // and summaries were missing on entire batches of thirty.
+    const body = [isQualityContent(summary) ? summary!.trim() : '', stake]
+      .filter(Boolean)
+      .join(' ')
+
+    if (!body) {
+      return suppress('content_quality', entity, 'no summary and no holding — headline only')
+    }
+
+    const card: SignalCard = {
+      id: `news:${id}`,
+      type: 'news',
+      surface: 'market',
+      // News is never critical. Something the market already knows is not an
+      // emergency in the book, and a red rail on a headline would devalue the
+      // rail everywhere else.
+      severity: held ? 'attention' : 'informational',
+      // The headline IS the message here — the one card type where the
+      // contract's "full sentence carrying the number" is already satisfied by
+      // the source, and rewriting it would be editorialising.
+      headline: headline.trim(),
+      metric,
+      body,
+      entity: cardEntity,
+      context: [
+        { label: source },
+        ...(held ? [{ label: `Held · ${heldIn.length}` }] : []),
+        ...(input.sentiment ? [{ label: input.sentiment }] : []),
+      ],
+      actions: actions(
+        // Reading is the action. The publisher's page opens in the in-app
+        // reader, so this stays inline — leaving the feed to read a headline
+        // is what made the old tile a dead end.
+        { id: 'read', label: 'Read', inline: true },
+        asset
+          ? { label: `Open ${asset.symbol}`, href: assetHref(asset.id) }
+          : { label: 'Open source', href: url },
+        TRIAGE,
+      ),
+      provenance: {
+        occurredAt: publishedAt,
+        reason: held
+          ? `${source} published this about ${cardEntity.ticker ?? cardEntity.name}, which you hold in ${heldIn.length} portfolio${heldIn.length === 1 ? '' : 's'}.`
+          : `${source} published this about ${cardEntity.ticker ?? cardEntity.name}, which sits adjacent to what the desk covers.`,
+      },
+      expiry: {
+        staleAfterDays: MAX_AGE_DAYS,
+      },
+      // The story, not the ticker: two stories about one name on one day are
+      // two claims, and only a syndicated repost of the same story is the same
+      // claim recurring.
+      dedupeKey: `news:${id}:${dayKey(publishedAt)}`,
+    }
+
+    return emit(card)
+  })
+}

--- a/src/lib/signals/builders/recommendation.ts
+++ b/src/lib/signals/builders/recommendation.ts
@@ -1,0 +1,210 @@
+import {
+  emit,
+  suppress,
+  type CardMetric,
+  type CardResult,
+  type Severity,
+  type SignalCard,
+} from '../contract'
+import { gate, isDisplayableNumber, isQualityContent } from '../suppression'
+import { actions, assetHref, dayKey, pct, TRIAGE } from './shared'
+
+/**
+ * A recommendation waiting on a decision.
+ *
+ * "Sell DASH" is not a decision anybody can make from a card. The same
+ * instruction means something entirely different at a 30bp position than at a
+ * 4%, and different again depending on who is asking — so the card leads with
+ * the size change, not the verb.
+ *
+ * This is the one card type where the numbers can genuinely contradict each
+ * other: a proposed weight below the current one attached to an "add" is not a
+ * rendering problem to be styled around, it is a recommendation that says two
+ * things at once, and showing it would ask somebody to approve a
+ * contradiction. Those go out through `inconsistent_numbers`.
+ */
+
+export type RecommendationAction = 'buy' | 'add' | 'trim' | 'sell' | 'hold'
+
+export interface RecommendationInput {
+  /** trade_queue_items.id */
+  id: string
+  assetId: string
+  symbol: string
+  companyName?: string | null
+  action: RecommendationAction | string | null
+  /** Weight the recommendation asks for, percent. */
+  proposedWeightPct: number | null
+  /** What the portfolio holds today, percent. Null when the name is new. */
+  currentWeightPct: number | null
+  /** Date of the holdings snapshot `currentWeightPct` came from. ISO. */
+  currentWeightAsOf: string | null
+  rationale: string | null
+  recommendedBy: string | null
+  portfolioId: string
+  portfolioName: string
+  /** When the recommendation was made. ISO. */
+  createdAt: string
+}
+
+/** A recommendation nobody has answered for this long has become a problem in
+ *  its own right, separate from whatever it proposes. */
+const STALE_DECISION_DAYS = 5
+const DAY_MS = 86_400_000
+
+const INCREASES = new Set(['buy', 'add'])
+const DECREASES = new Set(['trim', 'sell'])
+
+function severityFor(ageDays: number): Severity {
+  return ageDays >= STALE_DECISION_DAYS ? 'critical' : 'attention'
+}
+
+/**
+ * A new position has no current weight, and that is not missing data.
+ *
+ * Distinguishing "we hold none of it" from "we failed to look it up" is the
+ * caller's job, which is why `currentWeightPct` is explicitly null for the
+ * second case and 0 for the first. Getting this backwards would either hide
+ * every new buy or invent a 0% position for every failed join.
+ */
+export function buildRecommendationCard(input: RecommendationInput): CardResult {
+  return gate('recommendation', () => {
+    const {
+      id, assetId, symbol, action, proposedWeightPct, currentWeightPct,
+      currentWeightAsOf, rationale, recommendedBy, portfolioName, createdAt,
+    } = input
+    const entity = symbol || assetId
+
+    if (!isQualityContent(symbol)) {
+      return suppress('content_quality', entity, `symbol: ${JSON.stringify(symbol)}`)
+    }
+    const verb = String(action ?? '').trim().toLowerCase()
+    if (!verb) {
+      return suppress('missing_number', entity, 'action is null — nothing is being proposed')
+    }
+    // Rationale is the field users actually put mash into: `NDDFKJSDNFKJ` and
+    // `ksadjfnskdjn` both reached production through here. A recommendation
+    // with no readable reason cannot be approved on its merits.
+    if (!isQualityContent(rationale)) {
+      return suppress('content_quality', entity, `rationale: ${JSON.stringify(rationale)}`)
+    }
+    const made = new Date(createdAt).getTime()
+    if (!Number.isFinite(made)) {
+      return suppress('missing_number', entity, `createdAt: ${JSON.stringify(createdAt)}`)
+    }
+
+    const hasProposed = isDisplayableNumber(proposedWeightPct, { allowZero: true })
+    const hasCurrent = currentWeightPct != null && isDisplayableNumber(currentWeightPct, { allowZero: true })
+
+    if (hasProposed && (proposedWeightPct! < 0 || proposedWeightPct! > 100)) {
+      return suppress('inconsistent_numbers', entity, `proposedWeightPct ${proposedWeightPct} outside 0–100`)
+    }
+    if (hasCurrent && (currentWeightPct! < 0 || currentWeightPct! > 100)) {
+      return suppress('inconsistent_numbers', entity, `currentWeightPct ${currentWeightPct} outside 0–100`)
+    }
+
+    // The contradiction check. Only runs when both sides are known — an
+    // unknown current weight cannot disagree with anything.
+    let delta: number | null = null
+    if (hasProposed && hasCurrent) {
+      delta = proposedWeightPct! - currentWeightPct!
+      if (INCREASES.has(verb) && delta < 0) {
+        return suppress('inconsistent_numbers', entity,
+          `${verb} proposes ${proposedWeightPct}% against a current ${currentWeightPct}% — a decrease`)
+      }
+      if (DECREASES.has(verb) && delta > 0) {
+        return suppress('inconsistent_numbers', entity,
+          `${verb} proposes ${proposedWeightPct}% against a current ${currentWeightPct}% — an increase`)
+      }
+      if (verb !== 'hold' && delta === 0) {
+        return suppress('inconsistent_numbers', entity,
+          `${verb} proposes no change from ${currentWeightPct}%`)
+      }
+    }
+
+    /**
+     * The delta is only as fresh as its stalest input.
+     *
+     * It mixes a weight stated by a person against a weight read off a
+     * holdings snapshot, so stamping it with the recommendation's own date
+     * would claim a freshness the number does not have. The snapshot date
+     * wins, and the eyebrow renders it as "book 31 Jul".
+     */
+    let metric: CardMetric | null = null
+    if (delta != null && currentWeightAsOf && !Number.isNaN(new Date(currentWeightAsOf).getTime())) {
+      metric = {
+        value: pct(delta, 2),
+        label: `${currentWeightPct!.toFixed(1)}% → ${proposedWeightPct!.toFixed(1)}%`,
+        direction: 'neutral',
+        source: 'computed',
+        asOf: currentWeightAsOf,
+      }
+    } else if (hasProposed) {
+      // No current weight, or no date to anchor it to. The proposal alone is
+      // still a number worth leading with, and it is purely `stated` — no
+      // snapshot is involved, so nothing about it is stale.
+      metric = {
+        value: `${proposedWeightPct!.toFixed(1)}%`,
+        label: 'Proposed weight',
+        direction: 'neutral',
+        source: 'stated',
+        asOf: createdAt,
+      }
+    }
+    // metric stays null for a recommendation carrying no weights at all —
+    // "sell the position" with a written reason and no size. The contract
+    // allows that, and it is a real thing people write.
+
+    const ageDays = Math.floor((Date.now() - made) / DAY_MS)
+    const who = recommendedBy || 'A colleague'
+
+    const card: SignalCard = {
+      id: `recommendation:${id}`,
+      type: 'recommendation',
+      surface: 'research',
+      severity: severityFor(ageDays),
+      headline: delta != null
+        ? `${who} wants ${symbol} ${delta > 0 ? 'up' : 'down'} to ${proposedWeightPct!.toFixed(1)}% in ${portfolioName}`
+        : `${who} recommends you ${verb} ${symbol} in ${portfolioName}`,
+      metric,
+      body: rationale!.trim(),
+      entity: {
+        kind: 'asset',
+        id: assetId,
+        name: input.companyName || symbol,
+        ticker: symbol,
+      },
+      context: [
+        { label: portfolioName },
+        { label: verb.charAt(0).toUpperCase() + verb.slice(1) },
+        ...(ageDays >= STALE_DECISION_DAYS
+          ? [{ label: `Waiting ${ageDays} days` }]
+          : []),
+      ],
+      actions: actions(
+        // The only card of the three whose primary action is the decision
+        // itself. A recommendation you cannot answer from the feed is a
+        // notification, not a card.
+        { id: 'approve', label: 'Approve', inline: true },
+        { label: `Open ${symbol}`, href: assetHref(assetId) },
+        [{ id: 'reject', label: 'Decline', inline: true }, ...TRIAGE],
+      ),
+      provenance: {
+        actor: recommendedBy ? { name: recommendedBy } : undefined,
+        occurredAt: createdAt,
+        reason: `${who} raised this ${ageDays === 0 ? 'today' : `${ageDays} day${ageDays === 1 ? '' : 's'} ago`} against ${portfolioName}, and it is still waiting on a decision.`,
+      },
+      expiry: {
+        // Longer than the risk cards: a recommendation does not stop needing
+        // an answer because it got old. It gets louder — see severityFor.
+        staleAfterDays: 30,
+      },
+      // Keyed on the recommendation itself, not on the asset. Two people
+      // proposing different sizes for one name are two decisions, and
+      // collapsing them would silently discard one person's work.
+      dedupeKey: `recommendation:${id}:${dayKey(createdAt)}`,
+    }
+
+    return emit(card)
+  })
+}

--- a/src/lib/signals/builders/shared.ts
+++ b/src/lib/signals/builders/shared.ts
@@ -1,0 +1,44 @@
+import type { CardAction, CardActions } from '../contract'
+
+/**
+ * Pieces every builder needs, in one place so three builders cannot invent
+ * three action grammars — which is precisely how the previous seven card
+ * components ended up with four different action bars.
+ */
+
+export const pct = (n: number, dp = 1) => `${n >= 0 ? '+' : ''}${n.toFixed(dp)}%`
+
+/** Day precision, for dedupeKey trigger periods. */
+export const dayKey = (iso: string): string => {
+  const d = new Date(iso)
+  return Number.isNaN(d.getTime()) ? 'unknown' : d.toISOString().slice(0, 10)
+}
+
+/**
+ * Snooze and dismiss on every card, always in that order.
+ *
+ * Both are inline by definition — a triage surface where dismissing something
+ * takes you off the surface is not a triage surface. They live here rather
+ * than in each builder so the pair cannot drift apart or go missing from one
+ * card type, which is how two of the old cards became dead ends.
+ */
+export const TRIAGE: CardAction[] = [
+  { id: 'snooze', label: 'Snooze', inline: true },
+  { id: 'dismiss', label: 'Not useful', inline: true },
+]
+
+/**
+ * The app is tab-based rather than routed — there is no `/asset/:id` route —
+ * so hrefs here are logical targets the feed resolves to a tab open. They are
+ * kept in URL shape because the contract asks for an href and because the
+ * moment a route does exist, nothing about these builders has to change.
+ */
+export const assetHref = (assetId: string) => `/asset/${assetId}`
+
+export function actions(
+  primary: CardAction,
+  open: { label: string; href: string },
+  quick: CardAction[] = TRIAGE,
+): CardActions {
+  return { primary, quick, open }
+}

--- a/supabase/migrations/20260815120000_asset_notes_org_scoped_select.sql
+++ b/supabase/migrations/20260815120000_asset_notes_org_scoped_select.sql
@@ -1,0 +1,98 @@
+/**
+ * asset_notes: the SELECT policy permits reads across every organization.
+ *
+ * Live policy in production:
+ *
+ *   (auth.uid() = created_by)
+ *   OR (is_shared = true)
+ *   OR EXISTS (SELECT 1 FROM note_collaborations ...)
+ *
+ * The `is_shared = true` branch has no organization predicate, so a note
+ * flagged shared is readable by every authenticated user in all 27
+ * organizations — not just the author's colleagues.
+ *
+ * This is the original of the shape found on asset_models, which was copied
+ * from here and says so:
+ *
+ *   20251230000002_add_notes_models_section.sql:52
+ *   -- RLS Policies for asset_models (same pattern as asset_notes)
+ *
+ * ── Exposure ──────────────────────────────────────────────────────────────
+ *
+ * Zero today, and unreachable rather than merely unused: `is_shared` is false
+ * on all 57 rows, and no code path can set it true. Every write hardcodes
+ * false (AddReferenceModal, KeyReferencesSection x2, DocumentLibrarySection
+ * x3) and there is no sharing control in the notes UI. The only settable
+ * is_shared belongs to investment_case_templates, whose policy is already
+ * org-aware.
+ *
+ * So this is armed, not leaking. It becomes a live cross-tenant read the day
+ * somebody builds the share toggle — at which point the defect is invisible,
+ * because the feature will appear to work correctly.
+ *
+ * ── What changes ──────────────────────────────────────────────────────────
+ *
+ * The org predicate is added as an AND across the whole policy rather than
+ * only to the is_shared branch. Author and collaborator access should be
+ * org-bounded too: a collaboration invitation is not a reason to read another
+ * organization's note, and `created_by` matching is not either — the same
+ * person in two orgs should not carry notes between them.
+ *
+ * Legacy rows carry organization_id IS NULL (20260603140000 left them so, as
+ * pre-migration rows had no reconstructable origin org). Those become
+ * readable only by their author, which is the correct conservative outcome:
+ * an unattributable note should not be shared with an org it may not belong
+ * to.
+ *
+ * ── Reversibility ─────────────────────────────────────────────────────────
+ *
+ * The prior policy body is reproduced verbatim above. To restore, drop the
+ * new policy and recreate with that expression. This is a strict tightening:
+ * nothing readable after this was unreadable before.
+ *
+ * ── Blast radius ──────────────────────────────────────────────────────────
+ *
+ * 57 rows. 0 shared. Notes authored in an org remain readable to their author
+ * and collaborators within that org. The only reads removed are cross-org
+ * ones, none of which can currently occur.
+ */
+
+DROP POLICY IF EXISTS "Users can view own and shared notes" ON public.asset_notes;
+-- The live name in production may differ from the migration that created it;
+-- both spellings are dropped so the CREATE below cannot collide.
+DROP POLICY IF EXISTS "Users can view accessible notes" ON public.asset_notes;
+
+CREATE POLICY "Org members can view notes in current org"
+  ON public.asset_notes
+  FOR SELECT
+  TO authenticated
+  USING (
+    organization_id = current_org_id()
+    AND (
+      auth.uid() = created_by
+      OR is_shared = true
+      OR EXISTS (
+        SELECT 1 FROM note_collaborations nc
+        WHERE nc.note_id = asset_notes.id
+          AND nc.user_id = auth.uid()
+      )
+    )
+  );
+
+-- Legacy rows with no org can still be read by whoever wrote them, so a
+-- pre-2026 note does not vanish from its author's own view.
+CREATE POLICY "Authors can view their own unattributed notes"
+  ON public.asset_notes
+  FOR SELECT
+  TO authenticated
+  USING (organization_id IS NULL AND auth.uid() = created_by);
+
+-- ---------------------------------------------------------------------------
+-- Verification — run after applying.
+-- ---------------------------------------------------------------------------
+--
+--   SELECT policyname, qual FROM pg_policies
+--    WHERE tablename = 'asset_notes' AND cmd = 'SELECT';
+--
+-- Expect exactly the two policies above, both containing an organization
+-- predicate or an explicit author check.


### PR DESCRIPTION
Three builders on the card contract, rendering through the single SignalCardView with no per-type branch.

48 tests. The stale-quote guard and the recommendation contradiction guard were each broken deliberately and observed to fail before restoring.

Also: ticket for the unproven Netlify branch-deploy gate, and an **unapplied** migration for the asset_notes SELECT policy awaiting per-migration sign-off.

?? Generated with [Claude Code](https://claude.com/claude-code)