### PR TITLE
feat(brand): the launcher is the same mark, still until you hover it

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "guard:ci": "node scripts/ci-integrity.mjs",
     "guard:holdings": "node scripts/holdings-collapse-audit.mjs",
     "guard:tdz": "node scripts/lint-mobile-ratchet.mjs",
-    "guard:unit": "vitest run --project unit src/lib/org-scope src/lib/signals src/lib/mobile src/components/signals src/components/mobile",
+    "guard:unit": "vitest run --project unit src/lib/org-scope src/lib/signals src/lib/mobile src/lib/brand src/components/signals src/components/mobile src/components/ui",
     "guard:layout": "vite build --config vite.gallery.config.ts && playwright test --project=phone",
     "test": "vitest",
     "test:ui": "vitest --ui",

--- a/src/components/ui/TesseractLoader.tsx
+++ b/src/components/ui/TesseractLoader.tsx
@@ -1,64 +1,16 @@
-import { useEffect, useRef } from 'react'
+import { TesseractMark } from './TesseractMark'
 
 /**
- * A tesseract actually rotating through 4-space, projected down to the screen.
+ * The branded loading state: the Tesseract turning through itself.
  *
- * ── Why this is real geometry and not a CSS transform ─────────────────────
+ * The geometry, the schedules and the drawing all live in
+ * `lib/brand/tesseract-geometry` and `TesseractMark`, shared with the app
+ * launcher. This file is now only the loading COMPOSITION — the mark at a
+ * readable size with a line of copy under it — because everything else was
+ * identical to what the launcher needed, and a second copy would have drifted.
  *
- * The effect being reproduced is the one thing a CSS transform cannot do. A
- * `rotate3d` moves a rigid body: every vertex keeps its distance from every
- * other, so the shape can spin but the inner frame can never pass through the
- * outer one. What makes a hypercube read as four-dimensional is precisely that
- * the projected vertices move RELATIVE to each other — the inner frame swells
- * outward while the outer contracts, they trade places, and the connecting
- * edges stretch and skew because their endpoints are going different ways.
- *
- * You get that for free from the actual projection and essentially no other
- * way, so this computes it: sixteen vertices at (±1,±1,±1,±1), thirty-two
- * edges between vertices differing in exactly one coordinate, a continuous
- * rotation, a fixed oblique camera, then 4D→3D and 3D→2D perspective.
- *
- * ── Why the rotation is ZW, and why the camera is tilted ─────────────────
- *
- * ── Why ZW and not XW ────────────────────────────────────────────────────
- *
- * Both invert the cube; they separate it differently while doing so, and that
- * difference is the whole readability of the thing.
- *
- * XW slides the two cubes apart ALONG THE SCREEN. Partway through the
- * inversion they sit side by side, joined by the eight connecting edges, and
- * that band of connectors reads as a solid face — an extra plane that is not
- * there. Reported from a phone as exactly that.
- *
- * ZW separates them in DEPTH instead. One cube moves toward the viewer while
- * the other recedes, so under perspective they stay concentric and genuinely
- * pass through one another. Same inversion, no phantom plane.
- *
- * The rotation is the whole illusion. It swings each vertex through the W
- * axis, and since the 4D->3D projection divides by distance in W, a vertex
- * moving toward +W swells and one moving toward -W shrinks. Measured on the
- * projection: the outer frame spans 54 units and the inner 23; a quarter turn
- * later the outer has contracted to 23 and the inner has grown to 60. They
- * cross at the halfway point, which is the moment the structures pass through
- * one another. That is "inside becomes outside" as arithmetic rather than as
- * something tweened.
- *
- * The fixed camera tilt is what makes it VISIBLE, and getting there took three
- * attempts. Face-on, every projection of a hypercube is symmetric, so the swap
- * happens and looks like nothing: the picture at the end of the inversion is
- * the same picture you started with. Adding an animated 3D rotation only made
- * it read as spinning, and an orthogonal double rotation (XY+ZW) read as
- * pulsing — both of which are the wrong answers. Viewing the tesseract from an
- * oblique angle breaks the symmetry, so the cubes are distinguishable and the
- * passage between them is motion you can follow. The tilt is static: a camera
- * angle, not an animation.
- *
- * ── Why it drives the DOM directly ────────────────────────────────────────
- *
- * Thirty-two lines at 60fps through React state would be 60 reconciliations a
- * second to animate a loading indicator. The vertices are computed in a rAF
- * callback and written straight onto the `<line>` elements through refs, so
- * React renders this component once.
+ * See the geometry module for why the rotation is ZW rather than XW, why the
+ * camera is isometric, and why the loop is phrased rather than constant.
  */
 
 interface TesseractLoaderProps {
@@ -68,203 +20,15 @@ interface TesseractLoaderProps {
   text?: string
   /**
    * Smaller type for in-surface use. The default is the app-boot treatment,
-   * where the loader IS the screen and a large heading is right.
+   * where the loader IS the screen and a large heading is right; inside the
+   * feed it is one element among a header and a mode switch, and a heading
+   * that size reads as an error state.
    */
   compact?: boolean
 }
 
-/** The sixteen vertices of a 4-cube, one per sign combination. */
-const VERTICES: [number, number, number, number][] = Array.from(
-  { length: 16 },
-  (_, i) => [
-    i & 1 ? 1 : -1,
-    i & 2 ? 1 : -1,
-    i & 4 ? 1 : -1,
-    i & 8 ? 1 : -1,
-  ],
-)
-
-/**
- * The thirty-two edges: every pair of vertices differing in exactly one
- * coordinate. As bit patterns that is a one-bit difference, which `d & (d-1)`
- * tests in one step.
- */
-const EDGES: [number, number][] = (() => {
-  const out: [number, number][] = []
-  for (let i = 0; i < 16; i++) {
-    for (let j = i + 1; j < 16; j++) {
-      const d = i ^ j
-      if ((d & (d - 1)) === 0) out.push([i, j])
-    }
-  }
-  return out
-})()
-
-/**
- * Viewer distances for the two projections.
- *
- * `W_EYE` is the one that matters. A vertex reaches at most √2 ≈ 1.415 in W
- * once the XW rotation is running, so the divisor ranges over roughly 1.0 to
- * 3.8 — a scale ratio near 3.8:1 between the near and far cubes. That ratio is
- * the visible difference between "inner frame" and "outer frame"; push `W_EYE`
- * up and the two converge into one flat cube, pull it down and the near cube
- * explodes off the canvas as its divisor approaches zero.
- *
- * There is no Z_EYE. The 3D step is orthographic on purpose — see the
- * projection — because a perspective divide there would pull the near corners
- * of the hexagon out and the far ones in, and the regularity of that hexagon is
- * the mark.
- */
-const W_EYE = 2.5
-
-/**
- * The ISOMETRIC camera — looking straight down the cube's body diagonal.
- *
- * Not an arbitrary pleasing angle, which is what 22/28 degrees was and why the
- * mark read as off-kilter: at an arbitrary tilt the twelve edges project to
- * twelve different lengths and no two faces agree, so the figure looks skewed
- * rather than drawn.
- *
- * Down the (1,1,1) diagonal a cube projects to a REGULAR HEXAGON with a Y at
- * its centre — every edge the same length, every angle 120 degrees. That is the
- * Tesseract mark, and it is the shape the loop returns to at rest. 45 degrees
- * about Y then atan(1/sqrt(2)) about X is the standard construction.
- */
-const TILT_Y = Math.PI / 4
-const TILT_X = Math.atan(1 / Math.SQRT2)
-
-/**
- * The loop has three beats: invert, turn, invert.
- *
- * Constant angular motion is right for a physics demonstration and dull as a
- * loading state. Phrasing makes the inversion feel deliberate: the cube turns
- * through itself, settles, swings round on a spatial axis, and turns through
- * again.
- *
- * `morphSchedule` advances the 4D rotation over the opening and closing
- * stretches and holds through the middle; `spinSchedule` does the opposite.
- * Each is a smoothstep, so velocity is zero wherever a phase begins or ends —
- * which makes the handover read as a beat rather than a stutter, and keeps the
- * loop seam invisible: both arrive at the wrap with zero velocity and a whole
- * number of turns.
- */
+/** One loop. Three beats — invert, turn, invert — so ~1.8s per inversion. */
 const PERIOD_MS = 4500
-
-/** Hermite smoothstep, clamped. Zero velocity at both ends. */
-function smoothstep(a: number, b: number, u: number): number {
-  const t = Math.min(1, Math.max(0, (u - a) / (b - a)))
-  return t * t * (3 - 2 * t)
-}
-
-/**
- * How far through its full turn the 4D rotation is, 0..1 across the loop.
- *
- * Half the turn in the opening stretch and half in the closing one — and half a
- * turn IS one complete inversion, so the cube passes through itself once before
- * the spin and once after.
- */
-export const morphSchedule = (u: number): number =>
-  0.5 * smoothstep(0, 0.40, u) + 0.5 * smoothstep(0.60, 1, u)
-
-/** The spatial turn, which happens entirely between the two inversions. */
-export const spinSchedule = (u: number): number => smoothstep(0.42, 0.58, u)
-
-/**
- * Sized and centred by measurement.
- *
- * Down the body diagonal the projection is symmetric about the origin — the
- * measured extent is -1.199..1.199 across the whole loop — so the centre is
- * exactly 50 and needs no fudge. That symmetry is itself the check that the
- * camera is truly isometric; the previous arbitrary tilt measured
- * 17.6..92.7 about a centre of 55, which is what "off kilter" looked like as
- * numbers.
- *
- * 23.4 puts the figure in the middle ~56% of the frame. Air around a precise
- * line drawing is most of what makes it look precise.
- */
-const SCALE = 23.4
-const CENTER = 50
-
-/**
- * Which structure an edge belongs to.
- *
- * The eight CONNECTORS are the edges joining the two cubes, and they are the
- * clutter: drawn at the same weight as everything else they read as filled
- * faces rather than as links. Holding them back is most of what makes the
- * projection legible as two frames rather than one tangle.
- */
-const EDGE_KIND: ('cube' | 'link')[] = EDGES.map(([a, b]) =>
-  (a & 8) === (b & 8) ? 'cube' : 'link')
-
-interface Projected { x: number; y: number; depth: number }
-
-
-
-/**
- * Project the hypercube at rotation angle `t` (radians).
- *
- * Exported so a test can assert the properties that make it a tesseract rather
- * than a spinning square — that the inner and outer frames genuinely exchange
- * size, and that the loop returns to its starting geometry.
- */
-export function projectTesseract(t: number, spin = 0): Projected[] {
-  const c = Math.cos(t)
-  const s = Math.sin(t)
-  const cs = Math.cos(spin)
-  const ss = Math.sin(spin)
-  const cx = Math.cos(TILT_X)
-  const sx = Math.sin(TILT_X)
-  const cy = Math.cos(TILT_Y)
-  const sy = Math.sin(TILT_Y)
-
-  return VERTICES.map(([x0, y0, z0, w0]) => {
-    // The four-dimensional rotation, in the ZW plane so the two cubes separate
-    // in depth rather than across the screen. See the header.
-    const zr = z0 * c - w0 * s
-    const w = z0 * s + w0 * c
-
-    // The spatial turn, in XZ so it reads as the object rotating in space
-    // rather than the picture spinning on the screen.
-    const xs2 = x0 * cs - zr * ss
-    const zs2 = x0 * ss + zr * cs
-
-    // Fixed camera tilt. Static — see the header.
-    const y1 = y0 * cx - zs2 * sx
-    const z1 = y0 * sx + zs2 * cx
-    const x2 = xs2 * cy + z1 * sy
-    const z2 = -xs2 * sy + z1 * cy
-
-    // 4D -> 3D. Dividing by distance in W is what makes one cube large and the
-    // other small, and what makes them trade places as W changes sign.
-    const kw = 1 / (W_EYE - w)
-    const x3 = x2 * kw
-    const y3 = y1 * kw
-    const z3 = z2 * kw
-
-    // 3D -> 2D, ORTHOGRAPHIC.
-    //
-    // A perspective divide here would pull the near corners of the hexagon
-    // outward and the far ones in, and the regularity is the whole point of the
-    // isometric view. Depth still reads, from the W perspective above and from
-    // the opacity ramp — it does not need a second, competing one.
-    void z3
-    return {
-      x: CENTER + x3 * SCALE,
-      y: CENTER + y3 * SCALE,
-      // How near the viewer, 0..1, for a restrained depth cue.
-      depth: (w + 1.5) / 3,
-    }
-  })
-}
-
-/**
- * The frame at rest, computed once.
- *
- * Used for the initial render so the first paint is the recognisable mark
- * rather than an empty box waiting on the first animation frame, and reused as
- * the whole picture under reduced motion.
- */
-const START = projectTesseract(0)
 
 export function TesseractLoader({
   size = 80,
@@ -273,109 +37,9 @@ export function TesseractLoader({
   text = 'Loading...',
   compact = false,
 }: TesseractLoaderProps) {
-  const lineRefs = useRef<(SVGLineElement | null)[]>([])
-  const dotRefs = useRef<(SVGCircleElement | null)[]>([])
-
-  useEffect(() => {
-    /**
-     * Reduced motion: the mark, held still.
-     *
-     * A continuously inverting hypercube is close to the worst thing this
-     * setting exists to suppress, and it appears at the one moment a reader
-     * cannot look away because nothing else has rendered. The static frame is
-     * the recognisable projection, so the brand still lands.
-     */
-    const reduced = typeof window !== 'undefined'
-      && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
-
-    const draw = (t: number, spin: number) => {
-      const p = projectTesseract(t, spin)
-      EDGES.forEach(([a, b], i) => {
-        const el = lineRefs.current[i]
-        if (!el) return
-        el.setAttribute('x1', p[a].x.toFixed(2))
-        el.setAttribute('y1', p[a].y.toFixed(2))
-        el.setAttribute('x2', p[b].x.toFixed(2))
-        el.setAttribute('y2', p[b].y.toFixed(2))
-        // Depth, and the link edges held further back still. A wide opacity
-        // range is what separates the near frame from the far one; a narrow one
-        // flattens the projection into a single tangle of lines.
-        const d = (p[a].depth + p[b].depth) / 2
-        const base = 0.2 + d * 0.8
-        el.setAttribute('opacity', (EDGE_KIND[i] === 'link' ? base * 0.5 : base).toFixed(2))
-      })
-      p.forEach((v, i) => {
-        const el = dotRefs.current[i]
-        if (!el) return
-        el.setAttribute('cx', v.x.toFixed(2))
-        el.setAttribute('cy', v.y.toFixed(2))
-        // Nodes scale with depth as well as fade, so the near frame reads as
-        // nearer rather than merely brighter.
-        el.setAttribute('r', (0.7 + v.depth * 1.2).toFixed(2))
-        el.setAttribute('opacity', (0.25 + v.depth * 0.75).toFixed(2))
-      })
-    }
-
-    if (reduced) {
-      draw(0, 0)
-      return
-    }
-
-    let frame = 0
-    let start: number | null = null
-    const step = (now: number) => {
-      if (start == null) start = now
-      // Phrased, not constant — see PERIOD_MS.
-      const u = ((now - start) % PERIOD_MS) / PERIOD_MS
-      draw(morphSchedule(u) * Math.PI * 2, spinSchedule(u) * Math.PI * 2)
-      frame = requestAnimationFrame(step)
-    }
-    frame = requestAnimationFrame(step)
-    return () => cancelAnimationFrame(frame)
-  }, [])
-
   return (
-    <div className={`flex flex-col items-center justify-center ${className}`}>
-      <svg
-        width={size}
-        height={size}
-        viewBox="0 0 100 100"
-        data-testid="tesseract-loader"
-        role="img"
-        aria-label="Loading"
-      >
-        {/* Edges first, vertices over them, so the nodes read as joints rather
-            than as beads threaded on a line. */}
-        {EDGES.map(([a, b], i) => (
-          <line
-            key={`${a}-${b}`}
-            ref={el => { lineRefs.current[i] = el }}
-            x1={START[a].x}
-            y1={START[a].y}
-            x2={START[b].x}
-            y2={START[b].y}
-            stroke="#f59e0b"
-            // The eight links are drawn lighter than the twenty-four cube
-            // edges. Equal weight made them read as filled faces.
-            // Heavy, like the mark. The logo is a bold line drawing and a
-            // hairline version of it reads as a wireframe diagram instead.
-            strokeWidth={EDGE_KIND[i] === 'link' ? 1.6 : 2.6}
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            vectorEffect="non-scaling-stroke"
-          />
-        ))}
-        {START.map((v, i) => (
-          <circle
-            key={`v${i}`}
-            ref={el => { dotRefs.current[i] = el }}
-            cx={v.x}
-            cy={v.y}
-            r={1.4}
-            fill="#fbbf24"
-          />
-        ))}
-      </svg>
+    <div className={`flex flex-col items-center justify-center ${className}`} data-testid="tesseract-loader">
+      <TesseractMark size={size} periodMs={PERIOD_MS} animate />
 
       {showText && (
         <p className={compact

--- a/src/components/ui/TesseractLogo.tsx
+++ b/src/components/ui/TesseractLogo.tsx
@@ -1,4 +1,36 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
+
+import { TesseractMark } from './TesseractMark'
+
+/**
+ * The app-launcher mark: still by default, turning slowly under a pointer.
+ *
+ * ── What this replaces ────────────────────────────────────────────────────
+ *
+ * Eight vertices on eight separate CSS keyframe tracks, each tweening its own
+ * cx/cy, plus dashed "dynamic" edges on a ninth. It could not produce a
+ * coherent projection because nothing tied the vertices to a shape — they were
+ * eight independent animations that happened to start on a cube, which is why
+ * the edges drifted out of square as soon as it ran.
+ *
+ * It is now the same real 4D projection the loader draws, from the same module,
+ * so the launcher and the loading state are recognisably one mark.
+ *
+ * ── Why hover, and why slow ───────────────────────────────────────────────
+ *
+ * At rest it is a logo and should behave like one: a static, precise isometric
+ * hexagon that never competes with the content next to it. Chrome that moves on
+ * its own is chrome you learn to tune out.
+ *
+ * Under a pointer it earns a little life, at 15 seconds a loop against the
+ * loader's 4.5. Three times slower is the difference between "this is working"
+ * and "this is alive" — a launcher that inverted at loading speed would read as
+ * a progress indicator and imply something was happening when nothing was.
+ *
+ * Touch has no hover, so on a phone this is simply the static mark. That is the
+ * correct outcome rather than a gap: the drawer it opens is one tap away, and
+ * an animation nobody asked for is not worth a pointer-type branch.
+ */
 
 interface TesseractLogoProps {
   size?: number
@@ -6,190 +38,30 @@ interface TesseractLogoProps {
 }
 
 export function TesseractLogo({ size = 32, className = '' }: TesseractLogoProps) {
-  const [isAnimating, setIsAnimating] = useState(false)
+  const [hovered, setHovered] = useState(false)
 
   return (
     <div
       className={`cursor-pointer transition-transform duration-200 hover:scale-105 ${className}`}
       style={{ width: size, height: size }}
-      onMouseEnter={() => setIsAnimating(true)}
-      onMouseLeave={() => setIsAnimating(false)}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      data-testid="tesseract-logo"
+      data-animating={hovered ? 'true' : 'false'}
     >
-      <svg
-        width={size}
-        height={size}
-        viewBox="0 0 100 100"
-        className="transition-all duration-300"
-        style={{ transformStyle: 'preserve-3d' }}
-      >
-        <defs>
-          <style>
-            {`
-              /* Stable class-based animations */
-              .tesseract-logo.animating .vertex-0 {
-                animation: vertex-0-4d 4s ease-in-out infinite;
-              }
-              .tesseract-logo.animating .vertex-1 {
-                animation: vertex-1-4d 4s ease-in-out infinite;
-              }
-              .tesseract-logo.animating .vertex-2 {
-                animation: vertex-2-4d 4s ease-in-out infinite;
-              }
-              .tesseract-logo.animating .vertex-3 {
-                animation: vertex-3-4d 4s ease-in-out infinite;
-              }
-              .tesseract-logo.animating .vertex-4 {
-                animation: vertex-4-4d 4s ease-in-out infinite;
-              }
-              .tesseract-logo.animating .vertex-5 {
-                animation: vertex-5-4d 4s ease-in-out infinite;
-              }
-              .tesseract-logo.animating .vertex-6 {
-                animation: vertex-6-4d 4s ease-in-out infinite;
-              }
-              .tesseract-logo.animating .vertex-7 {
-                animation: vertex-7-4d 4s ease-in-out infinite;
-              }
-
-              /* EXTREME 4D vertex transformations - very large position changes */
-              @keyframes vertex-0-4d {
-                0% { transform: translate(0, 0) scale(1); opacity: 1; }
-                50% { transform: translate(50px, 50px) scale(2); opacity: 0.3; }
-                100% { transform: translate(0, 0) scale(1); opacity: 1; }
-              }
-
-              @keyframes vertex-1-4d {
-                0% { transform: translate(0, 0) scale(1); opacity: 1; }
-                50% { transform: translate(-50px, 50px) scale(2); opacity: 0.3; }
-                100% { transform: translate(0, 0) scale(1); opacity: 1; }
-              }
-
-              @keyframes vertex-2-4d {
-                0% { transform: translate(0, 0) scale(1); opacity: 1; }
-                50% { transform: translate(-50px, -50px) scale(2); opacity: 0.3; }
-                100% { transform: translate(0, 0) scale(1); opacity: 1; }
-              }
-
-              @keyframes vertex-3-4d {
-                0% { transform: translate(0, 0) scale(1); opacity: 1; }
-                50% { transform: translate(50px, -50px) scale(2); opacity: 0.3; }
-                100% { transform: translate(0, 0) scale(1); opacity: 1; }
-              }
-
-              @keyframes vertex-4-4d {
-                0% { transform: translate(0, 0) scale(0.8); opacity: 0.8; }
-                50% { transform: translate(-40px, -40px) scale(2.5); opacity: 1; }
-                100% { transform: translate(0, 0) scale(0.8); opacity: 0.8; }
-              }
-
-              @keyframes vertex-5-4d {
-                0% { transform: translate(0, 0) scale(0.8); opacity: 0.8; }
-                50% { transform: translate(40px, -40px) scale(2.5); opacity: 1; }
-                100% { transform: translate(0, 0) scale(0.8); opacity: 0.8; }
-              }
-
-              @keyframes vertex-6-4d {
-                0% { transform: translate(0, 0) scale(0.8); opacity: 0.8; }
-                50% { transform: translate(40px, 40px) scale(2.5); opacity: 1; }
-                100% { transform: translate(0, 0) scale(0.8); opacity: 0.8; }
-              }
-
-              @keyframes vertex-7-4d {
-                0% { transform: translate(0, 0) scale(0.8); opacity: 0.8; }
-                50% { transform: translate(-40px, 40px) scale(2.5); opacity: 1; }
-                100% { transform: translate(0, 0) scale(0.8); opacity: 0.8; }
-              }
-
-              /* Stable edge animations */
-              .tesseract-logo.animating .edge-dynamic {
-                animation: edge-morph-dramatic 4s linear infinite;
-              }
-
-              .tesseract-logo.animating .tesseract-edge {
-                animation: static-edge-pulse 4s linear infinite;
-              }
-
-              @keyframes edge-morph-dramatic {
-                0% { opacity: 0.7; stroke-width: 1; stroke-dasharray: 0, 0; transform: scale(1) rotate(0deg); }
-                25% { opacity: 0.3; stroke-width: 4; stroke-dasharray: 8, 4; transform: scale(0.6) rotate(90deg); }
-                50% { opacity: 1; stroke-width: 0.5; stroke-dasharray: 2, 6; transform: scale(1.5) rotate(180deg); }
-                75% { opacity: 0.5; stroke-width: 3; stroke-dasharray: 6, 2; transform: scale(0.8) rotate(270deg); }
-                100% { opacity: 0.7; stroke-width: 1; stroke-dasharray: 0, 0; transform: scale(1) rotate(360deg); }
-              }
-
-              @keyframes static-edge-pulse {
-                0% { opacity: 0.8; stroke-width: 1.5; }
-                25% { opacity: 0.4; stroke-width: 0.8; }
-                50% { opacity: 1; stroke-width: 2.5; }
-                75% { opacity: 0.6; stroke-width: 1.2; }
-                100% { opacity: 0.8; stroke-width: 1.5; }
-              }
-
-              /* Remove conflicting whole-tesseract animation */
-
-              /* Bold yellow tesseract color scheme */
-              .tesseract-vertex {
-                fill: #f59e0b;
-                stroke: #d97706;
-                stroke-width: 1.5;
-              }
-
-              .tesseract-edge {
-                stroke: #f59e0b;
-                stroke-width: 3;
-                fill: none;
-                opacity: 1;
-              }
-
-              .edge-dynamic {
-                stroke: #fbbf24;
-                stroke-width: 2.5;
-                fill: none;
-                opacity: 0.9;
-                stroke-dasharray: 3, 2;
-              }
-            `}
-          </style>
-        </defs>
-
-        <g className={`tesseract-logo ${isAnimating ? 'animating' : ''}`}>
-          {/* 8 Tesseract vertices that move through 4D space */}
-          <circle className="tesseract-vertex vertex-0" cx="15" cy="15" r="3" />
-          <circle className="tesseract-vertex vertex-1" cx="85" cy="15" r="3" />
-          <circle className="tesseract-vertex vertex-2" cx="85" cy="85" r="3" />
-          <circle className="tesseract-vertex vertex-3" cx="15" cy="85" r="3" />
-          <circle className="tesseract-vertex vertex-4" cx="30" cy="30" r="2.5" />
-          <circle className="tesseract-vertex vertex-5" cx="70" cy="30" r="2.5" />
-          <circle className="tesseract-vertex vertex-6" cx="70" cy="70" r="2.5" />
-          <circle className="tesseract-vertex vertex-7" cx="30" cy="70" r="2.5" />
-
-          {/* Static connecting lines that form the tesseract structure */}
-          <line className="tesseract-edge" x1="15" y1="15" x2="85" y2="15" />
-          <line className="tesseract-edge" x1="85" y1="15" x2="85" y2="85" />
-          <line className="tesseract-edge" x1="85" y1="85" x2="15" y2="85" />
-          <line className="tesseract-edge" x1="15" y1="85" x2="15" y2="15" />
-
-          <line className="tesseract-edge" x1="30" y1="30" x2="70" y2="30" />
-          <line className="tesseract-edge" x1="70" y1="30" x2="70" y2="70" />
-          <line className="tesseract-edge" x1="70" y1="70" x2="30" y2="70" />
-          <line className="tesseract-edge" x1="30" y1="70" x2="30" y2="30" />
-
-          {/* 4D connecting edges between the two cube projections */}
-          <line className="edge-dynamic" x1="15" y1="15" x2="30" y2="30" />
-          <line className="edge-dynamic" x1="85" y1="15" x2="70" y2="30" />
-          <line className="edge-dynamic" x1="85" y1="85" x2="70" y2="70" />
-          <line className="edge-dynamic" x1="15" y1="85" x2="30" y2="70" />
-
-          {/* Additional connecting lines for 4D structure */}
-          <line className="edge-dynamic" x1="15" y1="15" x2="85" y2="85" />
-          <line className="edge-dynamic" x1="85" y1="15" x2="15" y2="85" />
-          <line className="edge-dynamic" x1="30" y1="30" x2="70" y2="70" />
-          <line className="edge-dynamic" x1="70" y1="30" x2="30" y2="70" />
-
-          {/* Central core point */}
-          <circle className="tesseract-vertex" cx="50" cy="50" r="1.5" />
-        </g>
-      </svg>
+      <TesseractMark
+        size={size}
+        // Fifteen seconds. See the header: slow enough to read as life rather
+        // than as progress.
+        periodMs={15000}
+        animate={hovered}
+        // Heavier than the loader's proportionally, because the launcher is
+        // drawn at 24-26px where a hairline disappears into the header.
+        weight={3.4}
+        // No nodes at this size — sixteen dots on a 24px mark close up the
+        // gaps between the lines and it reads as a blob.
+        showNodes={false}
+      />
     </div>
   )
 }

--- a/src/components/ui/TesseractMark.tsx
+++ b/src/components/ui/TesseractMark.tsx
@@ -1,0 +1,140 @@
+import { useEffect, useRef } from 'react'
+
+import {
+  EDGES, EDGE_KIND, RESTING, morphSchedule, project, spinSchedule,
+} from '../../lib/brand/tesseract-geometry'
+
+/**
+ * The animated mark, drawn once and driven by whoever mounts it.
+ *
+ * ── Why one component for two very different uses ─────────────────────────
+ *
+ * The loader runs the loop continuously at 4.5s; the app launcher holds the
+ * resting frame and turns slowly only while a pointer is over it. Those are
+ * different behaviours and the same drawing, so what varies is a period and a
+ * boolean, not a second copy of the geometry.
+ *
+ * ── Why it drives the DOM directly ────────────────────────────────────────
+ *
+ * Thirty-two lines and sixteen nodes at 60fps through React state would be 60
+ * reconciliations a second to animate an icon. The vertices are computed in a
+ * rAF callback and written straight onto the elements through refs, so React
+ * renders this once and never again while it moves.
+ */
+
+interface TesseractMarkProps {
+  size: number
+  /** Milliseconds for one full loop. Larger is slower. */
+  periodMs: number
+  /** When false the mark holds its resting frame. */
+  animate: boolean
+  /** Stroke weight for the twenty-four cube edges; links are drawn lighter. */
+  weight?: number
+  /** Vertex nodes. Off at small sizes, where they close up the line work. */
+  showNodes?: boolean
+  className?: string
+}
+
+export function TesseractMark({
+  size, periodMs, animate, weight = 2.6, showNodes = true, className,
+}: TesseractMarkProps) {
+  const lineRefs = useRef<(SVGLineElement | null)[]>([])
+  const dotRefs = useRef<(SVGCircleElement | null)[]>([])
+
+  useEffect(() => {
+    const draw = (t: number, spin: number) => {
+      const p = project(t, spin)
+      EDGES.forEach(([a, b], i) => {
+        const el = lineRefs.current[i]
+        if (!el) return
+        el.setAttribute('x1', p[a].x.toFixed(2))
+        el.setAttribute('y1', p[a].y.toFixed(2))
+        el.setAttribute('x2', p[b].x.toFixed(2))
+        el.setAttribute('y2', p[b].y.toFixed(2))
+        // Depth, with the links held further back still. A wide opacity range
+        // is what separates the near frame from the far one; a narrow one
+        // flattens the projection into a single tangle.
+        const d = (p[a].depth + p[b].depth) / 2
+        const base = 0.2 + d * 0.8
+        el.setAttribute('opacity', (EDGE_KIND[i] === 'link' ? base * 0.5 : base).toFixed(2))
+      })
+      if (!showNodes) return
+      p.forEach((v, i) => {
+        const el = dotRefs.current[i]
+        if (!el) return
+        el.setAttribute('cx', v.x.toFixed(2))
+        el.setAttribute('cy', v.y.toFixed(2))
+        // Nodes scale as well as fade, so the near frame reads as nearer rather
+        // than merely brighter.
+        el.setAttribute('r', (0.7 + v.depth * 1.2).toFixed(2))
+        el.setAttribute('opacity', (0.25 + v.depth * 0.75).toFixed(2))
+      })
+    }
+
+    /**
+     * Reduced motion: the mark, held still.
+     *
+     * A continuously inverting hypercube is close to the worst thing this
+     * setting exists to suppress. The resting frame is the recognisable
+     * projection, so the brand still lands.
+     */
+    const reduced = typeof window !== 'undefined'
+      && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
+
+    if (!animate || reduced) {
+      draw(0, 0)
+      return
+    }
+
+    let frame = 0
+    let start: number | null = null
+    const step = (now: number) => {
+      if (start == null) start = now
+      const u = ((now - start) % periodMs) / periodMs
+      draw(morphSchedule(u) * Math.PI * 2, spinSchedule(u) * Math.PI * 2)
+      frame = requestAnimationFrame(step)
+    }
+    frame = requestAnimationFrame(step)
+    return () => cancelAnimationFrame(frame)
+  }, [animate, periodMs, showNodes])
+
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 100 100"
+      data-testid="tesseract-mark"
+      className={className}
+      role="img"
+      aria-label="Tesseract"
+    >
+      {EDGES.map(([a, b], i) => (
+        <line
+          key={`${a}-${b}`}
+          ref={el => { lineRefs.current[i] = el }}
+          x1={RESTING[a].x}
+          y1={RESTING[a].y}
+          x2={RESTING[b].x}
+          y2={RESTING[b].y}
+          stroke="#f59e0b"
+          // The eight links lighter than the twenty-four cube edges. Equal
+          // weight made them read as filled faces.
+          strokeWidth={EDGE_KIND[i] === 'link' ? weight * 0.6 : weight}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          vectorEffect="non-scaling-stroke"
+        />
+      ))}
+      {showNodes && RESTING.map((v, i) => (
+        <circle
+          key={`v${i}`}
+          ref={el => { dotRefs.current[i] = el }}
+          cx={v.x}
+          cy={v.y}
+          r={1.4}
+          fill="#fbbf24"
+        />
+      ))}
+    </svg>
+  )
+}

--- a/src/components/ui/__tests__/TesseractLogo.test.tsx
+++ b/src/components/ui/__tests__/TesseractLogo.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { fireEvent, render, screen } from '@testing-library/react'
+
+import { TesseractLogo } from '../TesseractLogo'
+import { RESTING, project } from '../../../lib/brand/tesseract-geometry'
+
+/**
+ * The launcher is a logo first and an animation second.
+ *
+ * What matters is that it is STILL until a pointer arrives — chrome that moves
+ * on its own is chrome people learn to tune out — and that when it does move it
+ * is the same mark the loader draws rather than a second lookalike.
+ */
+
+describe('app launcher mark', () => {
+  it('is still until hovered', () => {
+    render(<TesseractLogo size={24} />)
+    const el = screen.getByTestId('tesseract-logo')
+    expect(el.getAttribute('data-animating')).toBe('false')
+    fireEvent.mouseEnter(el)
+    expect(el.getAttribute('data-animating')).toBe('true')
+    fireEvent.mouseLeave(el)
+    expect(el.getAttribute('data-animating')).toBe('false')
+  })
+
+  it('draws the resting projection at rest', () => {
+    // The recognisable isometric hexagon, not an empty box waiting on a frame.
+    const { container } = render(<TesseractLogo size={24} />)
+    const first = container.querySelector('line')!
+    // Two decimals, because that is the precision the renderer writes.
+    expect(Number(first.getAttribute('x1'))).toBeCloseTo(RESTING[0].x, 2)
+    expect(Number(first.getAttribute('y1'))).toBeCloseTo(RESTING[0].y, 2)
+  })
+
+  it('draws the same 32-edge mark the loader does', () => {
+    // One geometry module, so the launcher and the loading state cannot drift
+    // into being two different logos.
+    const { container } = render(<TesseractLogo size={24} />)
+    expect(container.querySelectorAll('line')).toHaveLength(32)
+  })
+
+  it('omits vertex nodes at launcher size', () => {
+    // Sixteen dots on a 24px mark close the gaps between the lines and it reads
+    // as a blob.
+    const { container } = render(<TesseractLogo size={24} />)
+    expect(container.querySelectorAll('circle')).toHaveLength(0)
+  })
+
+  it('turns far slower than the loader', () => {
+    /**
+     * Asserted on the projection rather than on wall-clock timing, which a unit
+     * test cannot observe honestly. The launcher runs the same loop over 15s
+     * against the loader's 4.5 — three times slower is the difference between
+     * "this is alive" and "this is working", and a launcher inverting at
+     * loading speed would imply something was happening when nothing was.
+     */
+    const travel = (p: typeof RESTING) =>
+      p.reduce((n, v, i) => n + Math.hypot(v.x - RESTING[i].x, v.y - RESTING[i].y), 0)
+    const loaderAt2s = project((2000 / 4500) * Math.PI * 2)
+    const launcherAt2s = project((2000 / 15000) * Math.PI * 2)
+    expect(travel(launcherAt2s)).toBeLessThan(travel(loaderAt2s))
+  })
+})

--- a/src/lib/brand/__tests__/tesseract-geometry.test.ts
+++ b/src/lib/brand/__tests__/tesseract-geometry.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { morphSchedule, projectTesseract, spinSchedule } from '../../../components/ui/TesseractLoader'
+import { morphSchedule, project as projectTesseract, spinSchedule } from '../tesseract-geometry'
 
 /**
  * The properties that make this a tesseract rather than a spinning logo.

--- a/src/lib/brand/tesseract-geometry.ts
+++ b/src/lib/brand/tesseract-geometry.ts
@@ -1,0 +1,172 @@
+/**
+ * The Tesseract mark, as geometry rather than as a drawing.
+ *
+ * Shared by the loader and the app-launcher icon so there is exactly one
+ * definition of what the mark IS. They differ only in timing and weight: the
+ * loader runs the loop continuously, the launcher holds the resting frame and
+ * turns slowly while a pointer is over it.
+ *
+ * Pure — no React, no DOM, no clock. `t` and `spin` come from the caller, which
+ * is what lets both components drive it at different speeds from one source.
+ */
+
+/** The sixteen vertices of a 4-cube, one per sign combination. */
+export const VERTICES: [number, number, number, number][] = Array.from(
+  { length: 16 },
+  (_, i) => [i & 1 ? 1 : -1, i & 2 ? 1 : -1, i & 4 ? 1 : -1, i & 8 ? 1 : -1],
+)
+
+/**
+ * The thirty-two edges: every pair of vertices differing in exactly one
+ * coordinate. As bit patterns that is a one-bit difference, which `d & (d - 1)`
+ * tests in one step.
+ */
+export const EDGES: [number, number][] = (() => {
+  const out: [number, number][] = []
+  for (let i = 0; i < 16; i++) {
+    for (let j = i + 1; j < 16; j++) {
+      const d = i ^ j
+      if ((d & (d - 1)) === 0) out.push([i, j])
+    }
+  }
+  return out
+})()
+
+/**
+ * Which structure an edge belongs to.
+ *
+ * The eight LINKS join the two cubes, and they are the clutter: at the same
+ * weight as everything else they read as filled faces rather than as
+ * connections. Holding them back is most of what makes the projection legible
+ * as two frames rather than one tangle.
+ */
+export const EDGE_KIND: ('cube' | 'link')[] = EDGES.map(([a, b]) =>
+  (a & 8) === (b & 8) ? 'cube' : 'link')
+
+/**
+ * Distance to the viewer in W.
+ *
+ * This is the number that matters. A vertex reaches at most sqrt(2) in W once
+ * the rotation is running, so the divisor ranges over roughly 1.1 to 3.9 — a
+ * scale ratio near 3.6:1 between the near and far cubes, which is the visible
+ * difference between "inner frame" and "outer frame". Raise it and the two
+ * converge into one flat cube; lower it and the near cube explodes off the
+ * canvas as its divisor approaches zero.
+ *
+ * There is no Z_EYE. The 3D step is orthographic on purpose — see `project`.
+ */
+const W_EYE = 2.5
+
+/**
+ * The ISOMETRIC camera — looking straight down the cube's body diagonal.
+ *
+ * Not an arbitrary pleasing angle. At an arbitrary tilt a cube's twelve edges
+ * project to twelve different lengths with no two faces agreeing, and the
+ * figure reads as skewed rather than drawn. Down the (1,1,1) diagonal a cube
+ * projects to a REGULAR HEXAGON with a Y at its centre: every edge the same
+ * length, every angle 120 degrees. That is the mark.
+ *
+ * 45 degrees about Y then atan(1/sqrt(2)) about X is the standard construction.
+ */
+const TILT_Y = Math.PI / 4
+const TILT_X = Math.atan(1 / Math.SQRT2)
+
+/**
+ * Sized and centred by measurement.
+ *
+ * Down the body diagonal the projection is symmetric about the origin — the
+ * measured extent is -1.199..1.199 across the whole loop — so the centre is
+ * exactly 50 and needs no fudge. That symmetry is itself the check that the
+ * camera is truly isometric.
+ *
+ * 23.4 puts the figure in the middle ~56% of the frame. Air around a precise
+ * line drawing is most of what makes it look precise.
+ */
+const SCALE = 23.4
+const CENTER = 50
+
+export interface Projected { x: number; y: number; depth: number }
+
+/**
+ * Project the hypercube at 4D rotation `t` and spatial rotation `spin`.
+ *
+ * The rotation is in the ZW plane, which is what produces the inversion: it
+ * swings each vertex through W, and since the 4D->3D step divides by distance
+ * in W, a vertex moving toward +W swells and one moving toward -W shrinks. Half
+ * a turn later the cubes have exchanged roles.
+ *
+ * ZW rather than XW because of HOW the two separate on the way. XW slides them
+ * apart across the screen, so partway through they sit side by side joined by
+ * the eight links, and that band reads as a solid face — an extra plane that is
+ * not there. ZW separates them in depth, so they stay concentric and genuinely
+ * pass through one another.
+ */
+export function project(t: number, spin = 0): Projected[] {
+  const c = Math.cos(t)
+  const s = Math.sin(t)
+  const cs = Math.cos(spin)
+  const ss = Math.sin(spin)
+  const cx = Math.cos(TILT_X)
+  const sx = Math.sin(TILT_X)
+  const cy = Math.cos(TILT_Y)
+  const sy = Math.sin(TILT_Y)
+
+  return VERTICES.map(([x0, y0, z0, w0]) => {
+    const zr = z0 * c - w0 * s
+    const w = z0 * s + w0 * c
+
+    // The spatial turn, in XZ so it reads as the object rotating in space
+    // rather than the picture spinning on the screen.
+    const xs = x0 * cs - zr * ss
+    const zs = x0 * ss + zr * cs
+
+    const y1 = y0 * cx - zs * sx
+    const z1 = y0 * sx + zs * cx
+    const x2 = xs * cy + z1 * sy
+    const z2 = -xs * sy + z1 * cy
+
+    const kw = 1 / (W_EYE - w)
+    const x3 = x2 * kw
+    const y3 = y1 * kw
+
+    // 3D -> 2D, ORTHOGRAPHIC. A perspective divide here would pull the near
+    // corners of the hexagon out and the far ones in, and the regularity of
+    // that hexagon is the mark. Depth still reads, from the W perspective above
+    // and from the opacity ramp — it does not need a second, competing one.
+    void z2
+    return {
+      x: CENTER + x3 * SCALE,
+      y: CENTER + y3 * SCALE,
+      depth: (w + 1.5) / 3,
+    }
+  })
+}
+
+/** Hermite smoothstep, clamped. Zero velocity at both ends. */
+export function smoothstep(a: number, b: number, u: number): number {
+  const t = Math.min(1, Math.max(0, (u - a) / (b - a)))
+  return t * t * (3 - 2 * t)
+}
+
+/**
+ * The loop has three beats: invert, turn, invert.
+ *
+ * Constant angular motion is right for a physics demonstration and dull as a
+ * loading state. `morphSchedule` advances the 4D rotation over the opening and
+ * closing stretches and holds through the middle; `spinSchedule` does the
+ * opposite. Each is a smoothstep, so velocity is zero wherever a phase begins
+ * or ends — which makes the handover read as a beat rather than a stutter, and
+ * keeps the loop seam invisible: both arrive at the wrap with zero velocity and
+ * a whole number of turns.
+ *
+ * Half a turn of the 4D rotation IS one complete inversion, so the cube passes
+ * through itself once before the spin and once after.
+ */
+export const morphSchedule = (u: number): number =>
+  0.5 * smoothstep(0, 0.40, u) + 0.5 * smoothstep(0.60, 1, u)
+
+/** The spatial turn, which happens entirely between the two inversions. */
+export const spinSchedule = (u: number): number => smoothstep(0.42, 0.58, u)
+
+/** The frame at rest — the recognisable mark, and the reduced-motion state. */
+export const RESTING = project(0)


### PR DESCRIPTION
The app-launcher logo was **eight vertices on eight separate CSS keyframe tracks**, each tweening its own cx/cy, plus dashed "dynamic" edges on a ninth. It could not produce a coherent projection because nothing tied the vertices to a shape — they were eight independent animations that happened to start on a cube, which is why the edges drifted out of square as soon as it ran.

It is now the real 4D projection, from the **same module the loader draws from**, so the launcher and the loading state are recognisably one mark rather than two lookalikes that will drift apart.

### Still by default, slow on hover

At rest it is a logo and behaves like one: a precise isometric hexagon that never competes with the content beside it. Chrome that moves on its own is chrome people learn to tune out.

Under a pointer it runs the same invert-turn-invert loop over **15 seconds against the loader's 4.5**. Three times slower is the difference between "this is alive" and "this is working" — a launcher inverting at loading speed would read as a progress indicator and imply something was happening when nothing was.

Touch has no hover, so on a phone it is simply the static mark. That is the right outcome rather than a gap.

### Structure

Extracted `lib/brand/tesseract-geometry` (vertices, edges, isometric camera, ZW rotation, the two schedules) and `TesseractMark` (the drawing, driven by a period and a boolean). `TesseractLoader` is now only the loading composition. The geometry was going to be needed twice, and a second copy is how two logos become two different logos.

No vertex nodes at launcher size — sixteen dots on a 24px mark close the gaps between the lines and it reads as a blob — and a heavier stroke, because a hairline at 24px disappears into the header.

### Coverage

The projection tests move to `lib/brand` with the geometry, and `guard:unit` gains `src/lib/brand` and `src/components/ui` — **neither of which it covered**.

Full `npm run guard`: unit 427, layout 193, card-surface 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)