### PR TITLE
fix(feed): every tile fills the screen; outdated-case signals can finally fire

### DIFF
--- a/src/components/mobile/MobileDashboard.tsx
+++ b/src/components/mobile/MobileDashboard.tsx
@@ -874,7 +874,14 @@ export function MobileDashboard({
               : undefined
             if (asRecommendation) {
               return (
-                <div key={a.attention_id} ref={track({ assetId: a.context?.asset_id ?? null, kind: 'attention' })}>
+                                <div
+                  key={a.attention_id}
+                  // h-full, or the SignalCardSection inside collapses to content
+                  // height: `h-full` resolves against the PARENT, and a bare
+                  // wrapper div has none. That is why the market card rendered at
+                  // half a screen while the scenario cards — which render the
+                  // section directly, with no wrapper — filled it.
+                  className="h-full w-full" ref={track({ assetId: a.context?.asset_id ?? null, kind: 'attention' })}>
                   <SignalCardSection
                     card={asRecommendation}
                     onOpenAsset={openAsset}
@@ -990,7 +997,7 @@ export function MobileDashboard({
               const built = activeRiskByAsset.get(c.assetId)
               if (built) {
                 return (
-                  <div key={c.id} ref={track({ assetId: c.assetId ?? null, kind: 'template' })}>
+                  <div key={c.id} className="h-full w-full" ref={track({ assetId: c.assetId ?? null, kind: 'template' })}>
                     <SignalCardSection
                       card={built}
                       onOpenAsset={openAsset}
@@ -1045,7 +1052,7 @@ export function MobileDashboard({
               // already logged with its reason by gate().
               if (!built.ok) return null
               return (
-                <div key={n.id} ref={track({ assetId: null, kind: 'news' })}>
+                <div key={n.id} className="h-full w-full" ref={track({ assetId: null, kind: 'news' })}>
                   <SignalCardSection
                     card={built.card}
                   onOpenAsset={openAsset}

--- a/src/hooks/mobile/usePortfolioLenses.ts
+++ b/src/hooks/mobile/usePortfolioLenses.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../../lib/supabase'
 import { useOrganizationOptional } from '../../contexts/OrganizationContext'
+import { timeframeMonths } from '../../lib/signals/timeframe'
 
 /**
  * Four questions about the book that no existing screen asks.
@@ -126,15 +127,6 @@ const MIN_WEIGHT_PCT = 0.5
 /** A target this far past its own horizon has stopped being a view. */
 const OVERDUE_MONTHS = 2
 
-/** Parse "12M", "18M", "3Y" into months. */
-function timeframeMonths(tf: string | null | undefined): number | null {
-  if (!tf) return null
-  const m = /^(\d+)\s*([MY])$/i.exec(tf.trim())
-  if (!m) return null
-  const n = Number(m[1])
-  if (!Number.isFinite(n) || n <= 0) return null
-  return m[2].toUpperCase() === 'Y' ? n * 12 : n
-}
 
 export function usePortfolioLenses(options?: { enabled?: boolean }) {
   const currentOrgId = useOrganizationOptional()?.currentOrgId ?? null

--- a/src/lib/signals/__tests__/timeframe.test.ts
+++ b/src/lib/signals/__tests__/timeframe.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { timeframeMonths } from '../timeframe'
+
+/**
+ * The long-form cases are the exact strings in production. The previous parser
+ * matched none of them, so "outdated case" signals never rendered.
+ */
+describe('timeframeMonths', () => {
+  it('parses every form that exists in production', () => {
+    // 30 of 30 rows in analyst_price_targets use this shape.
+    expect(timeframeMonths('12 months')).toBe(12)
+    expect(timeframeMonths('6 months')).toBe(6)
+    expect(timeframeMonths('3 months')).toBe(3)
+    expect(timeframeMonths('11 months')).toBe(11)
+  })
+
+  it('still parses the short form the old parser expected', () => {
+    // Rejecting half a corpus is how the original defect happened; accepting
+    // both costs nothing.
+    expect(timeframeMonths('12M')).toBe(12)
+    expect(timeframeMonths('3Y')).toBe(36)
+    expect(timeframeMonths('18 mos')).toBe(18)
+    expect(timeframeMonths('2 years')).toBe(24)
+  })
+
+  it('is case and whitespace insensitive', () => {
+    expect(timeframeMonths('  12 MONTHS ')).toBe(12)
+    expect(timeframeMonths('1Y')).toBe(12)
+  })
+
+  it('rejects anything it cannot read rather than guessing', () => {
+    // Anchored at both ends: a permissive parser that reads "12 monthly
+    // reviews" as 12 months would put a fabricated horizon on a card.
+    expect(timeframeMonths('12 monthly reviews')).toBeNull()
+    expect(timeframeMonths('next quarter')).toBeNull()
+    expect(timeframeMonths('')).toBeNull()
+    expect(timeframeMonths(null)).toBeNull()
+    expect(timeframeMonths('0 months')).toBeNull()
+    expect(timeframeMonths('-6 months')).toBeNull()
+  })
+})

--- a/src/lib/signals/timeframe.ts
+++ b/src/lib/signals/timeframe.ts
@@ -1,0 +1,36 @@
+/**
+ * Parse a price-target horizon into months.
+ *
+ * This exists because the previous parser matched a format the product does not
+ * produce. It was `/^(\d+)\s*([MY])$/i` — "12M", "3Y" — while every one of the
+ * 30 rows in `analyst_price_targets` stores the long form:
+ *
+ *   "12 months" x21   "6 months" x7   "3 months" x1   "11 months" x1
+ *
+ * Zero matched. `timeframeMonths` therefore returned null for every target, the
+ * stale-target branch it guards never ran, and "outdated case" signals never
+ * rendered once in the life of that code. Not degraded — absent, silently, in
+ * exactly the way the conviction cards were absent.
+ *
+ * Both forms are accepted now, because the short form may exist in older rows
+ * or arrive from an importer, and a parser that rejects half the corpus is how
+ * this happened in the first place.
+ */
+
+/** "12 months", "12M", "3 years", "3Y", "18 mos" -> months. */
+export function timeframeMonths(tf: string | null | undefined): number | null {
+  if (!tf) return null
+  const s = tf.trim().toLowerCase()
+  if (!s) return null
+
+  // Number, optional space, then a unit that starts with m or y. Anchored at
+  // both ends so "12 monthly reviews" is rejected rather than silently read as
+  // 12 months.
+  const m = /^(\d+(?:\.\d+)?)\s*(m|mo|mos|month|months|y|yr|yrs|year|years)$/.exec(s)
+  if (!m) return null
+
+  const n = Number(m[1])
+  if (!Number.isFinite(n) || n <= 0) return null
+
+  return m[2].startsWith('y') ? Math.round(n * 12) : Math.round(n)
+}


### PR DESCRIPTION
Half-screen market tile: three wrapper divs had no height, so the h-full section collapsed to content.

Outdated-case signals have NEVER rendered: the horizon parser matched "12M" while all 30 production rows store "12 months". Third card kind found absent rather than degraded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)