### PR TITLE
feat(mobile): Apply writes a private thought, and Explore opens what you tapped

### DIFF
--- a/src/components/mobile/MobileDashboard.tsx
+++ b/src/components/mobile/MobileDashboard.tsx
@@ -18,6 +18,7 @@ import { usePortfolioLenses } from '../../hooks/mobile/usePortfolioLenses'
 import { FeedFilterSheet } from './FeedFilterSheet'
 import { FeedSlot } from './FeedSlot'
 import { FullscreenChart } from '../signals/FullscreenChart'
+import { writeJudgmentThought } from '../../lib/signals/judgment-thought'
 import { PricePane } from '../signals/PricePane'
 import { findExploreMatch } from '../../lib/mobile/explore-match'
 import { priceIdentity } from '../../lib/signals/price-availability'
@@ -187,6 +188,26 @@ export function MobileDashboard({ onNavigate }: MobileDashboardProps) {
    * choice for the reader — today just the active-risk what-if slider, which
    * arrives with a specific proposed weight and would lose it to a menu.
    */
+  /**
+   * The thought the last applied judgment wrote, so it can be shared.
+   *
+   * Held at the feed rather than on the card: the card that produced it may
+   * have scrolled out of the window by the time the reader decides to send it,
+   * and a windowed slot unmounting must not take the offer with it.
+   */
+  const [lastThought, setLastThought] = useState<{ id: string; symbol: string | null } | null>(null)
+
+  /**
+   * The offer expires. Sharing is deliberate, and a bar that waits forever
+   * turns into furniture the reader stops seeing — which is worse than not
+   * offering, because it also covers the bottom of the card.
+   */
+  useEffect(() => {
+    if (!lastThought) return
+    const t = setTimeout(() => setLastThought(null), 6000)
+    return () => clearTimeout(t)
+  }, [lastThought])
+
   const [captureCtx, setCaptureCtx] = useState<
     {
       assetId: string | null
@@ -258,6 +279,24 @@ export function MobileDashboard({ onNavigate }: MobileDashboardProps) {
           card: card.type, key: o.key,
         })
       }
+
+      /**
+       * The answer becomes something the reader can find again.
+       *
+       * Applying a judgment used to produce an audit row and a card that
+       * stopped asking — correct, and invisible. The surface asked for a
+       * decision and gave back nothing usable ten minutes later.
+       *
+       * The option's `note` is already first-person prose written for exactly
+       * this, so it lands as a private quick thought against the same name.
+       * Failure here does not fail the judgment: the judgment is the record
+       * and this is a convenience on top of it.
+       */
+      if (result.local && o.intent !== 'feed_quality') {
+        const wrote = await writeJudgmentThought({ userId, card, note: o.note })
+        if (wrote.thoughtId) setLastThought({ id: wrote.thoughtId, symbol: card.entity?.ticker ?? null })
+      }
+
       return result.local
     },
     [userId, currentOrgId],
@@ -1129,7 +1168,12 @@ export function MobileDashboard({ onNavigate }: MobileDashboardProps) {
       .map(c => c.item)),
     [exploreCandidates, exploreCategory],
   )
-  const { data: exploreSeries } = usePriceHistory(exploreSymbolList, { enabled: mode === 'explore' })
+  const { data: exploreSeries } = usePriceHistory(exploreSymbolList, {
+    enabled: mode === 'explore',
+    // Sixty closes for a sixty-pixel sparkline. Seven round trips became two,
+    // and nothing renders until all of them land — see `usePriceHistory`.
+    points: 60,
+  })
 
   // Interleave so consecutive screens are not all one kind. Scores are
   // position-derived rather than raw: each source ranks on its own scale, and
@@ -3548,6 +3592,49 @@ c.assetId ?? null,
           </div>
         )}
       </BottomSheet>
