### PR TITLE
fix(flag): the signal-cards flag could never turn on, and said nothing

### DIFF
--- a/src/components/mobile/MobileDashboard.tsx
+++ b/src/components/mobile/MobileDashboard.tsx
@@ -418,6 +418,21 @@ export function MobileDashboard({
     return m
   }, [recommendationResults])
 
+  /** How many contract cards this feed will actually render. The flag being on
+   *  and the feed containing contract cards are different claims, and only the
+   *  second one tells you whether looking is worthwhile. */
+  const signalCardCount = useMemo(() => {
+    if (!signalCardsOn) return 0
+    let n = 0
+    for (const e of feedEntries) {
+      if (e.kind === 'news') n++
+      else if (e.kind === 'template' && (e as any).card?.kind === 'active_risk') n++
+      else if (e.kind === 'attention' && (e as any).attention?.source_type === 'trade_queue_item'
+               && recommendationBySource.has((e as any).attention?.source_id)) n++
+    }
+    return n
+  }, [signalCardsOn, feedEntries, recommendationBySource])
+
   /** Keyed by assetId, replacing the active_risk template cards one for one. */
   const activeRiskByAsset = useMemo(() => {
     const m = new Map<string, SignalCard>()
@@ -811,6 +826,21 @@ export function MobileDashboard({
           it grow to its content instead of scrolling, and the snap sections
           inside are full-height by definition. Without it the scroller has no
           bounded height and every tile spills. */}
+      {/* Flag indicator. Deliberately ugly and impossible to miss — a temporary
+          state you cannot see you are in is worse than no flag at all. The
+          first attempt at this flag never turned on for anyone, because the
+          root route's <Navigate replace> dropped the query string before any
+          screen could read it, and nothing on screen said so. Goes when the
+          legacy tiles go. */}
+      {signalCardsOn && (
+        <div className="flex-shrink-0 flex items-center gap-2 px-3 py-1.5 bg-amber-400 text-black text-[11px] font-bold uppercase tracking-wide">
+          <span>flag: signal-cards ON</span>
+          <span className="font-medium normal-case tracking-normal opacity-80">
+            {signalCardCount} contract {signalCardCount === 1 ? 'card' : 'cards'} in this feed
+          </span>
+        </div>
+      )}
+
       <div
         ref={setScroller}
         className="flex-1 min-h-0 overflow-y-auto snap-y snap-mandatory overscroll-contain"

--- a/src/hooks/mobile/useRecommendationCards.ts
+++ b/src/hooks/mobile/useRecommendationCards.ts
@@ -34,7 +34,17 @@ export function useRecommendationCards(options?: { enabled?: boolean }) {
           portfolios!inner(id, name, organization_id)
         `)
         .eq('portfolios.organization_id', currentOrgId!)
-        .in('status', ['pending', 'proposed', 'awaiting_review'])
+        // The real status values, read from production rather than guessed.
+        // The first version filtered on 'pending', 'proposed' and
+        // 'awaiting_review' — none of which exist in this table, so the hook
+        // returned zero rows unconditionally and no recommendation card could
+        // ever render. Live distribution: idea 90, executed 49, deleted 49,
+        // approved 11, deciding 9, discussing 9, simulating 6.
+        //
+        // These four are the ones still awaiting a decision. 'approved' is
+        // already decided and 'executed' is done, so neither belongs on a card
+        // whose primary action is Approve.
+        .in('status', ['idea', 'deciding', 'discussing', 'simulating'])
         .order('created_at', { ascending: false })
         .limit(40)
 

--- a/src/lib/flags.ts
+++ b/src/lib/flags.ts
@@ -51,11 +51,14 @@ function write(set: Set<string>): void {
 /**
  * Apply any `?flag=` in the current URL, then report the active set.
  *
- * Called from `isFlagOn` rather than at module load so that a flag set by URL
- * takes effect on the first render that asks for it, including on a cold start
- * where the app mounts before any effect runs.
+ * Called from `main.tsx` before React mounts, NOT lazily from the screen that
+ * uses the flag. The root route redirects with `<Navigate to="/dashboard"
+ * replace />`, which discards the query string — so by the time the feed
+ * rendered and asked, the parameter was already gone and the flag silently
+ * never set. Reading it at entry is the only point that survives both the
+ * auth redirect and the dashboard redirect.
  */
-function syncFromUrl(): Set<string> {
+export function syncFlagsFromUrl(): Set<string> {
   const flags = read()
   if (typeof window === 'undefined') return flags
   const param = new URLSearchParams(window.location.search).get('flag')
@@ -88,8 +91,14 @@ function syncFromUrl(): Set<string> {
 let cached: Set<string> | null = null
 
 export function isFlagOn(name: FlagName): boolean {
-  if (cached === null) cached = syncFromUrl()
+  if (cached === null) cached = syncFlagsFromUrl()
   return cached.has(name)
+}
+
+/** Every flag currently on, for the debug indicator. */
+export function activeFlags(): string[] {
+  if (cached === null) cached = syncFlagsFromUrl()
+  return [...cached].sort()
 }
 
 /** Testing seam. */

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,14 @@
 import { StrictMode } from 'react'
+// Consume ?flag= before React mounts. The root route redirects with
+// <Navigate to="/dashboard" replace />, which drops the query string, so a
+// flag read inside any screen is read after the parameter is already gone.
+syncFlagsFromUrl()
+
 import { createRoot } from 'react-dom/client'
 import * as Sentry from '@sentry/react'
 import './index.css'
 import App from './App.tsx'
+import { syncFlagsFromUrl } from './lib/flags'
 
 // Sentry — must initialize before render so it can catch React errors.
 // We only init when a DSN is present, so local dev never reports out.


### PR DESCRIPTION
The flag has never been on for anyone: the root route's `<Navigate replace>` dropped the query string before any screen read it. Now consumed in main.tsx before React mounts.

Plus a loud banner reporting the flag AND the contract-card count, and a status filter that matches values that actually exist in trade_queue_items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)