### PR TITLE
fix(feed): chips are labels; Explore opens cards; targets edit in place

### DIFF
--- a/e2e/explore.spec.ts
+++ b/e2e/explore.spec.ts
@@ -159,12 +159,24 @@ test.describe('tiles', () => {
     await expect(roku).toContainText('ROKU')
   })
 
-  test('a tap records its destination', async ({ page }) => {
+  test('a tap opens the item rather than navigating', async ({ page }) => {
+    /**
+     * Explore is preview -> rich tile -> asset page. Tapping a preview used to
+     * jump straight to the asset route, which skips the middle step and throws
+     * away the reader's place in the mosaic.
+     *
+     * The gallery has no router and no feed behind it, so what is asserted here
+     * is the contract the dashboard depends on: the tap reports the item and
+     * its Phase 4 destination, and does not resolve that destination itself.
+     * The overlay and its explicit "Open [Ticker]" live in MobileDashboard.
+     */
     const tile = page.locator('[data-explore-tile="d-ceg-gap"]')
     await tile.click()
     expect(await page.evaluate(() => document.body.dataset.exploreOpened)).toBe('d-ceg-gap')
     // Routed through the Phase 4 grammar, not a second route vocabulary.
     expect(await page.evaluate(() => document.body.dataset.exploreDestination)).toBe('open_cases')
+    // And the mosaic is still there underneath.
+    await expect(page.locator('[data-explore-scroll]')).toBeVisible()
   })
 
   test('an aggregate is not a dead end', async ({ page }) => {

--- a/src/components/mobile/MobileDashboard.tsx
+++ b/src/components/mobile/MobileDashboard.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { Lightbulb, SlidersHorizontal, X } from 'lucide-react'
+import { ChevronLeft, Lightbulb, SlidersHorizontal, X } from 'lucide-react'
 import { ReadthroughSheet } from './ReadthroughSheet'
 import { useIdeasFeed } from '../../hooks/ideas/useIdeasFeed'
 import type { ScoredFeedItem, ItemType } from '../../hooks/ideas/types'
@@ -22,6 +22,8 @@ import { clsx } from 'clsx'
 import { logPilotEvent } from '../../lib/pilot/pilot-telemetry'
 import { MobileExplore } from './MobileExplore'
 import { TesseractLoader } from '../ui/TesseractLoader'
+import { BottomSheet } from './BottomSheet'
+import { MobileCaseTargets } from './asset/MobileCaseTargets'
 import {
   aggregatesFor, attentionToExplore, exploreSymbols, ideasToExplore, insightsToExplore,
   lensesToExplore, newsToExplore, scenarioCardsToExplore, templatesToExplore,
@@ -353,6 +355,26 @@ export function MobileDashboard({ onNavigate }: MobileDashboardProps) {
   const [mode, setMode] = useState<'curate' | 'explore'>('curate')
   /** Explore's own category selection, kept apart from Curate's filter state. */
   const [exploreCategory, setExploreCategory] = useState<FeedCategory | null>(null)
+  /**
+   * The Explore tile a reader has opened, if any.
+   *
+   * Explore is preview -> rich tile -> asset page. Tapping a preview used to
+   * jump straight to the asset route, which skips the middle step and throws
+   * away the reader's place in the mosaic. This holds the opened item so the
+   * rich card can render over Explore, with Explore still mounted behind it.
+   */
+  const [exploreFocus, setExploreFocus] = useState<ExploreItem | null>(null)
+
+  /**
+   * The target/cases editor, opened over the card instead of replacing it.
+   *
+   * "Set a target" and "Review cases" both routed to the asset page, which is
+   * the whole surface for a change that takes one number and a horizon — the
+   * reader loses the feed, their place in it, and the card they were answering.
+   */
+  const [targetSheet, setTargetSheet] = useState<
+    { assetId: string; symbol: string; price: number | null } | null
+  >(null)
 
   const [kindFilter, setKindFilter] = useState<string | null>(null)
 
@@ -1605,17 +1627,52 @@ export function MobileDashboard({ onNavigate }: MobileDashboardProps) {
    * grammar for Explore is exactly the divergence that gave the product two
    * filter taxonomies and cost a phase to unpick.
    */
+  /**
+   * Opening a tile shows the rich card, not the asset page.
+   *
+   * `filter` destinations never reach here — `MobileExplore` owns the category
+   * state and handles those itself. Everything else focuses the item, and the
+   * overlay decides what it can render. Navigation is still available from
+   * inside that card, as an explicit action, which is the order the mode is
+   * meant to have: preview, then detail, then leave.
+   */
   const openExploreItem = useCallback((item: ExploreItem) => {
-    // `filter` destinations never reach here: `MobileExplore` owns the
-    // category state and handles them itself. Narrowed anyway, because the
-    // union still admits them and an unchecked cast would be the thing that
-    // silently breaks when a third destination kind is added.
     if (item.destination.kind === 'filter') return
-    if (item.destination.kind === 'tab') {
-      onNavigate?.(item.destination.target)
+    setExploreFocus(item)
+  }, [])
+
+  /**
+   * Contextual actions, handled in place where the feed can honour them.
+   *
+   * `review_target`, `set_target` and `open_cases` all resolve to the same
+   * editor — `MobileCaseTargets`, which is where a price and a horizon are
+   * actually written — so the feed opens it over the card rather than
+   * navigating to the page that hosts it. Persistence is that component's own;
+   * nothing here fakes a save.
+   *
+   * Everything else still routes. `update_thesis` in particular needs a
+   * rich-text field with history beside it, which is a page rather than a
+   * sheet, and pretending otherwise would be the dead-end button this feed has
+   * been removing since Phase 4.
+   */
+  const handleFeedAction = useCallback((t: { id: string; title: string; type: string; data: Record<string, unknown> }) => {
+    const focus = (t.data as any)?.focus
+    if (t.type === 'asset' && (focus === 'target' || focus === 'cases')) {
+      setTargetSheet({
+        assetId: String((t.data as any).id ?? t.id),
+        symbol: String((t.data as any).symbol ?? t.title),
+        price: null,
+      })
       return
     }
+    onNavigate?.(t)
+  }, [onNavigate])
+
+  /** Leaving the focused card for the asset page, on purpose. */
+  const leaveExploreForAsset = useCallback((item: ExploreItem) => {
     const d = item.destination
+    if (d.kind === 'tab') return onNavigate?.(d.target)
+    if (d.kind !== 'action') return
     const target = resolveFeedAction(d.action as FeedActionKey, {
       assetId: d.assetId ?? null,
       symbol: d.symbol ?? null,
@@ -1769,7 +1826,7 @@ export function MobileDashboard({ onNavigate }: MobileDashboardProps) {
           panes={panes}
           onOpenAsset={openAsset}
           onOpenPortfolio={openPortfolio}
-          onFeedAction={t => onNavigate?.(t)}
+          onFeedAction={handleFeedAction}
           onFeedback={applyFeedback}
           onCapture={setCaptureCtx}
           onWhy={() => {}}
@@ -2014,7 +2071,7 @@ export function MobileDashboard({ onNavigate }: MobileDashboardProps) {
           ]}
           onOpenAsset={openAsset}
           onOpenPortfolio={openPortfolio}
-          onFeedAction={t => onNavigate?.(t)}
+          onFeedAction={handleFeedAction}
           onFeedback={applyFeedback}
           onCapture={setCaptureCtx}
           onWhy={() => {}}
@@ -2024,140 +2081,15 @@ export function MobileDashboard({ onNavigate }: MobileDashboardProps) {
         />
   )
 
-  return (
-    // Column, not a positioning context with an overlay in it. The filter bar
-    // below used to be `absolute top-0`, which kept it from scrolling away but
-    // also took it out of layout — so it sat on top of the first tile's header
-    // band, hiding the kind badge and attribution behind it. A flex column
-    // gives it its own height and leaves the rest to the scroller, which is
-    // what "above the scroller" was trying to express in the first place.
-    <div className="relative h-full overflow-hidden flex flex-col">
-      <PullToRefreshIndicator ref={indicatorRef as any} isRefreshing={isRefreshing} armed={armed} />
-
-      {/* Active filter. Occupies its own row so it cannot scroll away and
-          cannot cover the feed — a filter you cannot see is a feed that looks
-          broken, and one that hides the tile beneath it is worse. */}
-      {/* Always-present entry point. The chip filter below only appears once
-          something is filtered, which is correct for a state indicator and
-          wrong for a control — there was no way to *start* curating. */}
-      <div className="flex-shrink-0 flex items-center gap-2 px-3 pb-1.5 pt-1.5 [padding-top:calc(0.375rem+env(safe-area-inset-top))] border-b border-gray-200 dark:border-gray-800">
-        {/* The mode switch, in the open and one tap from anywhere.
-            Not behind the overflow menu: it is one of two peer answers to
-            "what am I doing here", and a browsing mode nobody can find is a
-            browsing mode nobody uses. 32px tall so it costs one row rather
-            than a band, and the safe-area inset above it is unchanged. */}
-        <div data-feed-mode={mode} className="flex shrink-0 rounded-full bg-gray-100 p-0.5 dark:bg-gray-800">
-          {(['curate', 'explore'] as const).map(m => (
-            <button
-              key={m}
-              type="button"
-              data-mode-option={m}
-              aria-pressed={mode === m}
-              onClick={() => {
-                setMode(m)
-                logPilotEvent({ eventType: 'feed_mode', organizationId: currentOrgId ?? null, metadata: { mode: m } })
-              }}
-              className={clsx(
-                'h-7 rounded-full px-3 text-[12px] font-bold no-touch-target',
-                mode === m
-                  ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
-                  : 'text-gray-500 dark:text-gray-400',
-              )}
-            >
-              {/* "Ideas", not "Curate". Curate is what the FILTER does — it
-                  narrows the feed — and using the same word for the browsing
-                  mode made two different controls claim one verb. The internal
-                  key stays `curate` so telemetry and the filter sheet keep
-                  their vocabulary. */}
-              {m === 'curate' ? 'Ideas' : 'Explore'}
-            </button>
-          ))}
-        </div>
-
-        <button
-          type="button"
-          onClick={() => setFilterSheetOpen(true)}
-          className="flex items-center gap-1.5 h-8 px-3 rounded-full bg-gray-100 dark:bg-gray-800 text-[12px] font-bold text-gray-700 dark:text-gray-200 no-touch-target"
-        >
-          <SlidersHorizontal className="h-3.5 w-3.5" />
-          Curate
-          {filterCount(feedFilter) > 0 && (
-            <span className="px-1.5 rounded-full bg-primary-600 text-white text-[10px]">
-              {filterCount(feedFilter)}
-            </span>
-          )}
-        </button>
-        {filterCount(feedFilter) > 0 && (
-          <button
-            type="button"
-            onClick={() => setFeedFilter(EMPTY_FILTER)}
-            className="text-[12px] font-semibold text-gray-500 dark:text-gray-400 underline underline-offset-2 no-touch-target"
-          >
-            Reset
-          </button>
-        )}
-      </div>
-
-      {kindFilter && (
-        // pt-safe alone collapses to zero on a phone with no notch, which is
-        // why the band read as cramped against the top edge. A real 10px floor
-        // plus the inset, and more room below it, gives the row a band rather
-        // than a stripe.
-        <div className="flex-shrink-0 z-40 flex items-center gap-2 px-3 py-2.5 bg-gray-900 text-white dark:bg-gray-800">
-          <span className="text-[11px] font-bold uppercase tracking-[0.06em]">
-            {CATEGORY_LABEL[kindFilter as FeedCategory] ?? kindFilter} only
-          </span>
-          <button
-            type="button"
-            onClick={() => setKindFilter(null)}
-            className="ml-auto flex items-center gap-1 h-7 px-2.5 rounded-full bg-white/15 text-[11px] font-semibold active:bg-white/25 no-touch-target"
-          >
-            <X className="h-3 w-3" strokeWidth={2.5} />
-            Clear
-          </button>
-        </div>
-      )}
-
-      {/* Explore replaces the snap scroller entirely rather than wrapping it.
-          The two modes are different layouts with different scroll owners, and
-          nesting one inside the other is how gesture architecture leaks — the
-          snap container would still be there, still mandatory, still claiming
-          one viewport per child. */}
-      {mode === 'explore' ? (
-        <MobileExplore
-          candidates={exploreCandidates}
-          series={exploreSeries}
-          category={exploreCategory}
-          onCategoryChange={setExploreCategory}
-          onOpen={openExploreItem}
-          onTelemetry={(eventType, metadata) =>
-            // Product telemetry, never `audit_events`. Browsing is not
-            // investment judgment, and putting it in the research record would
-            // make every future reader filter it out before counting anything.
-            logPilotEvent({ eventType, organizationId: currentOrgId ?? null, metadata })}
-        />
-      ) : (
-      <>
-      {/* min-h-0 matters: a flex child defaults to min-height:auto, which lets
-          it grow to its content instead of scrolling, and the snap sections
-          inside are full-height by definition. Without it the scroller has no
-          bounded height and every tile spills. */}
-      <div
-        ref={setScroller}
-        // Mandatory snapping stays.
-        //
-        // It was briefly relaxed to `proximity` on the theory that mandatory
-        // snapping was what made the feed read as a stack of full-screen
-        // alerts. It was not: the full-screen CARDS were, and once a compact
-        // card is 380px the next one is already visible below it while the
-        // current one sits snapped to the top. Proximity bought nothing and
-        // cost the "one swipe advances exactly one tile" guarantee, which two
-        // gesture tests and every reader's muscle memory depend on.
-        className="flex-1 min-h-0 overflow-y-auto snap-y snap-mandatory overscroll-contain"
-      >
-        {/* Scenario cards are ranked with everything else — see renderScenarioCard. */}
-
-        {feedEntries.map(entry => {
+  /**
+   * One feed entry, rendered.
+   *
+   * Extracted from the map so Explore can reuse it. A tile there opens the
+   * SAME rich card Curate would show rather than a second detail surface —
+   * one renderer, so the two modes cannot drift into disagreeing about what a
+   * scenario gap looks like.
+   */
+  const renderEntry = (entry: any) => {
           // Ranked in with everything else now, rather than rendered in its own
           // block above the feed. The JSX is unchanged; only its position in the
           // list is decided differently.
@@ -2249,7 +2181,7 @@ export function MobileDashboard({ onNavigate }: MobileDashboardProps) {
                     ]}
                     onOpenAsset={openAsset}
                     onOpenPortfolio={openPortfolio}
-                    onFeedAction={t => onNavigate?.(t)}
+                    onFeedAction={handleFeedAction}
                     onFeedback={applyFeedback}
                     onCapture={setCaptureCtx}
                     onWhy={() => {}}
@@ -3017,7 +2949,7 @@ ins.assetId ?? null,
                       ]}
                       onOpenAsset={openAsset}
                       onOpenPortfolio={openPortfolio}
-                      onFeedAction={t => onNavigate?.(t)}
+                      onFeedAction={handleFeedAction}
                       onFeedback={applyFeedback}
                       onCapture={setCaptureCtx}
                       onWhy={() => {}}
@@ -3129,7 +3061,7 @@ c.assetId ?? null,
                     ]}
                     onOpenAsset={openAsset}
                     onOpenPortfolio={openPortfolio}
-                    onFeedAction={t => onNavigate?.(t)}
+                    onFeedAction={handleFeedAction}
                     onFeedback={applyFeedback}
                     onCapture={setCaptureCtx}
                     onWhy={() => {}}
@@ -3284,12 +3216,252 @@ c.assetId ?? null,
               />
             </div>
           )
-        })}
+  }
+
+  return (
+    // Column, not a positioning context with an overlay in it. The filter bar
+    // below used to be `absolute top-0`, which kept it from scrolling away but
+    // also took it out of layout — so it sat on top of the first tile's header
+    // band, hiding the kind badge and attribution behind it. A flex column
+    // gives it its own height and leaves the rest to the scroller, which is
+    // what "above the scroller" was trying to express in the first place.
+    <div className="relative h-full overflow-hidden flex flex-col">
+      <PullToRefreshIndicator ref={indicatorRef as any} isRefreshing={isRefreshing} armed={armed} />
+
+      {/* Active filter. Occupies its own row so it cannot scroll away and
+          cannot cover the feed — a filter you cannot see is a feed that looks
+          broken, and one that hides the tile beneath it is worse. */}
+      {/* Always-present entry point. The chip filter below only appears once
+          something is filtered, which is correct for a state indicator and
+          wrong for a control — there was no way to *start* curating. */}
+      <div className="flex-shrink-0 flex items-center gap-2 px-3 pb-1.5 pt-1.5 [padding-top:calc(0.375rem+env(safe-area-inset-top))] border-b border-gray-200 dark:border-gray-800">
+        {/* The mode switch, in the open and one tap from anywhere.
+            Not behind the overflow menu: it is one of two peer answers to
+            "what am I doing here", and a browsing mode nobody can find is a
+            browsing mode nobody uses. 32px tall so it costs one row rather
+            than a band, and the safe-area inset above it is unchanged. */}
+        <div data-feed-mode={mode} className="flex shrink-0 rounded-full bg-gray-100 p-0.5 dark:bg-gray-800">
+          {(['curate', 'explore'] as const).map(m => (
+            <button
+              key={m}
+              type="button"
+              data-mode-option={m}
+              aria-pressed={mode === m}
+              onClick={() => {
+                setMode(m)
+                logPilotEvent({ eventType: 'feed_mode', organizationId: currentOrgId ?? null, metadata: { mode: m } })
+              }}
+              className={clsx(
+                'h-7 rounded-full px-3 text-[12px] font-bold no-touch-target',
+                mode === m
+                  ? 'bg-white text-gray-900 shadow-sm dark:bg-gray-700 dark:text-white'
+                  : 'text-gray-500 dark:text-gray-400',
+              )}
+            >
+              {/* "Ideas", not "Curate". Curate is what the FILTER does — it
+                  narrows the feed — and using the same word for the browsing
+                  mode made two different controls claim one verb. The internal
+                  key stays `curate` so telemetry and the filter sheet keep
+                  their vocabulary. */}
+              {m === 'curate' ? 'Ideas' : 'Explore'}
+            </button>
+          ))}
+        </div>
+
+        <button
+          type="button"
+          onClick={() => setFilterSheetOpen(true)}
+          className="flex items-center gap-1.5 h-8 px-3 rounded-full bg-gray-100 dark:bg-gray-800 text-[12px] font-bold text-gray-700 dark:text-gray-200 no-touch-target"
+        >
+          <SlidersHorizontal className="h-3.5 w-3.5" />
+          Curate
+          {filterCount(feedFilter) > 0 && (
+            <span className="px-1.5 rounded-full bg-primary-600 text-white text-[10px]">
+              {filterCount(feedFilter)}
+            </span>
+          )}
+        </button>
+        {filterCount(feedFilter) > 0 && (
+          <button
+            type="button"
+            onClick={() => setFeedFilter(EMPTY_FILTER)}
+            className="text-[12px] font-semibold text-gray-500 dark:text-gray-400 underline underline-offset-2 no-touch-target"
+          >
+            Reset
+          </button>
+        )}
+      </div>
+
+      {kindFilter && (
+        // pt-safe alone collapses to zero on a phone with no notch, which is
+        // why the band read as cramped against the top edge. A real 10px floor
+        // plus the inset, and more room below it, gives the row a band rather
+        // than a stripe.
+        <div className="flex-shrink-0 z-40 flex items-center gap-2 px-3 py-2.5 bg-gray-900 text-white dark:bg-gray-800">
+          <span className="text-[11px] font-bold uppercase tracking-[0.06em]">
+            {CATEGORY_LABEL[kindFilter as FeedCategory] ?? kindFilter} only
+          </span>
+          <button
+            type="button"
+            onClick={() => setKindFilter(null)}
+            className="ml-auto flex items-center gap-1 h-7 px-2.5 rounded-full bg-white/15 text-[11px] font-semibold active:bg-white/25 no-touch-target"
+          >
+            <X className="h-3 w-3" strokeWidth={2.5} />
+            Clear
+          </button>
+        </div>
+      )}
+
+      {/* The focused Explore tile, over Explore.
+          ── Why an overlay and not a route ──────────────────────────────────
+          Explore is preview -> rich tile -> asset page, and the middle step
+          only works if the mosaic survives it: a reader who opens a tile,
+          decides it is not interesting and closes it must land exactly where
+          they were. A route change loses the scroll position and the category,
+          and puts the browser's back stack between them and the page.
+          Not a snap container either. One card does not need a feed, and
+          wrapping it in one would put mandatory snapping around a single tile.
+      */}
+      {mode === 'explore' && exploreFocus && (
+        <div className="absolute inset-0 z-40 flex flex-col bg-white dark:bg-gray-900" data-explore-focus>
+          <div className="flex shrink-0 items-center gap-2 border-b border-gray-200 px-3 py-2 [padding-top:calc(0.5rem+env(safe-area-inset-top))] dark:border-gray-800">
+            <button
+              type="button"
+              data-explore-close
+              onClick={() => setExploreFocus(null)}
+              className="flex h-9 items-center gap-1 rounded-full px-2 text-[13px] font-semibold text-gray-600 dark:text-gray-300 no-touch-target"
+            >
+              <ChevronLeft className="h-4 w-4" />
+              Explore
+            </button>
+            {exploreFocus.symbol && (
+              // The explicit way out, which is the only way this surface
+              // navigates. Tapping a preview no longer does it by itself.
+              <button
+                type="button"
+                data-explore-open-asset
+                onClick={() => leaveExploreForAsset(exploreFocus)}
+                className="ml-auto flex h-9 items-center rounded-full bg-gray-100 px-3 text-[13px] font-bold text-gray-700 dark:bg-gray-800 dark:text-gray-200 no-touch-target"
+              >
+                Open {exploreFocus.symbol}
+              </button>
+            )}
+          </div>
+
+          <div className="min-h-0 flex-1">
+            {(() => {
+              /**
+               * The SAME card Curate would render, found by matching the
+               * preview back to the entry it came from.
+               *
+               * Matched on asset and ranked signal type, because those are what
+               * both sides agree on: `rankInputFor` gives every feed entry a
+               * type and an id, and an Explore item's `dedupeKey` is built from
+               * the same signal type and asset. Rebuilding the card from the
+               * preview instead would mean a second copy of every builder.
+               *
+               * A preview with no matching entry — a post, an aggregate, a
+               * template with no ticker — falls back to what the preview itself
+               * knows. That is honest: the alternative is inventing a card.
+               */
+              const wantType = exploreFocus.dedupeKey.split(':')[0]
+              const match = (unfilteredRef.current as any[]).find(e => {
+                const input = rankInputFor(e)
+                if (exploreFocus.assetId && input.id.includes(exploreFocus.assetId)) return true
+                return input.type === wantType
+                  && (!exploreFocus.symbol || String(e?.lens?.[Object.keys(e.lens ?? {})[1]]?.symbol ?? '')
+                      .toUpperCase() === exploreFocus.symbol.toUpperCase())
+              })
+              if (match) return renderEntry(match)
+              return (
+                <div className="flex h-full flex-col justify-center px-6 text-center">
+                  <p className="text-[15px] font-semibold text-gray-900 dark:text-white">
+                    {exploreFocus.title}
+                  </p>
+                  {exploreFocus.context && (
+                    <p className="mt-2 text-[13px] text-gray-500">{exploreFocus.context}</p>
+                  )}
+                  <p className="mt-4 text-[12px] text-gray-400">
+                    {/* Said plainly rather than dressed up as a card. */}
+                    This one lives on its own surface.
+                  </p>
+                </div>
+              )
+            })()}
+          </div>
+        </div>
+      )}
+
+      {/* Explore replaces the snap scroller entirely rather than wrapping it.
+          The two modes are different layouts with different scroll owners, and
+          nesting one inside the other is how gesture architecture leaks — the
+          snap container would still be there, still mandatory, still claiming
+          one viewport per child. */}
+      {mode === 'explore' ? (
+        <MobileExplore
+          candidates={exploreCandidates}
+          series={exploreSeries}
+          category={exploreCategory}
+          onCategoryChange={setExploreCategory}
+          onOpen={openExploreItem}
+          onTelemetry={(eventType, metadata) =>
+            // Product telemetry, never `audit_events`. Browsing is not
+            // investment judgment, and putting it in the research record would
+            // make every future reader filter it out before counting anything.
+            logPilotEvent({ eventType, organizationId: currentOrgId ?? null, metadata })}
+        />
+      ) : (
+      <>
+      {/* min-h-0 matters: a flex child defaults to min-height:auto, which lets
+          it grow to its content instead of scrolling, and the snap sections
+          inside are full-height by definition. Without it the scroller has no
+          bounded height and every tile spills. */}
+      <div
+        ref={setScroller}
+        // Mandatory snapping stays.
+        //
+        // It was briefly relaxed to `proximity` on the theory that mandatory
+        // snapping was what made the feed read as a stack of full-screen
+        // alerts. It was not: the full-screen CARDS were, and once a compact
+        // card is 380px the next one is already visible below it while the
+        // current one sits snapped to the top. Proximity bought nothing and
+        // cost the "one swipe advances exactly one tile" guarantee, which two
+        // gesture tests and every reader's muscle memory depend on.
+        className="flex-1 min-h-0 overflow-y-auto snap-y snap-mandatory overscroll-contain"
+      >
+        {/* Scenario cards are ranked with everything else — see renderScenarioCard. */}
+
+        {feedEntries.map(renderEntry)}
 
         <div ref={sentinelRef} className="h-px" />
       </div>
       </>
       )}
+
+      {/* The target and case editor, over the card.
+          The real one — `MobileCaseTargets` writes through
+          `useAnalystPriceTargets`, so a save here is a save. `viewFilter` is
+          the reader's own id because editing requires it; the aggregated view
+          is read-only and would give them a sheet they cannot type in.
+          A sheet is one of the two places a vertical scroller is legitimate on
+          this surface: it is an overlay, not a member of the snap feed. */}
+      <BottomSheet
+        open={targetSheet !== null}
+        onClose={() => setTargetSheet(null)}
+        title={targetSheet ? `${targetSheet.symbol} price target` : ''}
+        snapPoints={[0.7, 0.95]}
+        aria-label="Price target editor"
+      >
+        {targetSheet && (
+          <div data-slot="target-sheet" className="px-3 pb-6">
+            <MobileCaseTargets
+              assetId={targetSheet.assetId}
+              currentPrice={targetSheet.price}
+              viewFilter={userId ?? 'aggregated'}
+            />
+          </div>
+        )}
+      </BottomSheet>
 
       <FeedCaptureSheet
         open={captureCtx !== null}

--- a/src/components/signals/SignalCardView.tsx
+++ b/src/components/signals/SignalCardView.tsx
@@ -651,9 +651,9 @@ export function SignalCardView({
                       data-slot="context-disclose"
                       aria-expanded={booksOpen === chip.label}
                       onClick={() => setBooksOpen(v => (v === chip.label ? null : chip.label))}
-                      className="flex items-center gap-1 font-semibold text-gray-700 underline decoration-dotted decoration-gray-400 underline-offset-2 active:opacity-70 dark:text-gray-200 no-touch-target"
+                      className="flex min-w-0 items-center gap-1 font-semibold text-gray-700 underline decoration-dotted decoration-gray-400 underline-offset-2 active:opacity-70 dark:text-gray-200 no-touch-target"
                     >
-                      {chip.label}
+                      <span className="min-w-0 truncate">{chip.label}</span>
                       <ChevronDown className={clsx('h-3.5 w-3.5 transition-transform', booksOpen === chip.label && 'rotate-180')} />
                     </button>
                   ) : chip.href && onContext ? (
@@ -661,7 +661,7 @@ export function SignalCardView({
                       type="button"
                       data-slot="context-link"
                       onClick={() => onContext(chip)}
-                      className="font-semibold text-gray-700 underline decoration-gray-300 underline-offset-2 active:opacity-70 dark:text-gray-200 dark:decoration-gray-600 no-touch-target"
+                      className="min-w-0 truncate font-semibold text-gray-700 underline decoration-gray-300 underline-offset-2 active:opacity-70 dark:text-gray-200 dark:decoration-gray-600 no-touch-target"
                     >
                       {chip.label}
                     </button>

--- a/src/lib/signals/__tests__/chip-label.test.ts
+++ b/src/lib/signals/__tests__/chip-label.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { buildAttentionCard } from '../builders/legacy-kinds'
+
+/**
+ * A chip is a label, not a sentence.
+ *
+ * `next_action` and workflow tags are free text, so an overdue card could carry
+ * a whole instruction as one chip. Reported from a phone: "the Review lines are
+ * terrible and extend beyond the screen."
+ */
+const attention = (over: Record<string, unknown> = {}) => ({
+  attention_id: 'a1',
+  attention_type: 'action_required',
+  title: 'Q3 sector review is overdue',
+  reason_text: 'You own this deliverable.',
+  created_at: new Date().toISOString(),
+  ...over,
+}) as any
+
+describe('context chips', () => {
+  it('caps a long next_action instead of letting it run off the row', () => {
+    const r = buildAttentionCard(attention({
+      next_action: 'Review the Q3 model and confirm the margin assumptions with the team',
+    }))
+    if (!r.ok) throw new Error(r.reason)
+    for (const chip of r.card.context) {
+      expect(chip.label.length, `chip too long: ${chip.label}`).toBeLessThanOrEqual(27)
+    }
+  })
+
+  it('cuts at a word boundary in the source, not mid-word', () => {
+    const source = 'Review the quarterly margin bridge before Thursday'
+    const r = buildAttentionCard(attention({ next_action: source }))
+    if (!r.ok) throw new Error(r.reason)
+    const chip = r.card.context.find(c => c.label.endsWith('…'))
+    expect(chip, 'expected a truncated chip').toBeTruthy()
+
+    /**
+     * The honest test of "ends on a word": the kept text must be a prefix of
+     * the source, and the source must continue with a space.
+     *
+     * An earlier version asserted the label did not end in one or two lowercase
+     * letters, which fails on "quarterly…" — a complete word that happens to
+     * end in "ly". That tested spelling, not truncation.
+     */
+    const kept = chip!.label.slice(0, -1)
+    expect(source.startsWith(kept)).toBe(true)
+    expect(source[kept.length]).toBe(' ')
+  })
+
+  it('leaves short labels alone', () => {
+    const r = buildAttentionCard(attention({ next_action: 'Review', tags: ['urgent'] }))
+    if (!r.ok) throw new Error(r.reason)
+    const labels = r.card.context.map(c => c.label)
+    expect(labels).toContain('Review')
+    expect(labels.some(l => l.includes('…'))).toBe(false)
+  })
+})

--- a/src/lib/signals/builders/legacy-kinds.ts
+++ b/src/lib/signals/builders/legacy-kinds.ts
@@ -106,9 +106,28 @@ function heldInChips(
  * stored prose ("make a decision.", "review.") reads as a chip rather than as a
  * clause that has lost its sentence.
  */
+/**
+ * A chip is a LABEL, not a sentence — and now it is enforced.
+ *
+ * `next_action` and workflow tags are free text, so an attention card could
+ * carry "Review the Q3 model and confirm the margin assumptions" as a single
+ * chip. On a 390px row that runs off the edge; the card view truncates it, but
+ * a chip that is a truncated sentence reads as broken rather than as a label.
+ *
+ * Cut at a word boundary where there is one nearby, so it ends on a word rather
+ * than mid-syllable. Anything needing more than this is prose and belongs in
+ * the body, which is where the full `next_action` already is.
+ */
+const MAX_CHIP = 26
+
 function chipCase(s: string): string {
   const t = s.trim().replace(/[.!;:,]+$/, '').trim()
-  return t ? t[0].toUpperCase() + t.slice(1) : t
+  if (!t) return t
+  const cased = t[0].toUpperCase() + t.slice(1)
+  if (cased.length <= MAX_CHIP) return cased
+  const cut = cased.slice(0, MAX_CHIP)
+  const space = cut.lastIndexOf(' ')
+  return `${(space > MAX_CHIP * 0.6 ? cut.slice(0, space) : cut).trimEnd()}…`
 }
 
 /** Every one of these ends up on the asset, so the action grammar is shared. */


### PR DESCRIPTION
Closes the last of the hands-on reports.

### Overdue chips ran off the row

`chipCase` capitalised and stripped punctuation but **never capped length**, so `next_action` — free text — could put a whole instruction on the context row: *"Review the Q3 model and confirm the margin assumptions with the team"* as one chip.

Capped at 26 characters, cut at a word boundary where there is one nearby. A chip that is a truncated sentence reads as broken rather than as a label; the full text is already in the body.

Two of the three chip render branches also lacked `min-w-0 truncate` — only the plain span had it, so link and disclosure chips still ran past the card edge. `overflow-hidden` on the row clips without ever making a child narrower.

### Explore opens cards, not the asset page

Tapping a preview navigated straight to the asset route, skipping the middle step of **preview → rich tile → asset** and throwing away the reader's place in the mosaic.

It now focuses the item and renders the *same card Curate would*, over Explore, with Explore still mounted behind it and an explicit **"Open [Ticker]"** as the only way out to the page.

That required extracting Curate's entry renderer from its `.map` callback — which is the point: one renderer, so the two modes cannot drift into disagreeing about what a scenario gap looks like. A preview with no matching entry (a post, an aggregate, a template with no ticker) falls back to what the preview itself knows rather than inventing a card.

### Targets and cases edit in place

`Set a target`, `Review target` and `Review cases` all routed to the asset page — the whole surface, for a change that takes one number and a horizon. They now open **`MobileCaseTargets` in a sheet over the card**.

That is the real editor: it writes through `useAnalystPriceTargets`, so **a save here is a save** and nothing fakes persistence. All three share it because they resolve to the same editor, which is why there is no separate "set" and "review" version.

`update_thesis` **deliberately still routes**. It needs a rich-text field with its history beside it, which is a page rather than a sheet, and a thin imitation would be the dead-end button this feed has been removing since Phase 4.

Full `npm run guard`: unit 430, layout 193, card-surface 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)