### PR TITLE
fix: quotes were dead (502), and the holdings collapse class is closed

### DIFF
--- a/netlify/functions/quote.mjs
+++ b/netlify/functions/quote.mjs
@@ -1,0 +1,98 @@
+/**
+ * quote — fetch a Yahoo Finance chart payload for one symbol.
+ *
+ * This lives on Netlify rather than in supabase/functions/ for exactly the
+ * reason article-extract does: network egress. The Supabase edge function
+ * `yahoo-chart-proxy` is deployed and ACTIVE and returns **502 Bad Gateway** on
+ * every call — Yahoo refuses Supabase's datacenter egress at the connection
+ * level, the same refusal that made the article reader useless there.
+ *
+ * The consequence was not a degraded feed, it was an empty one. `getQuote`
+ * returned null for every symbol, so every scenario card suppressed with
+ * `quote_unavailable` and no signal content rendered at all. The suppression
+ * behaved correctly; the data path under it was dead.
+ *
+ * Verified from this machine before writing this: the same Yahoo endpoint
+ * returns 200 with live prices for AAPL, MSFT, NVDA, TSLA and AMZN, 8/8 on
+ * rapid successive calls. Netlify runs on different infrastructure again, which
+ * is the same lever article-extract already pulled successfully.
+ *
+ * If Yahoo blocks this egress too, the honest fix is a licensed quote API — a
+ * pilot prerequisite already recorded in docs/handoff.md — not a third proxy
+ * hop. Callers already treat a null quote as "unknown" and suppress, so a block
+ * degrades to silence rather than to a wrong number.
+ *
+ * Dependency-free on purpose.
+ */
+
+const FETCH_TIMEOUT_MS = 10_000
+const ALLOWED_RANGES = new Set(['1d', '5d', '1mo', '3mo', '6mo', '1y', '2y', '5y'])
+const ALLOWED_INTERVALS = new Set(['1m', '5m', '15m', '1d', '1wk', '1mo'])
+
+const json = (status, body) => new Response(JSON.stringify(body), {
+  status,
+  headers: {
+    'content-type': 'application/json',
+    // The browser calls this from the app origin; Netlify serves both, so this
+    // is same-origin in production. The header is here for `netlify dev`, which
+    // serves functions on a different port.
+    'access-control-allow-origin': '*',
+    'access-control-allow-headers': 'content-type',
+    // Quotes are worth a few seconds of edge caching: a feed asks for the same
+    // handful of symbols repeatedly on one render pass. Shorter than the
+    // 15-minute freshness ceiling in suppression.ts, so a cached response can
+    // never be the reason a card claims to be fresher than it is.
+    'cache-control': 'public, max-age=30',
+  },
+})
+
+export default async (request) => {
+  if (request.method === 'OPTIONS') return json(204, {})
+
+  const url = new URL(request.url)
+  const symbol = (url.searchParams.get('symbol') || '').trim().toUpperCase()
+  const range = url.searchParams.get('range') || '5d'
+  const interval = url.searchParams.get('interval') || '1d'
+
+  // Symbols reach this from user data, so the shape is constrained rather than
+  // interpolated blind — a ticker is letters, digits, dot, dash, caret.
+  if (!symbol || !/^[A-Z0-9.\-^]{1,12}$/.test(symbol)) {
+    return json(400, { error: 'bad symbol' })
+  }
+  if (!ALLOWED_RANGES.has(range) || !ALLOWED_INTERVALS.has(interval)) {
+    return json(400, { error: 'bad range or interval' })
+  }
+
+  const target =
+    `https://query1.finance.yahoo.com/v8/finance/chart/${encodeURIComponent(symbol)}` +
+    `?range=${range}&interval=${interval}`
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+  try {
+    const res = await fetch(target, {
+      signal: controller.signal,
+      headers: {
+        // Yahoo serves an interstitial to obviously-automated clients. This is
+        // the same shape the working manual test used.
+        'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36',
+        accept: 'application/json,text/plain,*/*',
+      },
+    })
+    if (!res.ok) return json(502, { error: `upstream ${res.status}` })
+
+    const text = await res.text()
+    // A 200 carrying HTML is a bot interstitial, not data. Returning it as JSON
+    // would hand the client something well-formed and wrong, which is the exact
+    // failure mode the placeholder quote used to have.
+    if (!text.startsWith('{')) return json(502, { error: 'upstream returned non-json' })
+
+    return json(200, JSON.parse(text))
+  } catch (e) {
+    return json(502, { error: e?.name === 'AbortError' ? 'upstream timeout' : 'upstream unreachable' })
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+export const config = { path: '/api/quote' }

--- a/scripts/holdings-collapse-audit.mjs
+++ b/scripts/holdings-collapse-audit.mjs
@@ -13,14 +13,9 @@
  * times too small, and because MIN_WEIGHT_PCT rejects anything under 0.5% the
  * conviction cards emitted NOTHING rather than something visibly wrong.
  *
- * An audit found 22 of 27 aggregating sites had no date constraint. The defect
- * was the norm. One has been fixed; the rest are listed below and MUST ONLY
- * SHRINK.
- *
- * The allowlist is the honest form of "not yet migrated". It is not an
- * exemption: every entry is a site that will silently inflate the moment its
- * portfolio has more than one snapshot date, which the seeded tenant will
- * deliberately produce.
+ * An audit found 22 of 27 aggregating sites had no date constraint — the defect
+ * was the norm rather than the outlier. All of them are now migrated, so the
+ * allowlist below is empty and adding to it is a regression.
  */
 import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
@@ -40,7 +35,14 @@ const walk = (dir) => {
 roots.forEach(walk)
 
 /** Constrains the snapshot date, or defers to the shared helper. */
-const SAFE = /\.eq\('date'|\.gte\('date'|\.lte\('date'|\.order\('date'|max\(date\)|latestSnapshotRows/
+/**
+ * Constrains the date, defers to the shared helper, or is explicitly marked
+ * reviewed-and-safe. The marker is for queries that build a SET rather than a
+ * sum — duplicates across snapshots cannot change a set — and it must carry a
+ * reason on the line, so a future reader can check the claim rather than trust
+ * the comment.
+ */
+const SAFE = /\.eq\('date'|\.gte\('date'|\.lte\('date'|\.order\('date'|max\(date\)|latestSnapshotRows|holdings-audit: safe/
 
 /** Sums, averages, or builds a denominator from the rows. */
 const AGGREGATES = /reduce\(|totals?\b|weightPct|weight_pct|\/\s*total|percent|\*\s*100\b/
@@ -50,29 +52,14 @@ const AGGREGATES = /reduce\(|totals?\b|weightPct|weight_pct|\/\s*total|percent|\
  * latestSnapshotRows. MAY ONLY SHRINK. Adding an entry is a regression and
  * should be rejected in review, not appended to.
  */
-const NOT_YET_MIGRATED = new Set([
-  'src/components/tabs/AssetTab.tsx:982',
-  'src/components/tabs/AssetTab.tsx:1009',
-  'src/components/thoughts/QuickTradeIdeaCapture.tsx:414',
-  'src/components/thoughts/QuickTradeIdeaCapture.tsx:433',
-  'src/components/thoughts/QuickTradeIdeaCapture.tsx:442',
-  'src/components/trading/AddTradeIdeaModal.tsx:197',
-  'src/components/trading/AddTradeIdeaModal.tsx:216',
-  'src/components/trading/AddTradeIdeaModal.tsx:225',
-  'src/components/trading/AddTradeIdeaModal.tsx:487',
-  'src/components/trading/CreateSimulationModal.tsx:85',
-  'src/components/trading/TradeIdeaDetailModal.tsx:458',
-  'src/components/trading/TradeIdeaDetailModal.tsx:468',
-  'src/components/trading/TradeIdeaDetailModal.tsx:855',
-  'src/components/trading/TradeIdeaDetailModal.tsx:864',
-  'src/components/trading/TradeIdeaDetailModal.tsx:912',
-  'src/components/trading/TradeIdeaDetailModal.tsx:921',
-  'src/hooks/ideas/useIdeasFeed.ts:109',
-  'src/pages/SimulationPage.tsx:837',
-  'src/pages/SimulationPage.tsx:1650',
-  'src/pages/SimulationPage.tsx:2726',
-  'src/pages/TradeQueuePage.tsx:1377',
-])
+/**
+ * EMPTY, and it must stay that way.
+ *
+ * All 21 sites have been migrated to latestSnapshotRows(), or — in one case —
+ * reviewed and marked `holdings-audit: safe` because it builds a Set rather
+ * than a sum. Adding an entry here is a regression, not a workaround.
+ */
+const NOT_YET_MIGRATED = new Set([])
 
 const sites = []
 for (const f of files) {
@@ -95,6 +82,11 @@ console.log(`portfolio_holdings query sites : ${sites.length}`)
 console.log(`  aggregating                  : ${agg.length}`)
 console.log(`  aggregating without a date   : ${unsafe.length}`)
 console.log(`  awaiting migration (allowed) : ${NOT_YET_MIGRATED.size}`)
+
+if (process.argv.includes('--list')) {
+  console.log('\nUNSAFE SITES (aggregating, no date constraint):')
+  unsafe.forEach(s => console.log(`  ${s.id}`))
+}
 
 if (unlisted.length) {
   console.error(`\nFAIL: ${unlisted.length} NEW aggregating query/queries with no date constraint:`)

--- a/src/components/tabs/AssetTab.tsx
+++ b/src/components/tabs/AssetTab.tsx
@@ -53,6 +53,7 @@ import { useUserAssetWidgets, type WidgetType } from '../../hooks/useUserAssetWi
 import { supabase } from '../../lib/supabase'
 import { formatDistanceToNow } from 'date-fns'
 import { calculateAssetCompleteness } from '../../utils/assetCompleteness'
+import { latestSnapshotRows } from '../../lib/holdings/latest-snapshot'
 
 // Visibility options for thesis sections
 const VISIBILITY_OPTIONS: { value: ContributionVisibility; label: string; icon: React.ElementType; description: string }[] = [
@@ -978,7 +979,7 @@ export function AssetTab({ asset, onCite, onNavigate, isFocusMode = false }: Ass
   const { data: portfolioHoldings } = useQuery({
     queryKey: ['portfolio-holdings', asset.id],
     queryFn: async () => {
-      const { data, error } = await supabase
+      const { data: holdingRows, error } = await supabase
         .from('portfolio_holdings')
         .select(`
           *,
@@ -1005,12 +1006,15 @@ export function AssetTab({ asset, onCite, onNavigate, isFocusMode = false }: Ass
       const totals: Record<string, number> = {}
 
       for (const portfolioId of portfolioIds) {
-        const { data, error } = await supabase
+        const { data: costRows, error } = await supabase
           .from('portfolio_holdings')
-          .select('shares, cost')
+          .select('shares, cost, date')
           .eq('portfolio_id', portfolioId)
 
         if (error) throw error
+        // Dated snapshots: summing every row multiplies cost basis by the
+        // number of uploads. See src/lib/holdings/latest-snapshot.ts.
+        const data = latestSnapshotRows(costRows ?? [])
 
         // Calculate total cost (cost basis) for this portfolio
         const totalCost = (data || []).reduce((sum, holding) => {

--- a/src/components/thoughts/QuickTradeIdeaCapture.tsx
+++ b/src/components/thoughts/QuickTradeIdeaCapture.tsx
@@ -14,6 +14,7 @@ import { clsx } from 'clsx'
 import type { TradeAction } from '../../types/trading'
 import { inferProvenance, type Provenance } from '../../lib/provenance'
 import { ContextTagsInput, type ContextTag } from '../ui/ContextTagsInput'
+import { latestSnapshotRows } from '../../lib/holdings/latest-snapshot'
 
 // Shape of a row returned by the duplicate-idea queries below. Kept loose
 // since we only project a handful of columns and don't need a full type.
@@ -429,19 +430,25 @@ export function QuickTradeIdeaCapture({
       if (selectedPortfolioIds.length === 0 || !currentAssetId) return []
 
       // Get holdings for the selected asset in all selected portfolios
-      const { data: assetHoldings, error: assetError } = await supabase
+      const { data: assetHoldingsRaw, error: assetError } = await supabase
         .from('portfolio_holdings')
-        .select('portfolio_id, shares, price')
+        .select('portfolio_id, shares, price, date')
         .eq('asset_id', currentAssetId)
         .in('portfolio_id', selectedPortfolioIds)
+      // portfolio_holdings is a series of dated snapshots; summing every row
+      // multiplies the total by the number of dates. See latest-snapshot.ts.
+      const assetHoldings = latestSnapshotRows(assetHoldingsRaw ?? [])
 
       if (assetError) throw assetError
 
       // Get total portfolio values for weight calculation
-      const { data: allHoldings, error: allError } = await supabase
+      const { data: allHoldingsRaw, error: allError } = await supabase
         .from('portfolio_holdings')
-        .select('portfolio_id, shares, price')
+        .select('portfolio_id, shares, price, date')
         .in('portfolio_id', selectedPortfolioIds)
+      // portfolio_holdings is a series of dated snapshots; summing every row
+      // multiplies the total by the number of dates. See latest-snapshot.ts.
+      const allHoldings = latestSnapshotRows(allHoldingsRaw ?? [])
 
       if (allError) throw allError
 

--- a/src/components/trading/AddTradeIdeaModal.tsx
+++ b/src/components/trading/AddTradeIdeaModal.tsx
@@ -12,6 +12,7 @@ import { ContextTagsInput, type ContextTag } from '../ui/ContextTagsInput'
 import { inferProvenance, type Provenance } from '../../lib/provenance'
 import type { TradeAction, PairLegType } from '../../types/trading'
 import { clsx } from 'clsx'
+import { latestSnapshotRows } from '../../lib/holdings/latest-snapshot'
 
 // Visibility options - must match database constraint: 'private', 'team', 'public'
 type VisibilityOption = 'private' | 'team'
@@ -212,19 +213,25 @@ export function AddTradeIdeaModal({
       if (selectedPortfolioIds.length === 0 || !assetId) return []
 
       // Get holdings for the selected asset in all selected portfolios
-      const { data: assetHoldings, error: assetError } = await supabase
+      const { data: assetHoldingsRaw, error: assetError } = await supabase
         .from('portfolio_holdings')
-        .select('portfolio_id, shares, price')
+        .select('portfolio_id, shares, price, date')
         .eq('asset_id', assetId)
         .in('portfolio_id', selectedPortfolioIds)
+      // portfolio_holdings is a series of dated snapshots; summing every row
+      // multiplies the total by the number of dates. See latest-snapshot.ts.
+      const assetHoldings = latestSnapshotRows(assetHoldingsRaw ?? [])
 
       if (assetError) throw assetError
 
       // Get total portfolio values for weight calculation
-      const { data: allHoldings, error: allError } = await supabase
+      const { data: allHoldingsRaw, error: allError } = await supabase
         .from('portfolio_holdings')
-        .select('portfolio_id, shares, price')
+        .select('portfolio_id, shares, price, date')
         .in('portfolio_id', selectedPortfolioIds)
+      // portfolio_holdings is a series of dated snapshots; summing every row
+      // multiplies the total by the number of dates. See latest-snapshot.ts.
+      const allHoldings = latestSnapshotRows(allHoldingsRaw ?? [])
 
       if (allError) throw allError
 
@@ -260,13 +267,16 @@ export function AddTradeIdeaModal({
     queryKey: ['asset-price', assetId],
     queryFn: async () => {
       // First try to get from portfolio_holdings (most recent price)
-      const { data: holdingData } = await supabase
+      const { data: holdingDataRaw } = await supabase
         .from('portfolio_holdings')
-        .select('price')
+        .select('price, date')
         .eq('asset_id', assetId)
         .gt('price', 0)
         .limit(1)
         .single()
+      // portfolio_holdings is a series of dated snapshots; summing every row
+      // multiplies the total by the number of dates. See latest-snapshot.ts.
+      const holdingData = latestSnapshotRows(holdingDataRaw ?? [])
 
       if (holdingData?.price) return holdingData.price
 
@@ -483,13 +493,14 @@ export function AddTradeIdeaModal({
   const { data: portfolioHoldings } = useQuery({
     queryKey: ['portfolio-holdings', firstSelectedPortfolioId],
     queryFn: async () => {
-      const { data, error } = await supabase
+      const { data: rows, error } = await supabase
         .from('portfolio_holdings')
-        .select('asset_id, shares, price')
+        .select('asset_id, shares, price, date')
         .eq('portfolio_id', firstSelectedPortfolioId!)
 
       if (error) throw error
-      return data
+      // Dated snapshots — only the newest is a current position.
+      return latestSnapshotRows(rows ?? [])
     },
     enabled: !!firstSelectedPortfolioId,
   })

--- a/src/components/trading/CreateSimulationModal.tsx
+++ b/src/components/trading/CreateSimulationModal.tsx
@@ -9,6 +9,7 @@ import { Input } from '../ui/Input'
 import { TextArea } from '../ui/TextArea'
 import type { TradeQueueItemWithDetails, BaselineHolding } from '../../types/trading'
 import { clsx } from 'clsx'
+import { latestSnapshotRows } from '../../lib/holdings/latest-snapshot'
 
 interface CreateSimulationModalProps {
   isOpen: boolean
@@ -81,7 +82,7 @@ export function CreateSimulationModal({
   const { data: holdings } = useQuery({
     queryKey: ['portfolio-holdings', portfolioId],
     queryFn: async () => {
-      const { data, error } = await supabase
+      const { data: holdingRows, error } = await supabase
         .from('portfolio_holdings')
         .select(`
           *,
@@ -90,6 +91,9 @@ export function CreateSimulationModal({
         .eq('portfolio_id', portfolioId)
 
       if (error) throw error
+      // Dated snapshots — a simulation baseline built from every upload would
+      // be the sum of the portfolio's whole history.
+      const data = latestSnapshotRows(holdingRows ?? [])
       return data
     },
     enabled: isOpen && !!portfolioId,

--- a/src/components/trading/TradeIdeaDetailModal.tsx
+++ b/src/components/trading/TradeIdeaDetailModal.tsx
@@ -69,6 +69,7 @@ import { ThesesDebatePanel } from './ThesesDebatePanel'
 // AddThesisModal replaced by inline composers in ThesesDebatePanel
 import { useThesisCounts, useTheses } from '../../hooks/useTheses'
 import { LinkedResearchSection } from './LinkedResearchSection'
+import { latestSnapshotRows } from '../../lib/holdings/latest-snapshot'
 
 type ModalTab = 'details' | 'debate' | 'discussion' | 'decisions' | 'activity'
 
@@ -454,20 +455,26 @@ export function TradeIdeaDetailModal({ isOpen, tradeId, onClose, initialTab = 'd
       let portfolioAum = 0
 
       if (pairTradePortfolioId) {
-        const { data: holdings, error: holdingsError } = await supabase
+        const { data: holdingsRaw, error: holdingsError } = await supabase
           .from('portfolio_holdings')
-          .select('asset_id, shares, price')
+          .select('asset_id, shares, price, date')
           .eq('portfolio_id', pairTradePortfolioId)
           .in('asset_id', pairTradeLegAssetIds)
+        // portfolio_holdings is a series of dated snapshots; summing every row
+        // multiplies the total by the number of dates. See latest-snapshot.ts.
+        const holdings = latestSnapshotRows(holdingsRaw ?? [])
 
         if (holdingsError) throw holdingsError
         assetHoldings = holdings || []
 
         // Get total portfolio value (AUM)
-        const { data: allHoldings, error: allError } = await supabase
+        const { data: allHoldingsRaw, error: allError } = await supabase
           .from('portfolio_holdings')
-          .select('shares, price')
+          .select('shares, price, date')
           .eq('portfolio_id', pairTradePortfolioId)
+        // portfolio_holdings is a series of dated snapshots; summing every row
+        // multiplies the total by the number of dates. See latest-snapshot.ts.
+        const allHoldings = latestSnapshotRows(allHoldingsRaw ?? [])
 
         if (allError) throw allError
 
@@ -851,19 +858,25 @@ export function TradeIdeaDetailModal({ isOpen, tradeId, onClose, initialTab = 'd
       if (!trade?.asset_id || linkedPortfolioIds.length === 0) return []
 
       // Get holdings for the asset in all linked portfolios
-      const { data: assetHoldings, error: assetError } = await supabase
+      const { data: assetHoldingsRaw, error: assetError } = await supabase
         .from('portfolio_holdings')
-        .select('portfolio_id, shares, price')
+        .select('portfolio_id, shares, price, date')
         .eq('asset_id', trade.asset_id)
         .in('portfolio_id', linkedPortfolioIds)
+      // portfolio_holdings is a series of dated snapshots; summing every row
+      // multiplies the total by the number of dates. See latest-snapshot.ts.
+      const assetHoldings = latestSnapshotRows(assetHoldingsRaw ?? [])
 
       if (assetError) throw assetError
 
       // Get total portfolio values for weight calculation
-      const { data: allHoldings, error: allError } = await supabase
+      const { data: allHoldingsRaw, error: allError } = await supabase
         .from('portfolio_holdings')
-        .select('portfolio_id, shares, price')
+        .select('portfolio_id, shares, price, date')
         .in('portfolio_id', linkedPortfolioIds)
+      // portfolio_holdings is a series of dated snapshots; summing every row
+      // multiplies the total by the number of dates. See latest-snapshot.ts.
+      const allHoldings = latestSnapshotRows(allHoldingsRaw ?? [])
 
       if (allError) throw allError
 
@@ -908,19 +921,25 @@ export function TradeIdeaDetailModal({ isOpen, tradeId, onClose, initialTab = 'd
       if (pairTradeLegAssetIds.length === 0 || pairTradeProposalPortfolioIds.length === 0) return {}
 
       // Get holdings for all leg assets in all proposal portfolios
-      const { data: holdings, error: holdingsError } = await supabase
+      const { data: holdingsRaw, error: holdingsError } = await supabase
         .from('portfolio_holdings')
-        .select('portfolio_id, asset_id, shares, price')
+        .select('portfolio_id, asset_id, shares, price, date')
         .in('portfolio_id', pairTradeProposalPortfolioIds)
         .in('asset_id', pairTradeLegAssetIds)
+      // portfolio_holdings is a series of dated snapshots; summing every row
+      // multiplies the total by the number of dates. See latest-snapshot.ts.
+      const holdings = latestSnapshotRows(holdingsRaw ?? [])
 
       if (holdingsError) throw holdingsError
 
       // Get total portfolio values for weight calculation
-      const { data: allHoldings, error: allError } = await supabase
+      const { data: allHoldingsRaw, error: allError } = await supabase
         .from('portfolio_holdings')
-        .select('portfolio_id, shares, price')
+        .select('portfolio_id, shares, price, date')
         .in('portfolio_id', pairTradeProposalPortfolioIds)
+      // portfolio_holdings is a series of dated snapshots; summing every row
+      // multiplies the total by the number of dates. See latest-snapshot.ts.
+      const allHoldings = latestSnapshotRows(allHoldingsRaw ?? [])
 
       if (allError) throw allError
 

--- a/src/hooks/ideas/useIdeasFeed.ts
+++ b/src/hooks/ideas/useIdeasFeed.ts
@@ -107,6 +107,9 @@ function useUserContext() {
       if (!user) return new Set<string>()
       const { data } = await supabase
         .from('portfolio_holdings')
+        // holdings-audit: safe — builds a Set of asset ids, and a set is
+        // unaffected by the same asset appearing on several snapshot dates.
+        // No sum, no denominator, so latestSnapshotRows would change nothing.
         .select('asset_id, portfolios!inner(id)')
       const ids = new Set<string>()
       for (const h of data || []) if (h.asset_id) ids.add(h.asset_id)

--- a/src/lib/financial-data/browser-client.ts
+++ b/src/lib/financial-data/browser-client.ts
@@ -216,11 +216,90 @@ export class BrowserFinancialService {
     }
   }
 
+  /**
+   * One parser for both egress paths.
+   *
+   * The Netlify function and the Supabase edge function return the identical
+   * Yahoo chart payload, so the parsing must not be duplicated — two copies
+   * drift, and the copy that drifts is the fallback nobody exercises until the
+   * primary is already down.
+   *
+   * `timestamp` is `regularMarketTime`, the moment the price was true, never
+   * the moment we fetched it. Every freshness check downstream rests on that
+   * distinction.
+   */
+  private quoteFromChart(symbol: string, data: any): Quote | null {
+    const chart = data?.chart?.result?.[0]
+    if (!chart) return null
+
+    const meta = chart.meta
+    const quote = chart.indicators?.quote?.[0]
+    if (!meta || !quote) return null
+
+    const prices = quote.close || []
+    const opens = quote.open || []
+    const highs = quote.high || []
+    const lows = quote.low || []
+
+    const latestIndex = prices.length - 1
+    if (latestIndex < 0) return null
+
+    const currentPrice = prices[latestIndex]
+    if (!Number.isFinite(currentPrice) || currentPrice <= 0) return null
+    if (!Number.isFinite(meta.regularMarketTime)) return null
+
+    const previousClose = meta.previousClose || currentPrice
+    const change = currentPrice - previousClose
+    const changePercent = previousClose !== 0 ? (change / previousClose) * 100 : 0
+
+    return {
+      symbol: meta.symbol || symbol.toUpperCase(),
+      price: currentPrice,
+      change,
+      changePercent,
+      open: opens[latestIndex] || currentPrice,
+      high: highs[latestIndex] || currentPrice,
+      low: lows[latestIndex] || currentPrice,
+      previousClose,
+      volume: meta.regularMarketVolume || 0,
+      marketCap: meta.marketCap,
+      timestamp: new Date(meta.regularMarketTime * 1000).toISOString(),
+      dayHigh: meta.regularMarketDayHigh || highs[latestIndex] || currentPrice,
+      dayLow: meta.regularMarketDayLow || lows[latestIndex] || currentPrice,
+    }
+  }
+
   private async fetchFromYahooFinance(symbol: string): Promise<Quote | null> {
-    // Route through the yahoo-chart-proxy Supabase edge function.
-    // Yahoo blocks direct browser requests via CORS and the free public
-    // CORS proxies this method used to rotate through have been paywalled
-    // or rate-limited to nothing — all quotes were silently failing.
+    /**
+     * Netlify first, Supabase edge second.
+     *
+     * `yahoo-chart-proxy` is deployed and ACTIVE and returns 502 on every call:
+     * Yahoo refuses Supabase's datacenter egress at the connection level, the
+     * same refusal that moved the article reader to Netlify. The effect was not
+     * a degraded feed but an empty one — every quote came back null, so every
+     * scenario card suppressed with `quote_unavailable` and no signal content
+     * rendered at all.
+     *
+     * The edge function is kept as a fallback rather than deleted: if Netlify
+     * is the one being blocked on some future day, having two independent
+     * egress paths is worth more than a tidy call site. Both failing still
+     * returns null, and null still means "we do not know" — never a fabricated
+     * price.
+     */
+    try {
+      const res = await fetch(`/api/quote?symbol=${encodeURIComponent(symbol)}&range=5d&interval=1d`)
+      if (res.ok) {
+        const data = await res.json()
+        const quote = this.quoteFromChart(symbol, data)
+        if (quote) return quote
+      } else {
+        console.warn('[browser-client] /api/quote returned', res.status, 'for', symbol)
+      }
+    } catch (e) {
+      console.warn('[browser-client] /api/quote unreachable:', e)
+    }
+
+    // Fallback: the Supabase edge proxy.
     try {
       const { supabase } = await import('../supabase')
       const { data, error } = await supabase.functions.invoke('yahoo-chart-proxy', {
@@ -235,41 +314,7 @@ export class BrowserFinancialService {
         return null
       }
 
-      const chart = data?.chart?.result?.[0]
-      if (!chart) return null
-
-      const meta = chart.meta
-      const quote = chart.indicators?.quote?.[0]
-      if (!meta || !quote) return null
-
-      const prices = quote.close || []
-      const opens = quote.open || []
-      const highs = quote.high || []
-      const lows = quote.low || []
-
-      const latestIndex = prices.length - 1
-      if (latestIndex < 0) return null
-
-      const currentPrice = prices[latestIndex]
-      const previousClose = meta.previousClose || currentPrice
-      const change = currentPrice - previousClose
-      const changePercent = previousClose !== 0 ? (change / previousClose) * 100 : 0
-
-      return {
-        symbol: meta.symbol || symbol.toUpperCase(),
-        price: currentPrice,
-        change,
-        changePercent,
-        open: opens[latestIndex] || currentPrice,
-        high: highs[latestIndex] || currentPrice,
-        low: lows[latestIndex] || currentPrice,
-        previousClose,
-        volume: meta.regularMarketVolume || 0,
-        marketCap: meta.marketCap,
-        timestamp: new Date(meta.regularMarketTime * 1000).toISOString(),
-        dayHigh: meta.regularMarketDayHigh || highs[latestIndex] || currentPrice,
-        dayLow: meta.regularMarketDayLow || lows[latestIndex] || currentPrice,
-      }
+      return this.quoteFromChart(symbol, data)
     } catch (e) {
       console.warn('[browser-client] yahoo-chart-proxy invoke threw:', e)
       return null

--- a/src/pages/SimulationPage.tsx
+++ b/src/pages/SimulationPage.tsx
@@ -113,6 +113,7 @@ import type { SimulationShareAccess, SimulationShareMode, SharedSimulationListIt
 import type { SizingValidationError, AssetPrice, IntentVariant } from '../types/trading'
 import { OrgBadge } from '../components/common/OrgBadge'
 import { DebateIndicatorBadge } from '../components/trading/DebateIndicatorBadge'
+import { latestSnapshotRows } from '../lib/holdings/latest-snapshot'
 
 interface SimulationPageProps {
   simulationId?: string
@@ -833,15 +834,19 @@ export function SimulationPage({ simulationId: propSimulationId, tabId, onClose,
         setIsAutoCreating(true)
         try {
           // Get portfolio holdings for baseline
-          const { data: holdings } = await supabase
+          const { data: holdingsRaw } = await supabase
             .from('portfolio_holdings')
             .select(`
+              date,
               asset_id,
               shares,
               price,
               assets (id, symbol, company_name, sector)
             `)
             .eq('portfolio_id', selectedPortfolioId)
+          // portfolio_holdings is a series of dated snapshots; summing every row
+          // multiplies the total by the number of dates. See latest-snapshot.ts.
+          const holdings = latestSnapshotRows(holdingsRaw ?? [])
 
           // Calculate baseline
           const totalValue = (holdings || []).reduce((sum, h) => sum + (h.shares * h.price), 0)
@@ -1646,10 +1651,13 @@ export function SimulationPage({ simulationId: propSimulationId, tabId, onClose,
       if (committed > 0 && selectedSimulationId && selectedPortfolioId) {
         void (async () => {
           try {
-            const { data: holdings } = await supabase
+            const { data: holdingsRaw } = await supabase
               .from('portfolio_holdings')
-              .select('asset_id, shares, price, assets (id, symbol, company_name, sector)')
+              .select('asset_id, shares, price, assets (id, symbol, company_name, sector), date')
               .eq('portfolio_id', selectedPortfolioId)
+            // portfolio_holdings is a series of dated snapshots; summing every row
+            // multiplies the total by the number of dates. See latest-snapshot.ts.
+            const holdings = latestSnapshotRows(holdingsRaw ?? [])
             const totalValue = (holdings || []).reduce(
               (s, h: any) => s + (Number(h.shares) || 0) * (Number(h.price) || 0),
               0,
@@ -2722,15 +2730,19 @@ export function SimulationPage({ simulationId: propSimulationId, tabId, onClose,
       if (!newSimPortfolioId) throw new Error('Portfolio required')
 
       // Get portfolio holdings for baseline
-      const { data: holdings, error: holdingsError } = await supabase
+      const { data: holdingsRaw, error: holdingsError } = await supabase
         .from('portfolio_holdings')
         .select(`
+              date,
           asset_id,
           shares,
           price,
           assets (id, symbol, company_name, sector)
         `)
         .eq('portfolio_id', newSimPortfolioId)
+      // portfolio_holdings is a series of dated snapshots; summing every row
+      // multiplies the total by the number of dates. See latest-snapshot.ts.
+      const holdings = latestSnapshotRows(holdingsRaw ?? [])
 
       if (holdingsError) throw holdingsError
 

--- a/src/pages/TradeQueuePage.tsx
+++ b/src/pages/TradeQueuePage.tsx
@@ -78,6 +78,7 @@ import type {
 } from '../types/trading'
 import { getDerivedUrgency, getUrgencySeverity, DERIVED_URGENCY_CONFIG, type DerivedUrgency } from '../lib/derived-urgency'
 import { clsx } from 'clsx'
+import { latestSnapshotRows } from '../lib/holdings/latest-snapshot'
 import { useTradeExpressionCounts, getExpressionStatus } from '../hooks/useTradeExpressionCounts'
 import { useTradeIdeaService } from '../hooks/useTradeIdeaService'
 import { submitRecommendation } from '../lib/services/recommendation-service'
@@ -1373,10 +1374,13 @@ export function TradeQueuePage() {
       }
 
       // Fetch all holdings for these portfolios to calculate total values and current positions
-      const { data: allHoldings } = await supabase
+      const { data: allHoldingsRaw } = await supabase
         .from('portfolio_holdings')
-        .select('portfolio_id, asset_id, shares, price')
+        .select('portfolio_id, asset_id, shares, price, date')
         .in('portfolio_id', portfolioIds)
+      // portfolio_holdings is a series of dated snapshots; summing every row
+      // multiplies the total by the number of dates. See latest-snapshot.ts.
+      const allHoldings = latestSnapshotRows(allHoldingsRaw ?? [])
 
       // Calculate portfolio totals
       const portfolioTotals = new Map<string, number>()


### PR DESCRIPTION
THE EMPTY FEED EXPLAINED: yahoo-chart-proxy returns 502 on every call, so every quote was null and every scenario card suppressed with quote_unavailable. New Netlify quote function on the path article-extract already proved works.

All 21 holdings sites migrated; allowlist now EMPTY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)