+
+      {/* What the answer produced, and the one thing to do with it.
+          ── Why a toast and not a card state ──────────────────────────────
+          The card that produced the thought may already have scrolled out of
+          the windowed set, and the reader's attention has moved on with it.
+          The offer to share belongs where they are looking now, and it has to
+          be dismissible without being the point — sharing is deliberate, and
+          most judgments are never shared. */}
+      {lastThought && (
+        <div
+          data-slot="judgment-thought-toast"
+          role="status"
+          className="pointer-events-auto fixed inset-x-3 bottom-[calc(1rem+env(safe-area-inset-bottom))] z-40 flex items-center gap-3 rounded-xl bg-gray-900 px-3 py-2.5 text-white shadow-lg dark:bg-gray-800"
+        >
+          <span className="min-w-0 flex-1 text-[13px] font-medium">
+            Saved to your thoughts
+            {lastThought.symbol ? ` on ${lastThought.symbol}` : ''}
+            {/* Said out loud, because the default is the part people need to
+                trust before they will answer honestly. */}
+            <span className="ml-1 text-gray-400">· private</span>
+          </span>
+          <button
+            type="button"
+            data-slot="judgment-thought-share"
+            onClick={() => {
+              setShareItem({ id: lastThought.id, type: 'quick_thought', title: 'Thought' } as any)
+              setLastThought(null)
+            }}
+            className="shrink-0 rounded-lg bg-white/15 px-2.5 py-1.5 text-[13px] font-bold text-white no-touch-target"
+          >
+            Share
+          </button>
+          <button
+            type="button"
+            data-slot="judgment-thought-dismiss"
+            aria-label="Dismiss"
+            onClick={() => setLastThought(null)}
+            className="shrink-0 rounded-lg px-1.5 py-1.5 text-[13px] font-semibold text-gray-400 no-touch-target"
+          >
+            ✕
+          </button>
+        </div>
+      )}
 
       <FeedCaptureSheet
         open={captureCtx !== null}

