### PR TITLE
feat(mobile): fullscreen chart, one exploration model, and a preview that opens what it previewed

### DIFF
--- a/src/components/mobile/MobileDashboard.tsx
+++ b/src/components/mobile/MobileDashboard.tsx
@@ -17,9 +17,11 @@ import { useSignalCards } from '../../hooks/ideas/useSignalCards'
 import { usePortfolioLenses } from '../../hooks/mobile/usePortfolioLenses'
 import { FeedFilterSheet } from './FeedFilterSheet'
 import { FeedSlot } from './FeedSlot'
+import { FullscreenChart } from '../signals/FullscreenChart'
+import { findExploreMatch } from '../../lib/mobile/explore-match'
 import { canChart, priceIdentity } from '../../lib/signals/price-availability'
 import { newsChartSymbol } from '../../lib/signals/news-chart'
-import { feedEntryKeys } from '../../lib/mobile/feed-entry-key'
+import { feedEntryKeys, symbolOfEntry } from '../../lib/mobile/feed-entry-key'
 import { EMPTY_FILTER, filterCount, useFeedFacets, type FeedFilter } from '../../hooks/mobile/useFeedFacets'
 import { CATEGORY_LABEL, categoryOf, type FeedCategory } from '../../lib/mobile/feed-categories'
 import { clsx } from 'clsx'
