### PR TITLE
docs: close the distinct-vs-current collapse as a class

### DIFF
--- a/docs/handoff.md
+++ b/docs/handoff.md
@@ -279,6 +279,51 @@ id**).
 
 ---
 
+## 5b. Pilot prerequisites (not nice-to-haves)
+
+**A licensed quote source.** The seed and the scenario cards use Yahoo's
+`query1.finance.yahoo.com/v8/finance/chart` endpoint. It is undocumented,
+unlicensed, and internal to Yahoo — fine for a demo tenant, not fine for pilot
+users at regulated firms whose compliance teams will ask where prices come
+from. Quotes must sit behind an interface so the provider can be swapped
+without touching any builder. Verified working 2026-08-17 for AAPL/MSFT/NVDA/
+TSLA/AMZN, 8/8 rapid calls returned 200 — and it is a bot-interstitial risk of
+the same class as iShares and Invesco, both of which return HTTP 200 with HTML.
+Assume it can vanish.
+
+**SSGA is the only working benchmark issuer.** iShares and Invesco return
+HTTP 200 with bot interstitials. That class of block escalates.
+
+## 5c. The distinct-vs-current collapse is a CLASS, not an instance
+
+`portfolio_holdings` is a series of dated snapshots, not a position list.
+Reading it without constraining the date treats every historical snapshot as a
+current position.
+
+Confirmed instance: `usePortfolioLenses` summed value across all dates for its
+denominator, inflating each portfolio total by its number of snapshot dates —
+measured at 36x on Tech & Consumer Growth, 27x on Vision Fund 10K. Every weight
+was up to 36x too small, and because `MIN_WEIGHT_PCT` rejects anything under
+0.5%, the conviction cards emitted NOTHING rather than something visibly wrong.
+Live and unflagged for the life of that code.
+
+`scripts/holdings-collapse-audit.mjs` enumerates the class:
+
+```
+portfolio_holdings query sites : 54
+  aggregating                  : 27
+  aggregating WITHOUT a date   : 22
+  non-aggregating (excluded)   : 27
+```
+
+21 of those 22 select `shares, price` (or `shares, cost`) and sum them —
+AssetTab, QuickTradeIdeaCapture, AddTradeIdeaModal, CreateSimulationModal,
+TradeIdeaDetailModal, SimulationPage, TradeQueuePage. All are exposed to the
+same inflation. Only `usePortfolioLenses` has been fixed.
+
+The remediation is one shared helper that returns the newest snapshot per
+portfolio, not 21 separate date filters — a per-site fix will drift.
+
 ## 6. Queue, in order
 
 1. **Fix active-risk benchmark suppression.** Emit `insufficient_coverage` when

--- a/scripts/holdings-collapse-audit.mjs
+++ b/scripts/holdings-collapse-audit.mjs
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+/**
+ * Enumerates every query over `portfolio_holdings` and classifies it.
+ *
+ * `portfolio_holdings` is a series of DATED SNAPSHOTS, not a position list.
+ * Reading it without constraining the date treats every historical snapshot as
+ * a current position — the distinct-vs-current collapse.
+ *
+ * It corrupted production silently: `usePortfolioLenses` summed value across all
+ * dates for its denominator, inflating each portfolio's total by its number of
+ * snapshot dates (measured at 36x). Every weight was up to 36x too small, and
+ * because MIN_WEIGHT_PCT rejects anything under 0.5%, the conviction cards
+ * emitted nothing rather than something visibly wrong.
+ *
+ * Not every site is wrong. A query that only needs the SET of names a portfolio
+ * has ever held — "which portfolios hold this?" — is unaffected by duplicates.
+ * The dangerous ones are those that sum, average, or compute a denominator.
+ *
+ * This prints the classification so the class can be closed by inspection
+ * rather than estimated.
+ */
+import { readdirSync, readFileSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+const roots = ['src', 'supabase/functions']
+const files = []
+const walk = (dir) => {
+  let entries
+  try { entries = readdirSync(dir) } catch { return }
+  for (const e of entries) {
+    if (e === 'node_modules') continue
+    const p = join(dir, e)
+    if (statSync(p).isDirectory()) walk(p)
+    else if (/\.(ts|tsx)$/.test(e)) files.push(p.split('\\').join('/'))
+  }
+}
+roots.forEach(walk)
+
+/** Constrains the snapshot date in the query or immediately after it. */
+const DATED = /\.eq\('date'|\.gte\('date'|\.lte\('date'|\.order\('date'|max\(date\)|latestDate|latest_date/
+
+/** Sums, averages, or builds a denominator from the rows. */
+const AGGREGATES = /reduce\(|totals?\b|weightPct|weight_pct|\/\s*total|percent|\*\s*100\b/
+
+const sites = []
+for (const f of files) {
+  const src = readFileSync(f, 'utf8')
+  const re = /\.from\('portfolio_holdings'\)/g
+  let m
+  while ((m = re.exec(src))) {
+    const line = src.slice(0, m.index).split('\n').length
+    const block = src.slice(m.index, m.index + 2500)
+    sites.push({ file: f, line, dated: DATED.test(block), aggregates: AGGREGATES.test(block) })
+  }
+}
+
+const agg = sites.filter(s => s.aggregates)
+const risky = agg.filter(s => !s.dated)
+
+console.log(`portfolio_holdings query sites : ${sites.length}`)
+console.log(`  aggregating                  : ${agg.length}`)
+console.log(`  aggregating WITHOUT a date   : ${risky.length}   <-- must be checked by hand`)
+console.log(`  non-aggregating (excluded)   : ${sites.length - agg.length}`)
+
+console.log('\nAGGREGATING SITES:')
+for (const s of agg.sort((a, b) => a.file.localeCompare(b.file))) {
+  console.log(`  ${s.dated ? 'DATED  ' : 'NO-DATE'}  ${s.file}:${s.line}`)
+}


### PR DESCRIPTION
Enumerated, not estimated: 54 holdings query sites, 27 aggregating, 22 without a date constraint, 21 of which sum shares and price.

Also records the licensed-quote-source pilot prerequisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)