### PR TITLE
fix(feed): the crash — CardCarousel called hooks after an early return

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -35,8 +35,22 @@ export default tseslint.config([
     //
     // functions: false because function declarations hoist and referencing
     // them early is idiomatic here. It is `const` and `let` that throw.
-    files: ['src/components/mobile/**/*.{ts,tsx}'],
+    files: ['src/components/mobile/**/*.{ts,tsx}', 'src/components/signals/**/*.{ts,tsx}'],
     rules: {
+      /**
+       * Hooks are positional, and a conditional return is a conditional hook.
+       *
+       * `CardCarousel` declared two refs beside the code that used them, which
+       * was after `if (panes.length === 1) return ...`. A card renders two
+       * hooks on one pass and four on the next — and a pane count DOES change
+       * between passes, because price history arrives and adds a chart pane.
+       * React threw #310 and every logged-in reader got "Oops! Something went
+       * wrong" on a hard refresh.
+       *
+       * tsc cannot see this, and neither can any assertion about rendered
+       * output, because the first render is fine. Only the rule catches it.
+       */
+      'react-hooks/rules-of-hooks': 'error',
       '@typescript-eslint/no-use-before-define': ['error', {
         variables: true,
         functions: false,

--- a/scripts/lint-mobile-ratchet.mjs
+++ b/scripts/lint-mobile-ratchet.mjs
@@ -16,7 +16,7 @@ const MAX_VIOLATIONS = 0  // May only decrease.
 
 let raw
 try {
-  raw = execFileSync('npx', ['eslint', 'src/components/mobile', '--ext', '.ts,.tsx', '-f', 'json'],
+  raw = execFileSync('npx', ['eslint', 'src/components/mobile', 'src/components/signals', '--ext', '.ts,.tsx', '-f', 'json'],
     { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024, shell: process.platform === 'win32' })
 } catch (e) {
   // eslint exits non-zero when it finds errors; that is not a failure to run.
@@ -33,13 +33,36 @@ try {
 }
 
 const files = report.length
-const violations = report.flatMap(f =>
-  f.messages
-    .filter(m => (m.ruleId ?? '').endsWith('no-use-before-define'))
-    .map(m => `${f.filePath}:${m.line} ${m.message}`))
+const pick = (test) => report.flatMap(f =>
+  f.messages.filter(m => test(m.ruleId ?? '')).map(m => `${f.filePath}:${m.line} ${m.message}`))
+
+const violations = pick(id => id.endsWith('no-use-before-define'))
+
+/**
+ * Conditional hooks, gated at zero.
+ *
+ * `CardCarousel` declared two refs after `if (panes.length === 1) return ...`,
+ * so a card rendered two hooks on one pass and four on the next — and a pane
+ * count does change between passes, because price history arrives and adds a
+ * chart pane. React threw #310 and every logged-in reader got the error
+ * boundary on a hard refresh.
+ *
+ * Separate from the ratchet above because this has no backlog to work down: it
+ * is a correctness rule and the count is zero today. `exhaustive-deps` is NOT
+ * included — it is advisory, has eight standing violations, and folding the two
+ * together would mean either allowlisting a crash class or blocking on style.
+ */
+const hookOrder = pick(id => id === 'react-hooks/rules-of-hooks')
 
 console.log(`files linted: ${files}`)
 console.log(`use-before-define violations: ${violations.length}`)
+console.log(`conditional-hook violations: ${hookOrder.length}`)
+
+if (hookOrder.length > 0) {
+  console.error(`FAIL: ${hookOrder.length} hooks called conditionally:`)
+  hookOrder.forEach(v => console.error('  ' + v))
+  process.exit(1)
+}
 
 if (files < MIN_FILES) {
   console.error(`FAIL: only ${files} files linted, expected at least ${MIN_FILES}. The linter did not do its work.`)

--- a/src/components/signals/CardCarousel.tsx
+++ b/src/components/signals/CardCarousel.tsx
@@ -48,8 +48,33 @@ interface CardCarouselProps {
  * arbitrates far more reliably than a scroll-position heuristic.
  */
 export function CardCarousel({ panes }: CardCarouselProps) {
+  /**
+   * EVERY hook lives here, above the early returns below.
+   *
+   * ── The crash this caused ─────────────────────────────────────────────────
+   *
+   * `dotsRef` and `scrubbing` were declared next to the code that uses them,
+   * which is after `if (panes.length === 1) return ...`. So a card rendered two
+   * hooks on one pass and four on the next — and a card's pane count DOES
+   * change between passes: it starts with a control, price history arrives, and
+   * a chart pane appears. React throws #310, the boundary catches it, and the
+   * reader gets "Oops! Something went wrong" on a hard refresh.
+   *
+   * Hooks are positional. A conditional return is a conditional hook call, and
+   * proximity to the code that reads them is not worth that.
+   */
   const [active, setActive] = useState(0)
   const trackRef = useRef<HTMLDivElement>(null)
+  const dotsRef = useRef<HTMLDivElement>(null)
+  /**
+   * Whether a scrub is in progress.
+   *
+   * A ref rather than `hasPointerCapture`: capture can be taken away
+   * mid-gesture — the browser reclaims it when an element is removed or a
+   * native scroll wins — and the handler would then silently stop following the
+   * finger with no way to tell that from a finished drag.
+   */
+  const scrubbing = useRef(false)
 
   if (!panes.length) return null
   // One pane needs no carousel furniture — indicators for a single page are
@@ -84,16 +109,6 @@ export function CardCarousel({ panes }: CardCarouselProps) {
     el.scrollTo({ left: i * el.clientWidth, behavior: 'smooth' })
   }
 
-  const dotsRef = useRef<HTMLDivElement>(null)
-  /**
-   * Whether a scrub is in progress.
-   *
-   * A ref rather than `hasPointerCapture`, which was the first version: capture
-   * can be taken away mid-gesture — the browser reclaims it when an element is
-   * removed or a native scroll wins — and the handler would then silently stop
-   * following the finger with no way to tell that from a finished drag.
-   */
-  const scrubbing = useRef(false)
 
   /**
    * Which pane a point on the dot row corresponds to.


### PR DESCRIPTION
React #310 on hard refresh. The stack put it inside `<article>` — `SignalCardView`'s root — and the component below it in the evidence band is `CardCarousel`:

```
51  useState(active)
54  if (!panes.length) return null
66  if (panes.length === 1) return (...)
96  const scrubbing = useRef(false)     <- after both returns
```

I added `dotsRef` and `scrubbing` next to the code that uses them, which is after the single-pane shortcut. So a card renders **two hooks on one pass and four on the next** — and a card's pane count *does* change between passes, because price history arrives and adds a chart pane to a card that started with only a control.

Every hook is now above both returns.

### Why nothing caught it

`tsc` cannot see it. The layout assertions cannot either, because the **first render is correct** — the throw needs a second render with a different pane count, which only happens when an async source lands. That is the same shape as the #138 regression this repo already has a ratchet for: green everywhere, broken for every logged-in user.

So `react-hooks/rules-of-hooks` is now an **error** across `src/components/mobile` and `src/components/signals`, and `guard:tdz` gates it at zero.

Verified by re-introducing the exact bug and watching the guard fail with file and line, then restoring and watching it pass:

```
conditional-hook violations: 1
FAIL: 1 hooks called conditionally:
  CardCarousel.tsx:105 React Hook "useRef" is called conditionally...
```

`exhaustive-deps` is deliberately **not** included — it is advisory, has eight standing violations, and folding the two together would mean either allowlisting a crash class or blocking the build on style.

Full `npm run guard`: unit 431, layout 197, conditional-hook 0, card-surface 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)