@@ -379,6 +381,23 @@ export function MobileDashboard({ onNavigate }: MobileDashboardProps) {
   const [targetSheet, setTargetSheet] = useState<
     { assetId: string; symbol: string; price: number | null } | null
   >(null)
+
+  /**
+   * The expanded chart, or nothing.
+   *
+   * Held here rather than per card so only one can ever be open, and so a
+   * windowed slot collapsing underneath does not take the overlay with it.
+   * Everything it needs is captured at open time — the series, the overlays,
+   * the resolved name — which also means it cannot re-resolve a symbol and
+   * find a different one.
+   */
+  const [fsChart, setFsChart] = useState<{
+    symbol: string
+    companyName: string | null
+    series: any[]
+    bands: PriceBand[]
+    markers: PriceMarker[]
+  } | null>(null)
 
   const [kindFilter, setKindFilter] = useState<string | null>(null)
 
@@ -1279,26 +1298,7 @@ export function MobileDashboard({ onNavigate }: MobileDashboardProps) {
      * silently remove whole categories from a "European only" view that the
      * reader never meant to exclude.
      */
-    const symbolOf = (e: any): string | null => {
-      switch (e.kind) {
-        case 'news':      return e.news?.primarySymbol ?? null
-        case 'template':  return e.card?.symbol ?? null
-        case 'insight':   return e.insight?.symbol ?? null
-        case 'lens':
-          return e.lens?.gap?.symbol ?? e.lens?.name?.symbol
-              ?? e.lens?.breach?.symbol ?? e.lens?.target?.symbol
-              ?? e.lens?.position?.symbol ?? null
-        // `e.idea`, not `e.item`. The entry stores the post under `idea` and
-        // has since it was written, so this returned undefined for every idea
-        // in the feed — which made `subject` null, which made `matchesFilter`
-        // drop every idea the moment any asset facet was set. The Ideas filter
-        // came back empty and nothing said why.
-        case 'idea':      return (e.idea as any)?.asset?.symbol ?? null
-        case 'scenario':  return e.card?.entity?.ticker ?? null
-        case 'attention': return null
-        default:          return null
-      }
-    }
+    const symbolOf = symbolOfEntry
 
     const assetFacetsActive =
       feedFilter.sectors.length > 0 || feedFilter.countries.length > 0 ||
@@ -1740,6 +1740,8 @@ export function MobileDashboard({ onNavigate }: MobileDashboardProps) {
       const id = priceIdentity(symbol, s2 => priceHistory?.get(tradedSymbolOf(s2)))
       if (!canChart(id)) return null
       const series = id.series
+      const bands = opts?.bands ?? []
+      const markers = opts?.markers ?? []
       return {
         id: 'price',
         label: 'Price',
@@ -1750,8 +1752,18 @@ export function MobileDashboard({ onNavigate }: MobileDashboardProps) {
             // the same name the series was looked up under.
             symbol={id.symbol}
             series={series}
-            bands={opts?.bands ?? []}
-            markers={opts?.markers ?? []}
+            bands={bands}
+            markers={markers}
+            /**
+             * The expand control is offered only where there is genuinely a
+             * tape to expand — this branch has already established that
+             * through `priceIdentity`, so the fullscreen chart can never be
+             * opened onto a symbol with no history.
+             */
+            onExpand={() => setFsChart({
+              symbol: id.symbol!, companyName: assetBySymbol.get(id.symbol!)?.companyName ?? null,
+              series, bands, markers,
+            })}
           />
         ),
       }
@@ -3422,14 +3434,14 @@ c.assetId ?? null,
                * template with no ticker — falls back to what the preview itself
                * knows. That is honest: the alternative is inventing a card.
                */
-              const wantType = exploreFocus.dedupeKey.split(':')[0]
-              const match = (unfilteredRef.current as any[]).find(e => {
-                const input = rankInputFor(e)
-                if (exploreFocus.assetId && input.id.includes(exploreFocus.assetId)) return true
-                return input.type === wantType
-                  && (!exploreFocus.symbol || String(e?.lens?.[Object.keys(e.lens ?? {})[1]]?.symbol ?? '')
-                      .toUpperCase() === exploreFocus.symbol.toUpperCase())
-              })
+              const match = findExploreMatch(
+                exploreFocus,
+                unfilteredRef.current as any[],
+                e => {
+                  const input = rankInputFor(e)
+                  return { type: input.type, id: input.id, symbol: symbolOfEntry(e) }
+                },
+              )
               if (match) return renderEntry(match)
               return (
                 <div className="flex h-full flex-col justify-center px-6 text-center">
@@ -3507,6 +3519,20 @@ c.assetId ?? null,
       </div>
       </>
       )}
+
+      {/* The expanded chart. One shell for every card kind — see
+          FullscreenChart for why the overlays are parameters rather than
+          variants. Closing restores the card and the feed untouched, because
+          nothing about the feed changed while it was open. */}
+      <FullscreenChart
+        open={fsChart !== null}
+        onClose={() => setFsChart(null)}
+        symbol={fsChart?.symbol ?? ''}
+        companyName={fsChart?.companyName}
+        series={fsChart?.series ?? []}
+        bands={fsChart?.bands}
+        markers={fsChart?.markers}
+      />
 
       {/* The target and case editor, over the card.
           The real one — `MobileCaseTargets` writes through

--- a/src/components/signals/CaseExplorer.tsx
+++ b/src/components/signals/CaseExplorer.tsx
@@ -1,0 +1,157 @@
+import { useState } from 'react'
+import { clsx } from 'clsx'
+
+import { ValueExplorer } from './ValueExplorer'
+import {
+  beginExploration, isDirty, upsidePct, type Exploration,
+} from '../../lib/mobile/exploration'
+
+/**
+ * Bear / Base / Bull, switchable and editable in place.
+ *
+ * ── The rule this exists to satisfy ───────────────────────────────────────
+ *
+ * "Changing Bear / Base / Bull must NOT require pressing Set a target first."
+ *
+ * Targets and scenarios are different concepts, and the old flow conflated
+ * them: reaching the cases meant going through the target control, so an
+ * analyst who works in cases was routed through a number they do not use in
+ * order to edit the numbers they do. A reader who says "I use cases" belongs
+ * in the scenario framework directly.
+ *
+ * ── Drafts are kept per case ──────────────────────────────────────────────
+ *
+ * Switching from Bear to Bull with an unsaved Bear value does not discard it.
+ * The brief allows either preserving drafts or prompting, and preserving is
+ * the simpler coherent behaviour: comparing cases is the entire point of
+ * having three, so flipping between them has to be free. A prompt on every
+ * switch would make the comparison the expensive operation.
+ *
+ * Each case keeps its own `Exploration`, so "recorded" stays per case and Save
+ * writes exactly the one the reader is looking at.
+ */
+
+export interface ExplorableCase {
+  id: string
+  /** "Bear", "Base", "Bull", or whatever the analyst named it. */
+  name: string
+  /** The recorded price for this case, or null if unset. */
+  price: number | null
+}
+
+interface CaseExplorerProps {
+  symbol: string
+  cases: ExplorableCase[]
+  currentPrice: number | null
+  onSave: (caseId: string, price: number) => void
+  saving?: boolean
+  /** Add a case the ladder does not have yet. Omitted when not permitted. */
+  onAddCase?: () => void
+  /** So the chart can draw the case being explored. */
+  onProposedChange?: (caseId: string, proposed: number | null) => void
+}
+
+const money = (v: number) => v >= 1000 ? `$${v.toFixed(0)}` : `$${v.toFixed(2)}`
+
+export function CaseExplorer({
+  symbol, cases, currentPrice, onSave, saving, onAddCase, onProposedChange,
+}: CaseExplorerProps) {
+  const [selectedId, setSelectedId] = useState(() => cases[0]?.id ?? '')
+  /**
+   * One exploration per case, created lazily.
+   *
+   * Keyed by case id rather than index so that a ladder which gains or loses a
+   * case does not silently shift somebody's unsaved draft onto a different
+   * scenario.
+   */
+  const [drafts, setDrafts] = useState<Record<string, Exploration>>(() =>
+    Object.fromEntries(cases.map(c => [c.id, beginExploration(c.price, currentPrice)])))
+
+  const selected = cases.find(c => c.id === selectedId) ?? cases[0]
+  if (!selected) return null
+
+  const state = drafts[selected.id] ?? beginExploration(selected.price, currentPrice)
+
+  const update = (next: Exploration) => {
+    setDrafts(d => ({ ...d, [selected.id]: next }))
+    onProposedChange?.(selected.id, next.proposed)
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col" data-slot="case-explorer">
+      {/* The selector. One tap per case, always visible, so comparing is a
+          tap rather than opening and closing three editors. */}
+      <div className="flex shrink-0 items-center gap-1" data-slot="case-selector">
+        {cases.map(c => {
+          const draft = drafts[c.id]
+          const dirty = draft ? isDirty(draft) : false
+          return (
+            <button
+              key={c.id}
+              type="button"
+              data-slot="case-tab"
+              data-case-id={c.id}
+              aria-pressed={c.id === selected.id}
+              onClick={() => setSelectedId(c.id)}
+              className={clsx(
+                'relative rounded-full px-2.5 py-1 text-[12px] font-bold transition-colors',
+                c.id === selected.id
+                  ? 'bg-gray-900 text-white dark:bg-white dark:text-gray-900'
+                  : 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300',
+              )}
+            >
+              {c.name}
+              {/* An unsaved draft on a case you are not looking at is
+                  invisible otherwise, and the reader would have no way to know
+                  work was waiting on another tab. */}
+              {dirty && (
+                <span
+                  data-slot="case-dirty"
+                  aria-label="unsaved"
+                  className="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-amber-500"
+                />
+              )}
+            </button>
+          )
+        })}
+        {onAddCase && (
+          <button
+            type="button"
+            data-slot="case-add"
+            aria-label="Add a case"
+            onClick={onAddCase}
+            className="rounded-full bg-gray-100 px-2 py-1 text-[12px] font-bold text-gray-500 dark:bg-gray-800"
+          >
+            +
+          </button>
+        )}
+      </div>
+
+      <div className="mt-2 min-h-0 flex-1">
+        <ValueExplorer
+          // Keyed on the case so the numeric-entry buffer inside cannot carry
+          // a half-typed Bear value across to Bull.
+          key={selected.id}
+          slot="case-value"
+          referenceLabel="Current"
+          recordedLabel={`${selected.name} recorded`}
+          proposedLabel="Proposed"
+          state={state}
+          onChange={update}
+          onSave={v => onSave(selected.id, v)}
+          saving={saving}
+          format={money}
+          secondary={v => {
+            const pct = upsidePct(v, currentPrice)
+            if (pct == null) return null
+            return `${pct >= 0 ? '+' : ''}${pct.toFixed(1)}% vs current`
+          }}
+          // The slider must reach every case on the ladder, or comparing them
+          // means dragging to a value the track cannot express.
+          reachable={cases.map(c => c.price)}
+          aria-label={`${symbol} ${selected.name}`}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/components/signals/FullscreenChart.tsx
+++ b/src/components/signals/FullscreenChart.tsx
@@ -1,0 +1,124 @@
+import { useEffect } from 'react'
+import { X } from 'lucide-react'
+
+import { PriceContext, type PriceBand, type PriceMarker, type PricePoint } from './PriceContext'
+
+/**
+ * The expanded chart. One shell, whatever card opened it.
+ *
+ * ── Why an overlay and not the asset page ─────────────────────────────────
+ *
+ * "Do not jump from Level 2 to Level 3 for interactions that can reasonably
+ * happen in place." Wanting a bigger chart is not a decision to leave the feed;
+ * routing to the asset page loses the card, the scroll position, and whatever
+ * the reader was part-way through on it. An overlay keeps all three, and
+ * closing puts them back exactly.
+ *
+ * ── Why the overlays are parameters rather than variants ──────────────────
+ *
+ * A target card wants its recorded level drawn; a scenario card wants bear,
+ * base and bull; a no-target card wants the price it is proposing; a news card
+ * wants the event date. Those are four sets of BANDS AND MARKERS, not four
+ * charts — `PriceContext` already draws both, and it already knows how to pin
+ * a level that sits far outside the price action rather than flattening the
+ * line to accommodate it.
+ *
+ * So there is exactly one fullscreen chart, and cards differ only in what they
+ * hand it. A second implementation would drift on the details that matter
+ * most: off-scale handling, the stale-data warning, and the refusal to label
+ * the right edge "today".
+ *
+ * ── What it will not do ───────────────────────────────────────────────────
+ *
+ * It takes a series or it renders nothing worth looking at. There is no symbol
+ * fallback and no way to reach one from here — the caller resolves
+ * availability through `price-availability` and simply does not offer the
+ * expand control when there is no tape. See `news-chart` for what happens when
+ * a chart is allowed to pick its own subject.
+ */
+
+export interface FullscreenChartProps {
+  open: boolean
+  onClose: () => void
+  symbol: string
+  companyName?: string | null
+  series: PricePoint[]
+  /** Recorded target, scenario levels, a proposal being explored. */
+  bands?: PriceBand[]
+  /** Event dates, horizons. */
+  markers?: PriceMarker[]
+}
+
+export function FullscreenChart({
+  open, onClose, symbol, companyName, series, bands = [], markers = [],
+}: FullscreenChartProps) {
+  /**
+   * Escape closes, and the page behind does not scroll.
+   *
+   * The feed is a snap scroller; leaving it live under a full-screen overlay
+   * means a scroll gesture that misses the chart moves the card the reader is
+   * about to come back to.
+   */
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose() }
+    window.addEventListener('keydown', onKey)
+    const prev = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      window.removeEventListener('keydown', onKey)
+      document.body.style.overflow = prev
+    }
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return (
+    <div
+      data-slot="fullscreen-chart"
+      role="dialog"
+      aria-modal="true"
+      aria-label={`${symbol} price history`}
+      className="fixed inset-0 z-50 flex flex-col bg-white dark:bg-gray-950"
+    >
+      <div className="flex shrink-0 items-start justify-between px-4 pt-3">
+        <div className="min-w-0">
+          <p data-slot="fs-symbol" className="text-[20px] font-bold leading-tight text-gray-900 dark:text-white">
+            {symbol}
+          </p>
+          {/* Only when we have it. 506 of 912 assets carry placeholder
+              metadata, and an empty line is better than "Unknown". */}
+          {companyName && (
+            <p data-slot="fs-name" className="truncate text-[13px] text-gray-500 dark:text-gray-400">
+              {companyName}
+            </p>
+          )}
+        </div>
+        <button
+          type="button"
+          data-slot="fs-close"
+          aria-label="Close"
+          onClick={onClose}
+          className="-mr-1 rounded-full p-2 text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-800"
+        >
+          <X className="h-5 w-5" />
+        </button>
+      </div>
+
+      {/* The chart takes everything left.
+          `PriceContext` carries its own read-out (symbol, inspected price,
+          change) and its own range chips, and it measures ranges from the
+          SERIES END rather than from today — so a symbol whose ingestion has
+          stalled shows a clearly labelled stale window instead of an empty
+          one. All of that is why this is a shell rather than a second chart. */}
+      <div className="min-h-0 flex-1 px-4 pb-6 pt-2">
+        <PriceContext
+          symbol={symbol}
+          series={series}
+          bands={bands}
+          markers={markers}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/components/signals/PriceContext.tsx
+++ b/src/components/signals/PriceContext.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { clsx } from 'clsx'
+import { Maximize2 } from 'lucide-react'
 
 import {
   GESTURE, advanceGesture, beginGesture, holdStillPossible, type GestureState,
@@ -38,6 +39,13 @@ interface PriceContextProps {
   /** Today, injectable so the staleness line is testable without mocking. */
   now?: Date
   initialRange?: RangeKey
+  /**
+   * Offered as an expand control beside the ranges when present.
+   *
+   * Optional so the fullscreen chart can render a `PriceContext` of its own
+   * without offering to expand what is already expanded.
+   */
+  onExpand?: () => void
 }
 
 /** Plot geometry, in viewBox units. Y only: x is always 0..100. */
@@ -130,6 +138,7 @@ function axisPrice(v: number): string {
  */
 export function PriceContext({
   symbol, series, bands = [], markers = [], staleAfterDays = STALE_DEFAULT_DAYS, now, initialRange,
+  onExpand,
 }: PriceContextProps) {
   const gradientId = useId()
   const [picked, setPicked] = useState<number | null>(null)
@@ -367,6 +376,21 @@ export function PriceContext({
         </span>
 
         <div className="ml-auto flex shrink-0 items-center gap-0.5" data-testid="price-ranges">
+          {/* Expand, beside the ranges rather than over the plot.
+              An affordance floating on the chart would sit in the middle of
+              the scrub area and be pressed by accident during exactly the
+              gesture it must not interrupt. */}
+          {onExpand && (
+            <button
+              type="button"
+              data-slot="chart-expand"
+              aria-label={`Expand ${symbol} chart`}
+              onClick={onExpand}
+              className="mr-0.5 rounded p-1 text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 no-touch-target"
+            >
+              <Maximize2 className="h-3.5 w-3.5" />
+            </button>
+          )}
           {available.map(r => (
             <button
               key={r.key}

--- a/src/components/signals/SizeExplorer.tsx
+++ b/src/components/signals/SizeExplorer.tsx
@@ -1,0 +1,111 @@
+import { useState } from 'react'
+
+import { ValueExplorer } from './ValueExplorer'
+import {
+  beginExploration, pointsChange, type Exploration,
+} from '../../lib/mobile/exploration'
+
+/**
+ * What if the position were X%?
+ *
+ * ── Analysis, not execution ───────────────────────────────────────────────
+ *
+ * This asks a question; it does not place a trade. The distinction is carried
+ * by the labels and by what Save does — it stages a proposed weight for
+ * somebody to act on through the trade flow, which is the only place a trade
+ * is ever committed. Nothing here reaches `accepted_trades`.
+ *
+ * ── Why "Change" is its own figure ────────────────────────────────────────
+ *
+ * A weight is already a percentage, so the difference between 7.2% and 5.0% is
+ * 2.2 POINTS, not 30%. Showing it as a percentage of a percentage is the
+ * classic way to make a sizing control lie, and the reader has to do the
+ * subtraction in their head otherwise. It gets a labelled figure of its own.
+ */
+
+interface SizeExplorerProps {
+  symbol: string
+  /** Today's weight in the book. */
+  currentPct: number | null
+  /** A previously staged proposal, if there is one. */
+  stagedPct?: number | null
+  /** Benchmark weight, so the slider can always reach neutral. */
+  benchmarkPct?: number | null
+  onStage: (proposedPct: number) => void
+  saving?: boolean
+}
+
+const pct = (v: number) => `${v.toFixed(1)}%`
+
+export function SizeExplorer({
+  symbol, currentPct, stagedPct = null, benchmarkPct = null, onStage, saving,
+}: SizeExplorerProps) {
+  const [state, setState] = useState<Exploration>(
+    () => beginExploration(stagedPct, currentPct),
+  )
+
+  const proposed = state.proposed
+  const change = pointsChange(proposed, currentPct)
+
+  return (
+    <div className="flex h-full min-h-0 flex-col" data-slot="size-explorer">
+      <ValueExplorer
+        slot="size-value"
+        referenceLabel="Current weight"
+        recordedLabel="Staged"
+        proposedLabel="Proposed"
+        state={state}
+        onChange={setState}
+        onSave={onStage}
+        saving={saving}
+        format={pct}
+        // No secondary under each figure: the consequence is a single number
+        // about the DIFFERENCE, so it belongs in its own row below rather than
+        // repeated under each value.
+        reachable={[benchmarkPct, 0]}
+        step={0.1}
+        presets={[
+          // Only the ones the existing numbers actually support. A preset that
+          // needs a calculation this card cannot do would be inventing risk
+          // maths, which is explicitly out of scope.
+          { label: 'Current', value: () => currentPct },
+          { label: 'Half', value: () => (currentPct != null ? currentPct / 2 : null) },
+          { label: '−1pt', value: () => (proposed ?? currentPct) != null ? Math.max(0, (proposed ?? currentPct)! - 1) : null },
+          { label: '+1pt', value: () => (proposed ?? currentPct) != null ? (proposed ?? currentPct)! + 1 : null },
+          ...(benchmarkPct != null ? [{ label: 'Neutral', value: () => benchmarkPct }] : []),
+        ]}
+        aria-label={`${symbol} weight`}
+      />
+
+      {/* The consequence, in points, and only while a proposal exists. */}
+      {change != null && (
+        <div className="mt-2 flex shrink-0 items-baseline gap-3" data-slot="size-change">
+          <div>
+            <p className="text-[10px] font-bold uppercase tracking-wide text-gray-400">Change</p>
+            <p className="text-[15px] font-bold tabular-nums text-gray-900 dark:text-white">
+              {change >= 0 ? '+' : '−'}{Math.abs(change).toFixed(1)} pts
+            </p>
+          </div>
+          {/* Active weight is a subtraction we can actually do — the benchmark
+              weight is on the card. Anything requiring a risk model is not
+              here, deliberately. */}
+          {benchmarkPct != null && proposed != null && (
+            <div data-slot="size-active">
+              <p className="text-[10px] font-bold uppercase tracking-wide text-gray-400">Active weight</p>
+              <p className="text-[15px] font-bold tabular-nums text-gray-900 dark:text-white">
+                {(proposed - benchmarkPct) >= 0 ? '+' : '−'}
+                {Math.abs(proposed - benchmarkPct).toFixed(1)} pts
+              </p>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* The one sentence on this control, and it earns its place: it is the
+          difference between an analytical tool and a trade ticket. */}
+      <p className="mt-1 shrink-0 text-[11px] text-gray-400">
+        Exploration only — staging a weight does not trade.
+      </p>
+    </div>
+  )
+}

--- a/src/components/signals/TargetExplorer.tsx
+++ b/src/components/signals/TargetExplorer.tsx
@@ -1,0 +1,82 @@
+import { useState } from 'react'
+
+import { ValueExplorer } from './ValueExplorer'
+import {
+  beginExploration, upsidePct, type Exploration,
+} from '../../lib/mobile/exploration'
+
+/**
+ * Explore a price target without committing to it.
+ *
+ * ── What this replaces ────────────────────────────────────────────────────
+ *
+ * `TargetTuner`, which showed one number and a slider. Dragging it changed a
+ * figure whose meaning shifted silently — market price, then recorded target,
+ * then your proposal — with nothing on screen saying which. Reported as the
+ * concept being strong and the execution hard to understand, which is exactly
+ * what that ambiguity produces.
+ *
+ * Everything specific to targets lives here — the labels, the money
+ * formatting, the upside calculation, the levels the slider must be able to
+ * reach. The interaction itself is `ValueExplorer`, shared with cases and
+ * position size, because all three are the same gesture over a different
+ * number.
+ */
+
+interface TargetExplorerProps {
+  symbol: string
+  /** Last close. The proposal is measured against this. */
+  currentPrice: number | null
+  /** The saved target, or null when the name has never had one. */
+  recordedTarget: number | null
+  /** Scenario levels, so the slider can always reach the cases on the card. */
+  caseLevels?: (number | null | undefined)[]
+  onSave: (target: number) => void
+  saving?: boolean
+  /** Notified as the reader explores, so the chart can draw the proposal. */
+  onProposedChange?: (proposed: number | null) => void
+}
+
+const money = (v: number) => v >= 1000 ? `$${v.toFixed(0)}` : `$${v.toFixed(2)}`
+
+export function TargetExplorer({
+  symbol, currentPrice, recordedTarget, caseLevels = [], onSave, saving, onProposedChange,
+}: TargetExplorerProps) {
+  const [state, setState] = useState<Exploration>(
+    () => beginExploration(recordedTarget, currentPrice),
+  )
+
+  const update = (next: Exploration) => {
+    setState(next)
+    // The chart draws the proposal as a band while it is being explored, so
+    // the reader sees where they are putting it rather than only the number.
+    onProposedChange?.(next.proposed)
+  }
+
+  return (
+    <ValueExplorer
+      slot="target-explorer"
+      referenceLabel="Current"
+      recordedLabel="Recorded target"
+      proposedLabel="Proposed"
+      state={state}
+      onChange={update}
+      onSave={onSave}
+      saving={saving}
+      format={money}
+      /**
+       * Upside against the market price, which is the only comparison that
+       * means anything for a target. Null when there is no price — 68 of 912
+       * assets have one — and the row simply does not render rather than
+       * claiming the upside is flat.
+       */
+      secondary={v => {
+        const pct = upsidePct(v, currentPrice)
+        if (pct == null) return null
+        return `${pct >= 0 ? '+' : ''}${pct.toFixed(1)}% vs current`
+      }}
+      reachable={caseLevels}
+      aria-label={`${symbol} target`}
+    />
+  )
+}

--- a/src/components/signals/ValueExplorer.tsx
+++ b/src/components/signals/ValueExplorer.tsx
@@ -1,0 +1,261 @@
+import { useEffect, useRef, useState } from 'react'
+import { clsx } from 'clsx'
+
+import {
+  commitExploration, displayedValue, isDirty, parseNumericEntry, propose,
+  resetExploration, sliderRange, type Exploration,
+} from '../../lib/mobile/exploration'
+
+/**
+ * One control for exploring a number, wearing whatever labels the card needs.
+ *
+ * ── Why the three values are always on screen ─────────────────────────────
+ *
+ * "Never require the user to infer which value a number represents." The old
+ * controls showed a single figure that silently changed meaning as you dragged
+ * — market price, then saved target, then your proposal — and there was no way
+ * to tell which one you were looking at, or what you would be overwriting.
+ *
+ * So the reference and the record are always visible, and the proposal appears
+ * beside them the moment it exists. Three labelled rows cost about 40px and
+ * remove the entire class of "which number is this".
+ *
+ * ── Why it explains itself through state rather than copy ─────────────────
+ *
+ * There is no instructional text. The Save and Cancel controls only exist
+ * while a proposal exists, so their presence IS the message that you are in an
+ * exploratory state and nothing has been written yet.
+ */
+
+export interface ValueExplorerProps {
+  /** e.g. "Current" — what the proposal is measured against. */
+  referenceLabel: string
+  /** e.g. "Recorded target". */
+  recordedLabel: string
+  /** e.g. "Proposed". */
+  proposedLabel?: string
+  state: Exploration
+  onChange: (next: Exploration) => void
+  /** Persist. Only called with a genuinely changed value. */
+  onSave: (value: number) => void
+  /** Render a number as the reader should see it. */
+  format: (v: number) => string
+  /**
+   * The secondary figure under a value — upside, or a change in points.
+   * Returns null when it cannot be computed, and nothing is rendered rather
+   * than a zero standing in for unknown.
+   */
+  secondary?: (v: number) => string | null
+  /** Extra levels the slider must be able to reach: cases, benchmark. */
+  reachable?: (number | null | undefined)[]
+  /** Quick presets, e.g. Half / -1pt. Omitted when the card has none. */
+  presets?: { label: string; value: () => number | null }[]
+  step?: number
+  saving?: boolean
+  /** Test/measurement hook. */
+  slot?: string
+}
+
+export function ValueExplorer({
+  referenceLabel, recordedLabel, proposedLabel = 'Proposed',
+  state, onChange, onSave, format, secondary, reachable = [], presets,
+  step, saving, slot = 'value-explorer',
+}: ValueExplorerProps) {
+  const [typing, setTyping] = useState<string | null>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const dirty = isDirty(state)
+  const shown = displayedValue(state)
+  const range = sliderRange([state.reference, state.recorded, ...reachable, state.proposed])
+  // The range decides its own step so the bounds sit ON the grid — see
+  // `sliderRange`. A caller may still override it where the unit demands one
+  // (weights step in tenths of a point regardless of the span).
+  const resolvedStep = step ?? range.step
+
+  useEffect(() => {
+    if (typing !== null) inputRef.current?.focus()
+  }, [typing])
+
+  const commit = () => {
+    const done = commitExploration(state)
+    if (!done) return
+    onSave(done.saved)
+    onChange(done.next)
+  }
+
+  const acceptTyped = () => {
+    if (typing === null) return
+    const parsed = parseNumericEntry(typing)
+    // A rejected entry leaves the state alone rather than zeroing it.
+    // `Number('')` is 0, and 0 is a value somebody could have meant.
+    if (parsed != null) onChange(propose(state, parsed))
+    setTyping(null)
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col" data-slot={slot}>
+      {/* The three values. Reference and record are always present; the
+          proposal joins them only once it exists, so the row itself says
+          whether anything is being explored. */}
+      <div className="flex shrink-0 items-start gap-4">
+        <Figure
+          label={referenceLabel}
+          value={state.reference}
+          format={format}
+          slot="reference"
+        />
+        <Figure
+          label={recordedLabel}
+          value={state.recorded}
+          format={format}
+          secondary={secondary}
+          slot="recorded"
+          emptyNote="None set"
+        />
+        {state.proposed != null && (
+          <Figure
+            label={proposedLabel}
+            value={state.proposed}
+            format={format}
+            secondary={secondary}
+            slot="proposed"
+            accent
+          />
+        )}
+      </div>
+
+      {/* Direct entry. A slider alone cannot express "two hundred and ten
+          exactly", and on a phone it never will — the track is 300px wide and
+          a dollar is a pixel. Tapping the figure is the same gesture people
+          already use to edit a value in every other app. */}
+      <div className="mt-2 flex shrink-0 items-center gap-2">
+        {typing === null ? (
+          <button
+            type="button"
+            data-slot="value-tap"
+            onClick={() => setTyping(shown != null ? String(Number(shown.toFixed(2))) : '')}
+            className="rounded border border-gray-300 px-2 py-1 text-[13px] font-bold tabular-nums text-gray-900 dark:border-gray-600 dark:text-white"
+          >
+            {shown != null ? format(shown) : '—'}
+          </button>
+        ) : (
+          <input
+            ref={inputRef}
+            data-slot="value-input"
+            // `decimal` rather than `numeric`: iOS shows a keypad with a
+            // decimal separator, which a price needs and a PIN pad lacks.
+            inputMode="decimal"
+            value={typing}
+            onChange={e => setTyping(e.target.value)}
+            onBlur={acceptTyped}
+            onKeyDown={e => {
+              if (e.key === 'Enter') acceptTyped()
+              if (e.key === 'Escape') setTyping(null)
+            }}
+            className="w-24 rounded border border-primary-500 px-2 py-1 text-[13px] font-bold tabular-nums"
+          />
+        )}
+
+        {presets?.map(p => (
+          <button
+            key={p.label}
+            type="button"
+            data-slot="preset"
+            onClick={() => { const v = p.value(); if (v != null) onChange(propose(state, v)) }}
+            className="rounded bg-gray-100 px-2 py-1 text-[11px] font-semibold text-gray-600 dark:bg-gray-800 dark:text-gray-300"
+          >
+            {p.label}
+          </button>
+        ))}
+
+        {dirty && (
+          <button
+            type="button"
+            data-slot="reset"
+            onClick={() => onChange(resetExploration(state))}
+            className="ml-auto text-[11px] font-semibold text-gray-500 underline"
+          >
+            Reset
+          </button>
+        )}
+      </div>
+
+      {/* The track.
+          `touch-action: none` and pointer capture, both deliberate: a pointer
+          that goes down on a thumb is unambiguous, so the slider claims the
+          gesture outright rather than competing with the carousel and the
+          feed. See `gesture-intent` — this is the `slider` owner, and it is
+          the one case decided at pointerdown rather than after a threshold. */}
+      <input
+        type="range"
+        data-slot="slider"
+        aria-label={`${proposedLabel} value`}
+        min={range.min}
+        max={range.max}
+        step={resolvedStep}
+        value={shown ?? range.min}
+        onPointerDown={e => e.currentTarget.setPointerCapture(e.pointerId)}
+        onChange={e => onChange(propose(state, Number(e.target.value)))}
+        className="mt-3 h-9 w-full shrink-0 cursor-pointer touch-none accent-primary-600"
+        style={{ touchAction: 'none' }}
+      />
+
+      {/* Save and Cancel exist only while a proposal does. Their presence is
+          how the reader knows nothing has been written yet — which is why
+          there is no sentence anywhere on this control explaining that. */}
+      {dirty && (
+        <div className="mt-2 flex shrink-0 gap-2">
+          <button
+            type="button"
+            data-slot="save"
+            disabled={saving}
+            onClick={commit}
+            className="rounded bg-primary-600 px-3 py-1.5 text-[13px] font-bold text-white disabled:opacity-50"
+          >
+            {saving ? 'Saving…' : 'Save'}
+          </button>
+          <button
+            type="button"
+            data-slot="cancel"
+            onClick={() => onChange(resetExploration(state))}
+            className="rounded border border-gray-300 px-3 py-1.5 text-[13px] font-semibold text-gray-600 dark:border-gray-600 dark:text-gray-300"
+          >
+            Cancel
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function Figure({
+  label, value, format, secondary, slot, accent, emptyNote,
+}: {
+  label: string
+  value: number | null
+  format: (v: number) => string
+  secondary?: (v: number) => string | null
+  slot: string
+  accent?: boolean
+  emptyNote?: string
+}) {
+  const sub = value != null && secondary ? secondary(value) : null
+  return (
+    <div data-slot={slot} className="min-w-0">
+      <p className="text-[10px] font-bold uppercase tracking-wide text-gray-400">{label}</p>
+      <p className={clsx(
+        'text-[17px] font-bold tabular-nums leading-tight',
+        accent ? 'text-primary-600 dark:text-primary-400' : 'text-gray-900 dark:text-white',
+      )}>
+        {value != null ? format(value) : (emptyNote ?? '—')}
+      </p>
+      {/* Rendered only when it can be computed. A card that cannot work out
+          upside must say nothing, not claim the upside is flat. */}
+      {sub && (
+        <p data-slot={`${slot}-secondary`} className="text-[11px] font-semibold tabular-nums text-gray-500">
+          {sub}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/signals/__tests__/explorers.test.tsx
+++ b/src/components/signals/__tests__/explorers.test.tsx
@@ -1,0 +1,258 @@
+import { describe, expect, it, vi } from 'vitest'
+import { fireEvent, render, within } from '@testing-library/react'
+
+import { TargetExplorer } from '../TargetExplorer'
+import { CaseExplorer } from '../CaseExplorer'
+import { SizeExplorer } from '../SizeExplorer'
+
+/**
+ * The three explorers are one interaction wearing three sets of labels, so
+ * these assert the shared guarantees once per control: which number is which,
+ * that dragging never writes, and that typing works where a slider cannot.
+ */
+
+const slot = (c: HTMLElement, name: string) => c.querySelector(`[data-slot="${name}"]`) as HTMLElement
+const text = (c: HTMLElement, name: string) => slot(c, name)?.textContent ?? ''
+const drag = (c: HTMLElement, to: number) =>
+  fireEvent.change(slot(c, 'slider'), { target: { value: String(to) } })
+
+describe('target: current, recorded and proposed are never ambiguous', () => {
+  const setup = (recorded: number | null = 210) => {
+    const onSave = vi.fn()
+    const r = render(
+      <TargetExplorer symbol="AAPL" currentPrice={182.4} recordedTarget={recorded} onSave={onSave} />,
+    )
+    return { ...r, onSave }
+  }
+
+  it('labels the market price and the saved target separately', () => {
+    const { container } = setup()
+    expect(text(container, 'reference')).toContain('Current')
+    expect(text(container, 'reference')).toContain('182.40')
+    expect(text(container, 'recorded')).toContain('Recorded target')
+    expect(text(container, 'recorded')).toContain('210.00')
+  })
+
+  it('shows no proposal until one exists', () => {
+    // The row itself says whether anything is being explored.
+    const { container } = setup()
+    expect(slot(container, 'proposed')).toBeNull()
+    drag(container, 225)
+    expect(text(container, 'proposed')).toContain('Proposed')
+    expect(text(container, 'proposed')).toContain('225')
+  })
+
+  it('states upside against the current price', () => {
+    const { container } = setup()
+    expect(text(container, 'recorded-secondary')).toContain('%')
+    expect(text(container, 'recorded-secondary')).toContain('vs current')
+  })
+
+  it('says nothing about upside when there is no price', () => {
+    /**
+     * 68 of 912 assets have a current price. Claiming the upside is flat is a
+     * number somebody could act on.
+     */
+    const { container } = render(
+      <TargetExplorer symbol="X" currentPrice={null} recordedTarget={210} onSave={vi.fn()} />,
+    )
+    expect(slot(container, 'recorded-secondary')).toBeNull()
+  })
+
+  it('does not save on a drag', () => {
+    // Exploration must be distinguishable from committed state, and dragging
+    // a slider is not a decision.
+    const { container, onSave } = setup()
+    drag(container, 300)
+    expect(onSave).not.toHaveBeenCalled()
+  })
+
+  it('saves only what was proposed, and only when asked', () => {
+    const { container, onSave } = setup()
+    drag(container, 240)
+    fireEvent.click(slot(container, 'save'))
+    expect(onSave).toHaveBeenCalledWith(240)
+  })
+
+  it('offers no save or cancel until something has changed', () => {
+    const { container } = setup()
+    expect(slot(container, 'save')).toBeNull()
+    expect(slot(container, 'cancel')).toBeNull()
+  })
+
+  it('cancels back to the recorded value', () => {
+    const { container } = setup()
+    drag(container, 300)
+    fireEvent.click(slot(container, 'cancel'))
+    expect(slot(container, 'proposed')).toBeNull()
+    expect(text(container, 'recorded')).toContain('210')
+  })
+
+  it('resets an untargeted name to the current price rather than to zero', () => {
+    const { container } = setup(null)
+    expect(text(container, 'recorded')).toContain('None set')
+    drag(container, 300)
+    fireEvent.click(slot(container, 'reset'))
+    expect(slot(container, 'proposed')).toBeNull()
+  })
+
+  it('accepts an exact number typed in', () => {
+    // A slider on a phone is 300px wide and a dollar is a pixel; it cannot
+    // express "two hundred and ten exactly" and never will.
+    const { container } = setup()
+    fireEvent.click(slot(container, 'value-tap'))
+    fireEvent.change(slot(container, 'value-input'), { target: { value: '$233.75' } })
+    fireEvent.keyDown(slot(container, 'value-input'), { key: 'Enter' })
+    expect(text(container, 'proposed')).toContain('233.75')
+  })
+
+  it('leaves the value alone when the entry is nonsense', () => {
+    const { container } = setup()
+    fireEvent.click(slot(container, 'value-tap'))
+    fireEvent.change(slot(container, 'value-input'), { target: { value: 'abc' } })
+    fireEvent.keyDown(slot(container, 'value-input'), { key: 'Enter' })
+    expect(slot(container, 'proposed')).toBeNull()
+  })
+})
+
+describe('cases: switchable without going through a target', () => {
+  const CASES = [
+    { id: 'bear', name: 'Bear', price: 140 },
+    { id: 'base', name: 'Base', price: 210 },
+    { id: 'bull', name: 'Bull', price: 300 },
+  ]
+  const setup = () => {
+    const onSave = vi.fn()
+    const r = render(
+      <CaseExplorer symbol="AAPL" cases={CASES} currentPrice={182.4} onSave={onSave} />,
+    )
+    return { ...r, onSave }
+  }
+
+  it('offers every case as a single tap', () => {
+    const { container } = setup()
+    const tabs = container.querySelectorAll('[data-slot="case-tab"]')
+    expect([...tabs].map(t => t.textContent)).toEqual(['Bear', 'Base', 'Bull'])
+  })
+
+  it('edits the selected case with no Set a target step anywhere', () => {
+    /**
+     * The hard rule. Targets and scenarios are different concepts, and routing
+     * an analyst who works in cases through a target number they do not use is
+     * what made case editing feel like indirection.
+     */
+    const { container } = setup()
+    expect(container.textContent).not.toMatch(/set a target/i)
+    expect(slot(container, 'case-value')).toBeTruthy()
+  })
+
+  it('switches which case is being edited', () => {
+    const { container } = setup()
+    expect(text(container, 'recorded')).toContain('Bear')
+    fireEvent.click(container.querySelector('[data-case-id="bull"]')!)
+    expect(text(container, 'recorded')).toContain('Bull')
+    expect(text(container, 'recorded')).toContain('300')
+  })
+
+  it('saves against the case the reader is actually looking at', () => {
+    const { container, onSave } = setup()
+    fireEvent.click(container.querySelector('[data-case-id="bull"]')!)
+    drag(container, 320)
+    fireEvent.click(slot(container, 'save'))
+    expect(onSave).toHaveBeenCalledWith('bull', 320)
+  })
+
+  it('keeps an unsaved draft when the reader flips to another case', () => {
+    /**
+     * Comparing cases is the entire point of having three, so flipping between
+     * them has to be free. Prompting on every switch would make the comparison
+     * the expensive operation; discarding silently would lose work.
+     */
+    const { container } = setup()
+    drag(container, 155)
+    fireEvent.click(container.querySelector('[data-case-id="bull"]')!)
+    expect(slot(container, 'proposed')).toBeNull()
+    fireEvent.click(container.querySelector('[data-case-id="bear"]')!)
+    expect(text(container, 'proposed')).toContain('155')
+  })
+
+  it('marks a case that has unsaved work on it', () => {
+    // Otherwise a draft on a tab you are not looking at is invisible.
+    const { container } = setup()
+    drag(container, 155)
+    fireEvent.click(container.querySelector('[data-case-id="bull"]')!)
+    const bear = container.querySelector('[data-case-id="bear"]') as HTMLElement
+    expect(within(bear).queryByLabelText('unsaved')).toBeTruthy()
+  })
+
+  it('does not carry a half-typed value across a switch', () => {
+    const { container } = setup()
+    fireEvent.click(slot(container, 'value-tap'))
+    fireEvent.change(slot(container, 'value-input'), { target: { value: '99' } })
+    fireEvent.click(container.querySelector('[data-case-id="bull"]')!)
+    expect(slot(container, 'value-input')).toBeNull()
+  })
+})
+
+describe('size: current, proposed and the change between them', () => {
+  const setup = (benchmark: number | null = 3.1) => {
+    const onStage = vi.fn()
+    const r = render(
+      <SizeExplorer symbol="NVDA" currentPct={7.2} benchmarkPct={benchmark} onStage={onStage} />,
+    )
+    return { ...r, onStage }
+  }
+
+  it('shows the change in points rather than as a percent of a percent', () => {
+    // 7.2% to 5.0% is 2.2 points. "-30%" would be the classic sizing lie.
+    const { container } = setup()
+    drag(container, 5.0)
+    expect(text(container, 'size-change')).toContain('2.2')
+    expect(text(container, 'size-change')).toContain('pts')
+  })
+
+  it('shows no change figure before anything is proposed', () => {
+    const { container } = setup()
+    expect(slot(container, 'size-change')).toBeNull()
+  })
+
+  it('derives active weight only where a benchmark exists', () => {
+    // A subtraction we can actually do. Anything needing a risk model is
+    // deliberately absent.
+    const { container } = setup()
+    drag(container, 5.0)
+    expect(text(container, 'size-active')).toContain('1.9')
+
+    const { container: c2 } = setup(null)
+    drag(c2, 5.0)
+    expect(slot(c2, 'size-active')).toBeNull()
+  })
+
+  it('offers quick weights the existing numbers support', () => {
+    const { container } = setup()
+    const labels = [...container.querySelectorAll('[data-slot="preset"]')].map(b => b.textContent)
+    expect(labels).toContain('Half')
+    expect(labels).toContain('Neutral')
+  })
+
+  it('half means half of the current weight', () => {
+    const { container } = setup()
+    fireEvent.click([...container.querySelectorAll('[data-slot="preset"]')]
+      .find(b => b.textContent === 'Half')!)
+    expect(text(container, 'proposed')).toContain('3.6')
+  })
+
+  it('says plainly that staging is not trading', () => {
+    // The one sentence on the control, and it earns its place: it is the
+    // difference between an analytical tool and a trade ticket.
+    const { container } = setup()
+    expect(container.textContent).toMatch(/does not trade/i)
+  })
+
+  it('stages rather than trades', () => {
+    const { container, onStage } = setup()
+    drag(container, 5.0)
+    fireEvent.click(slot(container, 'save'))
+    expect(onStage).toHaveBeenCalledWith(5)
+  })
+})

--- a/src/lib/ideas/__tests__/open-proposal.test.ts
+++ b/src/lib/ideas/__tests__/open-proposal.test.ts
@@ -92,3 +92,45 @@ describe('pair pagination', () => {
     expect(pairPageSlice(-5, PAGE)).toEqual([0, PAIRS_PER_PAGE])
   })
 })
+
+describe('a pair trade cannot be recreated across pages', () => {
+  /**
+   * The regression guard the phase asks for.
+   *
+   * There is exactly one pair trade in production, and it appeared once per
+   * page the reader scrolled — because the pair source regrouped the same slab
+   * of legs on every page with no offset. Deduping the symptom is not enough:
+   * if the slices ever overlap again, the same pair object is genuinely built
+   * twice and every downstream consumer sees two.
+   */
+  it('never emits the same pair id on two different pages', () => {
+    const PAIRS = Array.from({ length: 30 }, (_, i) => `pair-${i}`)
+    const emitted: string[] = []
+    for (let page = 0; page < 10; page++) {
+      const [from, to] = pairPageSlice(page * PAGE, PAGE)
+      emitted.push(...PAIRS.slice(from, to))
+    }
+    expect(new Set(emitted).size).toBe(emitted.length)
+  })
+
+  it('advances even when a page yields no OPEN pairs', () => {
+    /**
+     * Openness is judged after grouping, so a page can legitimately come back
+     * empty. The cursor must still move — a slice that stalls would serve the
+     * same window forever, which is the original defect wearing a status
+     * filter.
+     */
+    const a = pairPageSlice(0, PAGE)
+    const b = pairPageSlice(PAGE, PAGE)
+    expect(b[0]).toBeGreaterThanOrEqual(a[1])
+  })
+
+  it('keeps a pair whole rather than splitting it across pages', () => {
+    // Slicing is over PAIRS, never over legs. A pair split at a read boundary
+    // would render as two half-pairs, each missing a side.
+    const [from, to] = pairPageSlice(3 * PAGE, PAGE)
+    expect(Number.isInteger(from)).toBe(true)
+    expect(Number.isInteger(to)).toBe(true)
+    expect(to - from).toBe(PAIRS_PER_PAGE)
+  })
+})

--- a/src/lib/mobile/__tests__/exploration.test.ts
+++ b/src/lib/mobile/__tests__/exploration.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  beginExploration, commitExploration, displayedKind, displayedValue, isDirty,
+  parseNumericEntry, pointsChange, propose, resetExploration, sliderRange, upsidePct,
+} from '../exploration'
+
+describe('the three values stay distinguishable', () => {
+  it('shows the reference when nothing is recorded or proposed', () => {
+    // A name with no target still needs somewhere for the control to start,
+    // and the market price is the only number anybody has.
+    const e = beginExploration(null, 182.4)
+    expect(displayedValue(e)).toBe(182.4)
+    expect(displayedKind(e)).toBe('reference')
+  })
+
+  it('prefers the record over the reference, and the proposal over both', () => {
+    const e = beginExploration(210, 182.4)
+    expect(displayedKind(e)).toBe('recorded')
+    expect(displayedKind(propose(e, 225))).toBe('proposed')
+    expect(displayedValue(propose(e, 225))).toBe(225)
+  })
+
+  it('starts with no proposal at all', () => {
+    /**
+     * Null rather than "equal to recorded". A control whose proposal happens
+     * to match the record is visually identical to one nobody has touched, and
+     * the difference decides whether Save should do anything.
+     */
+    expect(beginExploration(210, 182).proposed).toBeNull()
+  })
+})
+
+describe('what counts as a change', () => {
+  it('is nothing until the reader moves something', () => {
+    expect(isDirty(beginExploration(210, 182))).toBe(false)
+  })
+
+  it('is a change when a name that had no target gets one', () => {
+    expect(isDirty(propose(beginExploration(null, 182), 210))).toBe(true)
+  })
+
+  it('is not a change when the proposal lands back on the record', () => {
+    // Saving this would write nothing and stamp an audit row saying somebody
+    // made a decision.
+    expect(isDirty(propose(beginExploration(210, 182), 210))).toBe(false)
+  })
+
+  it('tolerates the float noise a slider produces', () => {
+    /**
+     * A track stepping in cents yields values like 210.00000000000003, and
+     * `!==` on those leaves Save permanently enabled on a control nobody
+     * touched.
+     */
+    expect(isDirty(propose(beginExploration(210, 182), 210.00000000000003))).toBe(false)
+  })
+})
+
+describe('committing', () => {
+  it('turns the proposal into the record and stops exploring', () => {
+    const done = commitExploration(propose(beginExploration(210, 182), 225))
+    expect(done!.saved).toBe(225)
+    expect(done!.next.recorded).toBe(225)
+    expect(done!.next.proposed).toBeNull()
+  })
+
+  it('refuses to commit when there is nothing to commit', () => {
+    // The caller cannot accidentally save one value and display another,
+    // because it gets both from the same call or neither.
+    expect(commitExploration(beginExploration(210, 182))).toBeNull()
+    expect(commitExploration(propose(beginExploration(210, 182), 210))).toBeNull()
+  })
+
+  it('does not overwrite the record on a mere drag', () => {
+    // Exploration must be visually and actually distinct from committed state.
+    const explored = propose(beginExploration(210, 182), 300)
+    expect(explored.recorded).toBe(210)
+  })
+})
+
+describe('reset', () => {
+  it('returns to the number of record', () => {
+    const e = propose(beginExploration(210, 182), 300)
+    expect(displayedValue(resetExploration(e))).toBe(210)
+  })
+
+  it('returns an untargeted name to the current price, not to zero', () => {
+    const e = propose(beginExploration(null, 182), 300)
+    expect(displayedValue(resetExploration(e))).toBe(182)
+  })
+})
+
+describe('secondary figures', () => {
+  it('computes upside against the reference', () => {
+    expect(upsidePct(210, 182.4)!).toBeCloseTo(15.13, 1)
+  })
+
+  it('returns null rather than zero when there is no reference', () => {
+    /**
+     * 68 of 912 assets have a current price. A card that cannot compute upside
+     * must say nothing — claiming the upside is flat is a number somebody
+     * could act on.
+     */
+    expect(upsidePct(210, null)).toBeNull()
+    expect(upsidePct(210, 0)).toBeNull()
+  })
+
+  it('measures a weight change in points, not in percent of a percent', () => {
+    // 7.2% to 5.0% is 2.2 points. Calling it -30% is the classic way to make a
+    // sizing control lie.
+    expect(pointsChange(5.0, 7.2)!).toBeCloseTo(-2.2, 5)
+  })
+})
+
+describe('the slider always reaches what the card is talking about', () => {
+  it('spans every level it was given', () => {
+    /**
+     * A fixed window is wrong at both ends: too fine on a $3 name, and it puts
+     * a bull case off the end of the track on one that has re-rated. Deriving
+     * the range guarantees the reader can drag to the values on screen.
+     */
+    const r = sliderRange([182, 210, 95, 340])
+    expect(r.min).toBeLessThan(95)
+    expect(r.max).toBeGreaterThan(340)
+  })
+
+  it('never goes below zero', () => {
+    expect(sliderRange([1, 2]).min).toBeGreaterThanOrEqual(0)
+  })
+
+  it('leaves room to propose beyond the levels already recorded', () => {
+    /**
+     * Span padding alone is too tight when the known levels sit close
+     * together: a $182 price with a $210 target tops the track out at $220,
+     * and the reader cannot propose $225 — on a control whose entire purpose
+     * is exploring values nobody has recorded yet.
+     */
+    const r = sliderRange([182.4, 210])
+    expect(r.max).toBeGreaterThanOrEqual(210 * 1.25)
+  })
+
+  it('puts its own bounds on its own step grid', () => {
+    /**
+     * An `<input type="range">` quantises to `min + n * step`. A minimum of
+     * 9.2483 puts every reachable value on that offset grid, so a reader
+     * aiming at 225 lands on 224.9483 — the number shown stops being the
+     * number saved, which is the failure this control exists to prevent.
+     */
+    for (const points of [[182.4, 210], [3.2, 4.1], [1200, 1900]]) {
+      const r = sliderRange(points)
+      expect(Math.abs(r.min / r.step - Math.round(r.min / r.step)), String(points)).toBeLessThan(1e-6)
+    }
+  })
+
+  it('copes with a single level, and with none', () => {
+    expect(sliderRange([100]).max).toBeGreaterThan(100)
+    expect(sliderRange([null, undefined])).toEqual({ min: 0, max: 100, step: 1 })
+  })
+})
+
+describe('typed entry', () => {
+  it('accepts what people actually type', () => {
+    for (const [raw, want] of [['$210', 210], ['1,250.50', 1250.5], ['5.2%', 5.2], [' 210 ', 210]] as const) {
+      expect(parseNumericEntry(raw), raw).toBe(want)
+    }
+  })
+
+  it('rejects rather than coerces', () => {
+    /**
+     * `Number('')` is 0, and zero is a real value somebody could have meant.
+     * Coercing an empty or malformed field into it would silently record a
+     * target of nothing.
+     */
+    for (const raw of ['', '   ', 'abc', '-5', '0']) {
+      expect(parseNumericEntry(raw), raw).toBeNull()
+    }
+  })
+})

--- a/src/lib/mobile/__tests__/explore-match.test.ts
+++ b/src/lib/mobile/__tests__/explore-match.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+
+import { findExploreMatch, matchScore, targetType } from '../explore-match'
+import { symbolOfEntry } from '../feed-entry-key'
+
+const entry = (type: string, assetId: string, symbol?: string) => ({
+  type, id: `${type}:${assetId}`, symbol: symbol ?? null,
+})
+
+describe('a preview opens the object it previewed', () => {
+  it('requires the type AND the asset to agree', () => {
+    /**
+     * The bug this replaces short-circuited on the asset alone. A name usually
+     * carries several findings at once — that is the premise of the feed — so
+     * tapping "NVDA has no price target" opened whichever NVDA card happened
+     * to be earliest in the pool, often the active-risk one. The reader taps
+     * one finding and gets a different one about the same company.
+     */
+    const target = { dedupeKey: 'no_target:a1', assetId: 'a1', symbol: 'NVDA' }
+    expect(matchScore(target, entry('active_risk', 'a1', 'NVDA'))).toBe(0)
+    expect(matchScore(target, entry('no_target', 'a1', 'NVDA'))).toBeGreaterThan(0)
+  })
+
+  it('picks the right card out of several for one name', () => {
+    const pool = [
+      entry('active_risk', 'a1', 'NVDA'),
+      entry('research_stale', 'a1', 'NVDA'),
+      entry('no_target', 'a1', 'NVDA'),
+    ]
+    const found = findExploreMatch(
+      { dedupeKey: 'no_target:a1', assetId: 'a1', symbol: 'NVDA' }, pool, e => e,
+    )
+    expect(found?.type).toBe('no_target')
+  })
+
+  it('prefers the entry that matches the asset over one that only matches the type', () => {
+    // Both are no-target cards; only one is about the name that was tapped.
+    const pool = [entry('no_target', 'other', 'AAPL'), entry('no_target', 'a1', 'NVDA')]
+    const found = findExploreMatch(
+      { dedupeKey: 'no_target:a1', assetId: 'a1', symbol: 'NVDA' }, pool, e => e,
+    )
+    expect(found?.id).toContain('a1')
+  })
+
+  it('falls back to the symbol when the asset id is not on the entry', () => {
+    // News and template entries do not always carry an asset id.
+    const pool = [{ type: 'news', id: 'news:x', symbol: 'CAT' }]
+    const found = findExploreMatch({ dedupeKey: 'news:cat', symbol: 'CAT' }, pool, e => e)
+    expect(found).toBeTruthy()
+  })
+
+  it('will not open a card about a different company', () => {
+    // Same finding, wrong name — worse than opening nothing.
+    const pool = [entry('no_target', 'other', 'AAPL')]
+    expect(findExploreMatch(
+      { dedupeKey: 'no_target:a1', assetId: 'a1', symbol: 'NVDA' }, pool, e => e,
+    )).toBeNull()
+  })
+
+  it('matches an unattributed preview on type alone', () => {
+    // A workflow item or a macro template names no asset, and matching it on
+    // type is then the only thing that can be asked of it.
+    const pool = [{ type: 'project_overdue', id: 'p:1', symbol: null }]
+    expect(findExploreMatch({ dedupeKey: 'project_overdue:x' }, pool, e => e)).toBeTruthy()
+  })
+
+  it('returns null rather than inventing a card', () => {
+    /**
+     * A real answer: a post, an aggregate, or a template with no ticker has no
+     * Level-2 renderer, and the overlay says so. Inventing one would mean a
+     * second copy of every builder.
+     */
+    expect(findExploreMatch({ dedupeKey: 'thought:x' }, [entry('news', 'a1')], e => e)).toBeNull()
+  })
+
+  it('is stable — the feed order breaks ties', () => {
+    const pool = [entry('no_target', 'a1', 'NVDA'), entry('no_target', 'a1', 'NVDA')]
+    const t = { dedupeKey: 'no_target:a1', assetId: 'a1', symbol: 'NVDA' }
+    expect(findExploreMatch(t, pool, e => e)).toBe(pool[0])
+  })
+
+  it('reads the signal type off the dedupe key', () => {
+    expect(targetType({ dedupeKey: 'scenario_gap:a1' })).toBe('scenario_gap')
+  })
+})
+
+describe('one symbol resolver, shared by the filter and the matcher', () => {
+  it('knows where each kind hides its symbol', () => {
+    expect(symbolOfEntry({ kind: 'news', news: { primarySymbol: 'CAT' } })).toBe('CAT')
+    expect(symbolOfEntry({ kind: 'template', card: { symbol: 'AAPL' } })).toBe('AAPL')
+    expect(symbolOfEntry({ kind: 'insight', insight: { symbol: 'NVDA' } })).toBe('NVDA')
+    expect(symbolOfEntry({ kind: 'scenario', card: { entity: { ticker: 'MSFT' } } })).toBe('MSFT')
+    expect(symbolOfEntry({ kind: 'lens', lens: { target: { symbol: 'ORCL' } } })).toBe('ORCL')
+  })
+
+  it('reads an idea from `idea`, not from `item`', () => {
+    /**
+     * Reading the wrong key returned undefined for every idea in the feed,
+     * which made every idea vanish the moment any asset facet was set — with
+     * nothing saying why. Two callers now depend on this, so a second copy
+     * that got it wrong would break the Explore matcher the same way.
+     */
+    expect(symbolOfEntry({ kind: 'idea', idea: { asset: { symbol: 'DASH' } } })).toBe('DASH')
+  })
+
+  it('answers null for tiles that genuinely have no symbol', () => {
+    // Kept when only category filters are set, dropped when an asset facet is.
+    expect(symbolOfEntry({ kind: 'attention', attention: {} })).toBeNull()
+    expect(symbolOfEntry({ kind: 'news', news: {} })).toBeNull()
+  })
+})

--- a/src/lib/mobile/exploration.ts
+++ b/src/lib/mobile/exploration.ts
@@ -1,0 +1,212 @@
+/**
+ * Exploring a number without committing to it.
+ *
+ * ── Why one model for three controls ──────────────────────────────────────
+ *
+ * The target tuner, the case editor and the size explorer are the same
+ * interaction wearing three different sets of labels: there is a number of
+ * record, the reader drags it somewhere else to see what that would mean, and
+ * then either commits or does not. Each had implemented that separately, and
+ * each got a different part of it wrong — one wrote through on every drag, one
+ * had no way back to the recorded value, none of them said which number the
+ * reader was currently looking at.
+ *
+ * That last one is the whole complaint. "The target manipulation concept is
+ * strong but the current execution is difficult to understand" is what happens
+ * when a control shows one number and the reader cannot tell whether it is the
+ * market price, the saved view, or the thing they just dragged to.
+ *
+ * ── The three values, always distinguishable ──────────────────────────────
+ *
+ *   REFERENCE  what the market says      — never editable, context only
+ *   RECORDED   what the firm has saved   — the number of record
+ *   PROPOSED   what the reader is trying — exists only while exploring
+ *
+ * `proposed` is null until somebody moves something. That is deliberate: a
+ * control with a proposed value equal to the recorded one is visually
+ * indistinguishable from one that has never been touched, and the difference
+ * matters for whether Save should do anything.
+ *
+ * Pure — no React, no persistence. The components render it; the callers save
+ * it through whatever infrastructure already owns that number.
+ */
+
+export interface Exploration {
+  /** The market price, or whatever the proposal is measured against. */
+  reference: number | null
+  /** The saved value. Null when nothing has ever been recorded. */
+  recorded: number | null
+  /** What the reader is trying. Null when they are not exploring. */
+  proposed: number | null
+}
+
+export function beginExploration(recorded: number | null, reference: number | null): Exploration {
+  return { reference, recorded, proposed: null }
+}
+
+/**
+ * The value a control should currently display.
+ *
+ * Proposed wins while exploring, then the recorded value, then the reference.
+ * The fallback to reference is what gives a name with no target a sensible
+ * place for the slider to start: the market price, which is the only number
+ * anyone has.
+ */
+export function displayedValue(e: Exploration): number | null {
+  return e.proposed ?? e.recorded ?? e.reference
+}
+
+/** Which of the three the reader is looking at. Drives the label. */
+export function displayedKind(e: Exploration): 'proposed' | 'recorded' | 'reference' | 'none' {
+  if (e.proposed != null) return 'proposed'
+  if (e.recorded != null) return 'recorded'
+  if (e.reference != null) return 'reference'
+  return 'none'
+}
+
+/**
+ * Whether there is anything to save.
+ *
+ * A proposal identical to the recorded value is not a change, and offering to
+ * save it invites a write that records nothing and stamps an audit row saying
+ * somebody made a decision.
+ */
+export function isDirty(e: Exploration): boolean {
+  if (e.proposed == null) return false
+  if (e.recorded == null) return true
+  return !nearlyEqual(e.proposed, e.recorded)
+}
+
+/**
+ * Percentage from the reference to a value.
+ *
+ * Null rather than zero when there is no reference: a card that cannot compute
+ * upside must say so, not claim the upside is flat. That distinction is the
+ * same one `price-availability` draws, for the same reason.
+ */
+export function upsidePct(value: number | null, reference: number | null): number | null {
+  if (value == null || reference == null || !Number.isFinite(reference) || reference <= 0) return null
+  return ((value - reference) / reference) * 100
+}
+
+/** Absolute change in points, for values that ARE percentages (weights). */
+export function pointsChange(value: number | null, from: number | null): number | null {
+  if (value == null || from == null) return null
+  return value - from
+}
+
+/** Stop exploring and go back to the number of record. */
+export function resetExploration(e: Exploration): Exploration {
+  return { ...e, proposed: null }
+}
+
+export function propose(e: Exploration, value: number): Exploration {
+  if (!Number.isFinite(value)) return e
+  return { ...e, proposed: value }
+}
+
+/**
+ * Commit: the proposal becomes the record.
+ *
+ * Returns the new state AND the value to persist, so a caller cannot
+ * accidentally save one thing and display another.
+ */
+export function commitExploration(e: Exploration): { next: Exploration; saved: number } | null {
+  if (!isDirty(e) || e.proposed == null) return null
+  return { next: { ...e, recorded: e.proposed, proposed: null }, saved: e.proposed }
+}
+
+/**
+ * Float comparison with a tolerance suited to money and percentages.
+ *
+ * A slider that steps in cents produces values like 210.00000000000003, and
+ * `!==` on those makes Save permanently enabled on a control nobody touched.
+ */
+export function nearlyEqual(a: number, b: number, epsilon = 1e-6): boolean {
+  return Math.abs(a - b) <= epsilon * Math.max(1, Math.abs(a), Math.abs(b))
+}
+
+/**
+ * A sensible range for a slider around a set of reference points.
+ *
+ * ── Why the bounds are derived rather than fixed ──────────────────────────
+ *
+ * A fixed ±50% window is wrong at both ends: on a name trading at $3 it offers
+ * a resolution nobody needs, and on one whose bull case is 4× the price it puts
+ * the case off the end of the track. So the range covers every number the
+ * reader can already see — price, recorded target, every case — with headroom,
+ * which guarantees that dragging can always REACH the values the card is
+ * talking about.
+ */
+export function sliderRange(
+  points: (number | null | undefined)[],
+  padding = 0.35,
+): { min: number; max: number; step: number } {
+  const vals = points.filter((v): v is number => typeof v === 'number' && Number.isFinite(v) && v > 0)
+  if (!vals.length) return { min: 0, max: 100, step: 1 }
+  const lo = Math.min(...vals)
+  const hi = Math.max(...vals)
+  const span = hi - lo || hi * 0.5 || 1
+  const padded = span * (1 + padding * 2)
+
+  /**
+   * Step and bounds are derived TOGETHER, and the bounds snap to the step.
+   *
+   * An `<input type="range">` quantises to `min + n * step`, so a range whose
+   * minimum is 9.2483 puts every reachable value on that offset grid — and a
+   * reader who types 225, or drags to what looks like 225, gets 224.9483. The
+   * number they see is then not the number that saves, which is the exact
+   * failure this whole control exists to prevent.
+   *
+   * Snapping `min` down to a multiple of the step makes every round number in
+   * the range reachable, which is what people actually aim for.
+   */
+  const step = niceStep(padded / 300)
+
+  /**
+   * Headroom is relative as well as span-based.
+   *
+   * Span padding alone is too tight when the known levels sit close together:
+   * a $182 price with a $210 target gives a 28-point span, so a 35% pad tops
+   * the track out at $220 and the reader simply cannot propose $225. The
+   * control's whole purpose is exploring values nobody has recorded yet, so
+   * the range has to extend beyond the ones that have been.
+   *
+   * A quarter above the highest level and a quarter below the lowest is
+   * scale-invariant, so it behaves the same on a $3 name and a $3,000 one.
+   */
+  const rawMin = Math.min(lo - span * padding, lo * 0.75)
+  const rawMax = Math.max(hi + span * padding, hi * 1.25)
+  return {
+    min: Math.max(0, Math.floor(rawMin / step) * step),
+    max: Math.ceil(rawMax / step) * step,
+    step,
+  }
+}
+
+/** The nearest 1/2/5 x 10^n at or below `raw`. Round numbers, at any scale. */
+function niceStep(raw: number): number {
+  if (!Number.isFinite(raw) || raw <= 0) return 1
+  const exp = Math.floor(Math.log10(raw))
+  const mag = Math.pow(10, exp)
+  const norm = raw / mag
+  const mult = norm >= 5 ? 5 : norm >= 2 ? 2 : 1
+  return mult * mag
+}
+
+/**
+ * Parse what somebody typed into a price or percentage field.
+ *
+ * Tolerant of the things people actually type — currency symbols, thousands
+ * separators, a stray percent sign — and strict about the result: anything
+ * that does not resolve to a finite positive number is rejected rather than
+ * coerced, because `Number('')` is 0 and a target of zero is a real value that
+ * nobody meant to enter.
+ */
+export function parseNumericEntry(raw: string): number | null {
+  const cleaned = raw.replace(/[$€£¥,\s%]/g, '')
+  if (!cleaned) return null
+  const n = Number(cleaned)
+  if (!Number.isFinite(n) || n <= 0) return null
+  return n
+}

--- a/src/lib/mobile/explore-match.ts
+++ b/src/lib/mobile/explore-match.ts
@@ -1,0 +1,99 @@
+/**
+ * Finding the feed entry an Explore preview came from.
+ *
+ * ── Why this is not just "the card for that asset" ────────────────────────
+ *
+ * Tapping a preview must open THAT object's full tile — a no-target preview
+ * opens the no-target card, a scenario preview opens the scenario card. The
+ * matcher did this:
+ *
+ *     if (focus.assetId && input.id.includes(focus.assetId)) return true
+ *     return input.type === wantType && ...
+ *
+ * The first line short-circuits on the asset alone. A name usually carries
+ * several findings at once — that is the entire premise of the feed — so
+ * tapping "NVDA has no price target" would open whichever NVDA card happened
+ * to be earliest in the pool, often the active-risk one. The reader taps a
+ * specific finding and gets a different one about the same company, which
+ * reads as the app ignoring the tap.
+ *
+ * Both facts have to agree. An asset match alone is not an object match.
+ *
+ * Pure — takes already-extracted descriptors so it can be tested without a
+ * feed, a query client, or a rendered card.
+ */
+
+export interface ExploreTarget {
+  /** `signalType:asset` — the preview's own identity. */
+  dedupeKey: string
+  assetId?: string | null
+  symbol?: string | null
+}
+
+export interface EntryDescriptor {
+  /** The ranked signal type for this entry. */
+  type: string
+  /** The ranking id, which embeds the asset id where there is one. */
+  id: string
+  /** The entry's symbol, however its kind happens to store it. */
+  symbol?: string | null
+}
+
+/** The signal type a preview is about. */
+export function targetType(t: ExploreTarget): string {
+  return t.dedupeKey.split(':')[0]
+}
+
+/**
+ * Score how well an entry answers a preview. Higher is better; 0 is no match.
+ *
+ * Scored rather than boolean because more than one entry can legitimately
+ * satisfy the type, and the one that also matches the asset is the right
+ * answer. Returning the first type match would reopen the same class of bug
+ * from the other direction.
+ */
+export function matchScore(t: ExploreTarget, e: EntryDescriptor): number {
+  if (e.type !== targetType(t)) return 0
+
+  const wantAsset = t.assetId ?? null
+  const wantSymbol = t.symbol ? t.symbol.toUpperCase() : null
+  const hasAsset = wantAsset ? e.id.includes(wantAsset) : false
+  const hasSymbol = wantSymbol && e.symbol ? e.symbol.toUpperCase() === wantSymbol : false
+
+  // Type and asset both agree: this is the object the reader tapped.
+  if (hasAsset) return 3
+  if (hasSymbol) return 2
+
+  /**
+   * The type matches and the preview names no asset at all — a template with
+   * no ticker, a workflow item. That is a legitimate match, and ranked below
+   * the identified ones so it can never beat them.
+   */
+  if (!wantAsset && !wantSymbol) return 1
+
+  // Type matches but the preview IS about a specific name and this entry is
+  // about a different one. Not a match; opening it would be the original bug.
+  return 0
+}
+
+/**
+ * The best entry for a preview, or null.
+ *
+ * Null is a real answer: a post, an aggregate, or a template with no ticker
+ * has no Level-2 card, and the overlay says so rather than inventing one.
+ */
+export function findExploreMatch<T>(
+  t: ExploreTarget,
+  entries: T[],
+  describe: (e: T) => EntryDescriptor,
+): T | null {
+  let best: T | null = null
+  let bestScore = 0
+  for (const e of entries) {
+    const score = matchScore(t, describe(e))
+    // Strictly greater, so the FIRST entry at the winning score wins and the
+    // result is stable — the feed's own order decides ties.
+    if (score > bestScore) { best = e; bestScore = score }
+  }
+  return best
+}

--- a/src/lib/mobile/feed-entry-key.ts
+++ b/src/lib/mobile/feed-entry-key.ts
@@ -66,3 +66,35 @@ export function feedEntryKeys(entries: AnyEntry[]): string[] {
     return n === 0 ? base : `${base}#${n}`
   })
 }
+
+/**
+ * The symbol a feed entry is about, where it has one.
+ *
+ * Every kind stores it somewhere different, and a tile with no symbol — a
+ * macro event, an unattributed story, a workflow item — genuinely has none.
+ * Null is the honest answer; the filter keeps such tiles when only category
+ * filters are set and drops them when an asset facet is, which is what stops
+ * a "European only" view silently deleting whole categories.
+ *
+ * Hoisted out of the dashboard because two callers now need it and they must
+ * not disagree: the filter uses it to decide what a tile is about, and the
+ * Explore matcher uses it to decide which card a preview opens. A second copy
+ * that resolved `idea` differently is exactly how the Ideas filter came back
+ * empty once already.
+ */
+export function symbolOfEntry(e: AnyEntry): string | null {
+  switch (e?.kind) {
+    case 'news':      return e.news?.primarySymbol ?? null
+    case 'template':  return e.card?.symbol ?? null
+    case 'insight':   return e.insight?.symbol ?? null
+    case 'lens':      return lensSymbol(e.lens) || null
+    // `e.idea`, not `e.item`. The entry has stored the post under `idea` since
+    // it was written, and reading the wrong key returned undefined for every
+    // idea in the feed — which made every idea vanish the moment any asset
+    // facet was set, with nothing saying why.
+    case 'idea':      return e.idea?.asset?.symbol ?? null
+    case 'scenario':  return e.card?.entity?.ticker ?? null
+    case 'attention': return null
+    default:          return null
+  }
+}


### PR DESCRIPTION
Phase 9.2 continued — Parts 3–7 plus the pair-trade regression guard.

### One exploration model (Parts 4, 5, 6)
Target, cases and size are the same gesture over a different number. `exploration.ts` names the three values — REFERENCE / RECORDED / PROPOSED — and `ValueExplorer` keeps all three labelled on screen. Save and Cancel exist only while a proposal does, so their presence IS the message that nothing is written yet. No instructional copy anywhere.

**Slider bug worth naming:** `<input type=range>` quantises to `min + n*step`, so a min of 9.2483 puts every value on that offset grid — aim at 225, land on 224.9483. Bounds and step are now derived together and snap to the grid. Headroom is relative too: a $182 price with a $210 target topped out at $220, so $225 was unreachable on a control whose purpose is proposing values nobody recorded.

**Cases:** Bear/Base/Bull in one tap, no "Set a target" step. Drafts kept per case — comparing is the point of having three. Unsaved work is marked.

**Size:** change in POINTS (7.2% → 5.0% is 2.2 pts, not −30%). Active weight only where a benchmark exists. One sentence survives: staging does not trade.

### Fullscreen chart (Part 3)
One shell. Target levels and scenario ladders are bands/markers, not chart variants. Overlay, not the asset page. Expand sits beside the range chips, not over the plot where the scrub gesture lives. Offered only where `priceIdentity` already proved a tape exists.

### Explore opens the right object (Part 7)
The matcher short-circuited on the asset alone, so tapping "NVDA has no price target" opened whichever NVDA card was earliest — often active risk. Type **and** asset must agree now. `symbolOfEntry` hoisted so the filter and the matcher cannot disagree.

### Pair trades (Part 14)
No pair id on two pages; cursor advances through empty pages; slicing stays over pairs, not legs.

guard: 577 unit, 0 card-surface type errors, 204 phone. Windowing intact. quick_thoughts migration **not** run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)