--- a/src/components/mobile/MobileExplore.tsx
+++ b/src/components/mobile/MobileExplore.tsx
@@ -98,7 +98,15 @@ function Tile({
         // the tap reaches the full version — recreating Phase 8.1's nested
         // scroll problem in a smaller grid would be the same defect, cheaper to
         // miss.
-        'flex w-full flex-col overflow-hidden rounded-xl border border-gray-200 bg-white p-3 text-left',
+        // `h-full` so a tile fills its grid cell.
+        //
+        // The grid is `auto-rows-min`, so a row is as tall as its tallest
+        // member — and a shorter tile beside it drew its border at its own
+        // content height, leaving a band of page showing underneath. Reported
+        // as odd empty space. The gap was always inside the row; the tile just
+        // was not claiming it. Filling the cell turns that space into part of
+        // the tile, which is what it looked like it should have been.
+        'flex h-full w-full flex-col overflow-hidden rounded-xl border border-gray-200 bg-white p-3 text-left',
         'active:scale-[0.985] active:opacity-90 transition-transform',
         'dark:border-gray-700 dark:bg-gray-900',
         // `col-span-full`, not `col-span-2`. In the single-column layout a

--- a/src/hooks/mobile/usePriceHistory.ts
+++ b/src/hooks/mobile/usePriceHistory.ts
@@ -92,7 +92,26 @@ const MAX_SYMBOLS = 24
  */
 const PAGE = 1000
 
-export function usePriceHistory(symbols: string[], options?: { enabled?: boolean }) {
+export function usePriceHistory(
+  symbols: string[],
+  options?: {
+    enabled?: boolean
+    /**
+     * Closes per symbol. Lower is dramatically faster.
+     *
+     * The batch is paged at 1,000 rows, so the request count is
+     * `ceil(points x symbols / 1000)` — 24 symbols at the 260-close default is
+     * seven serial-ish round trips, and NOTHING renders until all of them
+     * land, because the result is one map behind one query key.
+     *
+     * Explore draws sparklines about sixty pixels wide. Sixty closes is more
+     * resolution than that can show, and it turns seven requests into two.
+     * Reported as Explore taking too long for its sparklines to appear.
+     */
+    points?: number
+  },
+) {
+  const maxPoints = options?.points ?? MAX_POINTS
   const wanted = Array.from(new Set(symbols.map(s => s.toUpperCase()).filter(Boolean)))
     .slice(0, MAX_SYMBOLS)
     .sort()
@@ -100,7 +119,7 @@ export function usePriceHistory(symbols: string[], options?: { enabled?: boolean
   return useQuery({
     // Sorted and de-duplicated above, so a re-render that reorders the feed
     // does not look like a new query.
-    queryKey: ['feed-price-history', wanted.join(',')],
+    queryKey: ['feed-price-history', maxPoints, wanted.join(',')],
     enabled: (options?.enabled ?? true) && wanted.length > 0,
     staleTime: 60 * 60 * 1000,
     queryFn: async (): Promise<Map<string, PricePoint[]>> => {
@@ -122,7 +141,7 @@ export function usePriceHistory(symbols: string[], options?: { enabled?: boolean
        * differently per request. Ordering by (date, symbol) makes the sequence
        * deterministic, which is the precondition for paging it at all.
        */
-      const pages = Math.ceil((MAX_POINTS * wanted.length) / PAGE)
+      const pages = Math.ceil((maxPoints * wanted.length) / PAGE)
       const responses = await Promise.all(
         Array.from({ length: pages }, (_, i) =>
           supabase
@@ -149,7 +168,7 @@ export function usePriceHistory(symbols: string[], options?: { enabled?: boolean
         if (!Number.isFinite(close) || close <= 0 || !r.date) continue
         const sym = String(r.symbol).toUpperCase()
         const list = out.get(sym) ?? []
-        if (list.length >= MAX_POINTS) continue
+        if (list.length >= maxPoints) continue
         list.push({ date: String(r.date), close })
         out.set(sym, list)
       }

--- a/src/lib/mobile/__tests__/explore-match.test.ts
+++ b/src/lib/mobile/__tests__/explore-match.test.ts
@@ -109,3 +109,38 @@ describe('one symbol resolver, shared by the filter and the matcher', () => {
     expect(symbolOfEntry({ kind: 'news', news: {} })).toBeNull()
   })
 })
+
+describe('the declared type beats the dedupe key', () => {
+  it('matches a conviction tile, whose key says something else entirely', () => {
+    /**
+     * `dedupeKey` is `conviction:<asset>`; the ranked card is
+     * `conviction_oversized`. Nothing could ever match, so tapping a
+     * conviction tile fell through to "this one lives on its own surface".
+     * The adapters build those keys from local vocabulary — `conviction`,
+     * `post`, `attention`, `economic`, each insight's own kind — and none of
+     * them are SignalType values.
+     */
+    const target = {
+      dedupeKey: 'conviction:a1', signalType: 'conviction_oversized',
+      assetId: 'a1', symbol: 'NVDA',
+    }
+    expect(targetType(target)).toBe('conviction_oversized')
+    expect(findExploreMatch(target, [entry('conviction_oversized', 'a1', 'NVDA')], e => e)).toBeTruthy()
+  })
+
+  it('matches an insight tile', () => {
+    const target = { dedupeKey: 'no_thesis:a1', signalType: 'no_research', assetId: 'a1' }
+    expect(findExploreMatch(target, [entry('no_research', 'a1')], e => e)).toBeTruthy()
+  })
+
+  it('still falls back to the key for anything not yet declaring a type', () => {
+    expect(targetType({ dedupeKey: 'news:x' })).toBe('news')
+  })
+
+  it('opens nothing for an aggregate, which has no single card', () => {
+    // Correct behaviour, not a gap: "5 new ideas" filters Explore rather than
+    // opening one object.
+    const target = { dedupeKey: 'aggregate:ideas', signalType: null }
+    expect(findExploreMatch(target, [entry('trade_idea', 'a1')], e => e)).toBeNull()
+  })
+})

--- a/src/lib/mobile/explore-adapters.ts
+++ b/src/lib/mobile/explore-adapters.ts
@@ -1,3 +1,4 @@
+import { signalTypeForTemplate } from '../signals/builders/legacy-kinds'
 import type { ExploreItem } from './explore-item'
 import type { FeedCategory } from './feed-categories'
 
@@ -41,6 +42,7 @@ export function lensesToExplore(lenses: {
       // Keyed on the CONDITION, not on the adapter. A target reached is one
       // artifact however many surfaces describe it.
       dedupeKey: `target_hit:${b.assetId}`,
+      signalType: 'target_hit',
       category: 'decisions', subtype: 'signal',
       title: `${b.symbol} passed its target`,
       context: `Trading ${pct.toFixed(0)}% through $${Number(b.target).toFixed(0)}`,
@@ -60,6 +62,7 @@ export function lensesToExplore(lenses: {
     out.push({
       id: `lens-stale-${t.assetId}`,
       dedupeKey: `target_expired:${t.assetId}`,
+      signalType: 'target_expired',
       category: 'decisions', subtype: 'signal',
       title: `${t.symbol} target has run past its horizon`,
       context: `${t.overdueMonths} month${t.overdueMonths === 1 ? '' : 's'} past a ${t.timeframe ?? 'stated'} view`,
@@ -76,6 +79,7 @@ export function lensesToExplore(lenses: {
     out.push({
       id: `lens-untargeted-${u.assetId}`,
       dedupeKey: `no_target:${u.assetId}`,
+      signalType: 'no_target',
       category: 'decisions', subtype: 'signal',
       title: `${u.symbol} has no price target on record`,
       context: `${Number(u.weightPct).toFixed(1)}% of ${u.portfolioName}`,
@@ -93,6 +97,8 @@ export function lensesToExplore(lenses: {
     out.push({
       id: `lens-conviction-${g.assetId}`,
       dedupeKey: `conviction:${g.assetId}`,
+      // The ranker splits conviction by direction; the key never did.
+      signalType: g.direction === 'overweight' ? 'conviction_oversized' : 'conviction_undersized',
       category: 'decisions', subtype: 'signal',
       title: `${g.symbol} is ${over ? 'larger' : 'smaller'} than its conviction`,
       context: `${Number(g.weightPct).toFixed(1)}% in ${g.portfolioName}${g.conviction ? ` · conviction ${g.conviction}` : ''}`,
@@ -109,6 +115,7 @@ export function lensesToExplore(lenses: {
     out.push({
       id: `lens-crowded-${c.assetId}`,
       dedupeKey: `crowding:${c.assetId}`,
+      signalType: 'crowding',
       category: 'decisions', subtype: 'signal',
       title: `${c.symbol} is held across ${c.portfolioCount} portfolios`,
       context: `Largest weight ${Number(c.maxWeightPct).toFixed(1)}%`,
@@ -129,6 +136,7 @@ export function scenarioCardsToExplore(cards: any[]): ExploreItem[] {
   return (cards ?? []).map(c => ({
     id: `scenario-${c.entity?.id ?? c.id}`,
     dedupeKey: `scenario_gap:${c.entity?.id ?? c.id}`,
+    signalType: 'scenario_gap',
     category: 'decisions' as FeedCategory,
     subtype: 'signal' as const,
     title: c.headline,
@@ -157,6 +165,8 @@ export function insightsToExplore(insights: any[]): ExploreItem[] {
     return {
       id: `insight-${i.id}`,
       dedupeKey: `${i.kind}:${i.assetId}`,
+      // Insight kinds are their own vocabulary; the cards are not.
+      signalType: i.kind === 'no_thesis' ? 'no_research' : 'research_stale',
       category: 'research' as FeedCategory,
       subtype: 'research' as const,
       title: i.headline,
@@ -204,6 +214,7 @@ export function ideasToExplore(posts: any[]): ExploreItem[] {
     return {
       id: `idea-${p.id}`,
       dedupeKey: `post:${p.id}`,
+      signalType: p.type === 'trade' || p.type === 'trade_idea' ? 'trade_idea' : 'thought',
       category: (isThesis ? 'research' : 'ideas') as FeedCategory,
       subtype: isThesis ? ('research' as const) : ('idea' as const),
       title: p.title ?? p.headline ?? (isTrade ? 'Trade idea' : 'Thought'),
@@ -230,6 +241,7 @@ export function newsToExplore(news: any[]): ExploreItem[] {
   return (news ?? []).map(n => ({
     id: `news-${n.id ?? n.url}`,
     dedupeKey: `news:${n.id ?? n.url}`,
+    signalType: 'news',
     category: 'news' as FeedCategory,
     subtype: 'news' as const,
     title: n.headline ?? n.title ?? '',
@@ -250,6 +262,9 @@ export function templatesToExplore(cards: any[]): ExploreItem[] {
   return (cards ?? []).map(c => ({
     id: `tpl-${c.id ?? `${c.kind}-${c.symbol}`}`,
     dedupeKey: `${c.kind}:${c.assetId ?? c.symbol ?? c.id}`,
+    // `economic` is not `economic_release`, and `active_risk` is not in the map
+    // at all — both are exactly why this goes through one function.
+    signalType: signalTypeForTemplate(c.kind),
     category: 'news' as FeedCategory,
     subtype: 'news' as const,
     title: c.headline ?? '',
@@ -273,6 +288,9 @@ export function attentionToExplore(items: any[]): ExploreItem[] {
     return {
       id: `attn-${a.attention_id}`,
       dedupeKey: `attention:${a.attention_id}`,
+      signalType: a.source_type === 'trade_queue_item' ? 'recommendation'
+        : a.source_type === 'project' || a.source_type === 'project_deliverable' ? 'project_overdue'
+        : 'awaiting_review',
       category: (isTrade ? 'decisions' : 'workflow') as FeedCategory,
       subtype: isTrade ? ('signal' as const) : ('workflow' as const),
       title: a.title ?? a.summary ?? 'Awaiting you',
@@ -324,6 +342,8 @@ export function aggregatesFor(items: ExploreItem[], now: number): ExploreItem[] 
     out.push({
       id: `agg-${g.category}`,
       dedupeKey: `aggregate:${g.category}`,
+      // No single card behind it, by design — see the aggregate behaviour.
+      signalType: null,
       category: g.category,
       subtype: 'aggregate',
       title: g.label(n),

--- a/src/lib/mobile/explore-item.ts
+++ b/src/lib/mobile/explore-item.ts
@@ -53,6 +53,24 @@ export interface ExploreItem {
    * two different ids and be the same artifact. See `dedupeExplore`.
    */
   dedupeKey: string
+  /**
+   * The canonical signal type this preview stands for.
+   *
+   * ── Why this is not read off `dedupeKey` ────────────────────────────────
+   *
+   * It was, and it could not work. A dedupe key is a dedupe key: the adapters
+   * built theirs from whatever local vocabulary was to hand — `conviction`,
+   * `post`, `attention`, `economic`, and each insight's own `kind`. None of
+   * those are `SignalType` values, so a matcher comparing the prefix against
+   * the ranked type failed for whole families of tile, and tapping them fell
+   * through to "this one lives on its own surface" even though a perfectly
+   * good Level-2 card existed.
+   *
+   * Declaring it makes the contract explicit rather than inferred from the
+   * shape of a string that was never meant to carry it. Null for aggregates,
+   * which genuinely have no single card behind them.
+   */
+  signalType: string | null
 
   /** The Phase 8.1 canonical category. One taxonomy, shared with Curate. */
   category: FeedCategory

--- a/src/lib/mobile/explore-match.ts
+++ b/src/lib/mobile/explore-match.ts
@@ -24,8 +24,15 @@
  */
 
 export interface ExploreTarget {
-  /** `signalType:asset` — the preview's own identity. */
+  /** The preview's own identity. NOT a reliable source of its type. */
   dedupeKey: string
+  /**
+   * The declared type, where the adapter set one. Null for aggregates.
+   *
+   * Preferred over the dedupe key in every case, because the key's prefix was
+   * never a `SignalType` — see `ExploreItem.signalType`.
+   */
+  signalType?: string | null
   assetId?: string | null
   symbol?: string | null
 }
@@ -39,9 +46,19 @@ export interface EntryDescriptor {
   symbol?: string | null
 }
 
-/** The signal type a preview is about. */
+/**
+ * The signal type a preview is about.
+ *
+ * The declared field wins. The dedupe-key prefix survives only as a fallback
+ * for anything not yet migrated, and it is a poor one: the adapters built
+ * those keys from local vocabulary — `conviction`, `post`, `attention`,
+ * `economic`, each insight's own `kind` — none of which are `SignalType`
+ * values. Matching on it failed for whole families of tile, which is why
+ * tapping them fell through to "this one lives on its own surface" when a
+ * perfectly good Level-2 card existed.
+ */
 export function targetType(t: ExploreTarget): string {
-  return t.dedupeKey.split(':')[0]
+  return t.signalType ?? t.dedupeKey.split(':')[0]
 }
 
 /**

--- a/src/lib/signals/judgment-thought.ts
+++ b/src/lib/signals/judgment-thought.ts
@@ -1,0 +1,88 @@
+import { supabase } from '../supabase'
+import type { SignalCard } from './contract'
+
+/**
+ * A judgment becomes a thought the reader can actually find.
+ *
+ * ── Why answering needed an artefact ──────────────────────────────────────
+ *
+ * Applying a judgment wrote an audit row and a local disposition. Both are
+ * correct and neither is visible: the card stops asking, and that is the whole
+ * of what the reader gets back. So the surface asked for a decision and
+ * returned nothing they could use ten minutes later — which is how a triage
+ * control becomes one people stop touching.
+ *
+ * The judgment options already carry `note`, written in the first person
+ * precisely so it could be recorded as prose. This writes it as a quick
+ * thought against the same name, so a week later "what did I decide about
+ * NVDA" has an answer in the place people already look for one.
+ *
+ * ── Private by default ────────────────────────────────────────────────────
+ *
+ * A judgment made while scrolling is a working note, not a publication. It
+ * lands as `private`, and sharing is a separate, deliberate act from the
+ * recorded state — the reader chooses to show it to someone, and until then it
+ * is theirs. Defaulting the other way would make people hesitate before
+ * answering honestly, which defeats the point of asking.
+ *
+ * ── Why a failure here is not a failure of the judgment ───────────────────
+ *
+ * The judgment is the record; the thought is a convenience on top of it. If
+ * this write fails the judgment still stands, so the caller is told what
+ * happened and nothing is rolled back. Reporting a judgment as failed because
+ * its companion note did not save would be the tail wagging the dog.
+ */
+
+export interface JudgmentThoughtInput {
+  userId: string
+  card: SignalCard
+  /** The option's first-person note. Already written for this purpose. */
+  note: string
+}
+
+export interface JudgmentThoughtResult {
+  /** The row id, for a follow-on share. Null when nothing was written. */
+  thoughtId: string | null
+  reason: 'written' | 'no_note' | 'failed'
+}
+
+/**
+ * The asset a card is about, where it has one.
+ *
+ * Cards carry their subject as an entity with an optional ticker and id. A
+ * thought with no asset is still a thought — a macro card, a workflow item —
+ * so this returns null rather than refusing to write.
+ */
+function assetIdOf(card: SignalCard): string | null {
+  const e = (card as any).entity
+  return (e?.assetId ?? e?.id ?? null) || null
+}
+
+export async function writeJudgmentThought(
+  input: JudgmentThoughtInput,
+): Promise<JudgmentThoughtResult> {
+  const content = input.note?.trim()
+  // Feed-quality options ("show fewer like this") carry no note, and inventing
+  // prose for them would put opinions about the FEED into the research record.
+  if (!content) return { thoughtId: null, reason: 'no_note' }
+
+  const { data, error } = await supabase
+    .from('quick_thoughts')
+    .insert({
+      content,
+      created_by: input.userId,
+      asset_id: assetIdOf(input.card),
+      // Private. See the header: a judgment made while scrolling is a working
+      // note, and defaulting to visible would make people answer less honestly.
+      visibility: 'private',
+      // `organization_id` is deliberately absent. A BEFORE INSERT trigger
+      // stamps it from `users.current_organization_id`, and passing it here
+      // would be a second source of truth for tenancy — the one thing the
+      // org-scoping work is most careful about.
+    } as any)
+    .select('id')
+    .single()
+
+  if (error || !data) return { thoughtId: null, reason: 'failed' }
+  return { thoughtId: (data as any).id as string, reason: 'written' }
+}


### PR DESCRIPTION
### Answering now produces something you can find

Applying a judgment wrote an audit row and a local disposition — both correct, neither visible. The surface asked for a decision and returned nothing usable ten minutes later.

The options already carry `note`, first-person prose written for exactly this. It lands as a quick thought against the same name. **Private** — a judgment made while scrolling is a working note, not a publication. A toast says what was saved, says "private" out loud, and offers to share. Defaulting the other way would make people hesitate before answering honestly.

The thought is a convenience on top of the judgment: if it fails, the judgment still stands. Feed-quality options are excluded — they carry no note, and inventing prose for "show fewer like this" would put opinions about the *feed* into the research record.

### Explore tiles that could never open

The matcher read the signal type off the dedupe key prefix. But the adapters built those keys from local vocabulary — `conviction`, `post`, `attention`, `economic`, each insight's own `kind`. None are `SignalType` values, so whole families of tile could never match. `conviction` ≠ `conviction_oversized`; `economic` ≠ `economic_release`.

`ExploreItem` declares `signalType` now. Null for aggregates, which genuinely have no card — "5 new ideas" still filters Explore rather than opening one object.

### Latency and the gaps

The sparkline batch pages at 1,000 rows: 24 symbols × 260 closes = seven round trips, and nothing renders until all land. Sparklines are ~60px wide, so 60 closes is already more than can be shown. Seven requests → two.

The empty space was `auto-rows-min`: a row is as tall as its tallest member, and a shorter tile drew its border at its own content height with page showing underneath. The gap was always inside the row; the tile just wasn't claiming it.

guard: 597 unit, 0 card-surface type errors, 204 phone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)